### PR TITLE
Add basic setup and makefile usage instructions.

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -1,0 +1,26 @@
+# An example Makefile suitable for use in SpiNNaker applications using the
+# spinnaker_tools libraries and makefiles.
+
+# The name of the application to be built (binary will be this with a `.aplx`
+# extension)
+APP = example
+
+# Directory to create APLX files in (must include trailing slash)
+APP_OUTPUT_DIR = ./
+
+# Directory to place compilation artefacts (must include trailing slash)
+BUILD_DIR = ./
+
+# A space-separated list of object files to be built into the executable. These
+# .o files will be created from corresponding .c files (e.g. example.c in this
+# case).
+OBJECTS = example.o
+
+# The spinnaker_tools standard makefile
+include $(SPINN_DIRS)/Makefile.common
+
+all: $(APP_OUTPUT_DIR)$(APP).aplx
+
+clean:
+	$(RM) $(OBJECTS) $(BUILD_DIR)$(APP).elf $(BUILD_DIR)$(APP).txt $(APP_OUTPUT_DIR)$(APP).aplx
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Setup
 
 These makefiles require the CodeSourcery ARM cross compiler to be installed.
 Installation instructions can be found on the [SpiNNaker
-Wiki](https://spinnaker.cs.manchester.ac.uk/tiki-index.php?page=CodeSorcery+ARM+Cross+Compiler).
+Wiki](https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/wiki/1.3-C-Development-for-SpiNNaker#-install-development-dependencies).
 
 Once the compiler has been installed, you must build the standard SpiNNaker
 libraries:

--- a/README.md
+++ b/README.md
@@ -5,51 +5,7 @@ This repository contains the standard low-level SpiNNaker application
 development libraries (`spin1_api` and `sark`) and a set of tools and Makefiles
 for building SpiNNaker applications.
 
-Setup
------
+Please see the SpiNNakerManchester GitHub wiki for documentation:
 
-These makefiles require the CodeSourcery ARM cross compiler to be installed.
-Installation instructions can be found on the [SpiNNaker
-Wiki](https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/wiki/1.3-C-Development-for-SpiNNaker#-install-development-dependencies).
-
-Once the compiler has been installed, you must build the standard SpiNNaker
-libraries:
-
-	$ cd spinnaker_tools  # You must be in the spinnaker_tools directory!
-	$ source setup
-	$ make
-
-
-Building Applications
----------------------
-
-When using the makefiles supplied in this repository, you must set up a number
-of environment variables using:
-
-	$ cd spinnaker_tools  # You must be in the spinnaker_tools directory!
-	$ source setup
-
-You should also ensure you have compiled the SpiNNaker libraries as described
-above otherwise application compilation will fail.
-
-### Basic Application Compilation
-
-To quickly compile a simple single-file application for SpiNNaker, you can use
-the following command:
-
-	$ make -f $SPINN_DIRS/Makefile.app APP=example
-
-This will compile the application in `example.c` and produce a SpiNNaker binary
-called `example.aplx` in the current directory.
-
-### Example Makefile
-
-Though the above is suitable while prototyping applications, real-world
-applications may contain many source files and should be compiled using their
-own makefile.
-
-[Makefile.example](./Makefile.example) provides an annotated Makefile template
-showing how a simple C program can be compiled for SpiNNaker using these tools.
-Once your makefile is set up, your application can then be compiled by calling:
-
-	$ make
+* [Installation](https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/wiki/1.3-C-Development-for-SpiNNaker#c-development-for-spinnaker)
+* [Makefile Usage](https://github.com/SpiNNakerManchester/SpiNNakerManchester.github.io/wiki/1.3-C-Development-for-SpiNNaker#BuildUsage)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+Native SpiNNaker Application Libraries
+======================================
+
+This repository contains the standard low-level SpiNNaker application
+development libraries (`spin1_api` and `sark`) and a set of tools and Makefiles
+for building SpiNNaker applications.
+
+Setup
+-----
+
+These makefiles require the CodeSourcery ARM cross compiler to be installed.
+Installation instructions can be found on the [SpiNNaker
+Wiki](https://spinnaker.cs.manchester.ac.uk/tiki-index.php?page=CodeSorcery+ARM+Cross+Compiler).
+
+Once the compiler has been installed, you must build the standard SpiNNaker
+libraries:
+
+	$ cd spinnaker_tools  # You must be in the spinnaker_tools directory!
+	$ source setup
+	$ make
+
+
+Building Applications
+---------------------
+
+When using the makefiles supplied in this repository, you must set up a number
+of environment variables using:
+
+	$ cd spinnaker_tools  # You must be in the spinnaker_tools directory!
+	$ source setup
+
+You should also ensure you have compiled the SpiNNaker libraries as described
+above otherwise application compilation will fail.
+
+### Basic Application Compilation
+
+To quickly compile a simple single-file application for SpiNNaker, you can use
+the following command:
+
+	make -f $SPINN_DIRS/Makefile.app APP=example
+
+This will compile the application in `example.c` and produce a SpiNNaker binary
+called `example.aplx` in the current directory.
+
+### Example Makefile
+
+Though the above is suitable while prototyping applications, real-world
+applications may contain many source files and should be compiled using their
+own makefile.
+
+[Makefile.example](./Makefile.example) provides an annotated Makefile template
+showing how a simple C program can be compiled for SpiNNaker using these tools.
+Once your makefile is set up, your application can then be compiled by calling:
+
+	$ make

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ above otherwise application compilation will fail.
 To quickly compile a simple single-file application for SpiNNaker, you can use
 the following command:
 
-	make -f $SPINN_DIRS/Makefile.app APP=example
+	$ make -f $SPINN_DIRS/Makefile.app APP=example
 
 This will compile the application in `example.c` and produce a SpiNNaker binary
 called `example.aplx` in the current directory.


### PR DESCRIPTION
Specifically point at where the cross compiler can be found and provide a very
quick introduction to compiling SpiNNaker applications using the provided
makefiles.
