### PR TITLE
Add .init section to linker map.

### DIFF
--- a/lib/sark.lnk
+++ b/lib/sark.lnk
@@ -41,6 +41,7 @@ SECTIONS
           __init_array_end = .;
           * (.rodata*);
           * (.fini*);
+          * (.init*);
     } > ITCM
 
     . = ALIGN (4);


### PR DESCRIPTION
This section appears to be produced by recent GCCs (observed on v5.3.0).

Bug observed by me but fixed by ST.

@rowleya If you're happy with this one feel free to hit merge :) (NB: this PR is for a branch off the full_source_from_bit_bucket_merged branch, not master!)
