### PR TITLE
Fix sdp response address and bump version

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -12,7 +12,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"2.1.0"
-#define	SLLT_VER_NUM	0x020100
+#define	SLLT_VER_STR	"2.2.0-dev"
+#define	SLLT_VER_NUM	0x020200
 
 #endif

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -659,33 +659,24 @@ void proc_route_msg (uint arg1, uint srce_ip)
       msg->flags = flags &= ~SDPF_SUM;
     }
 
-  uint dest_addr = msg->dest_addr;
-  uint srce_addr = msg->srce_addr;
-
   // Map (255, 255) to the root chip's coordinates
-  if (dest_addr == 0xFFFF)
-    {
-      msg->dest_addr = p2p_root;
-      dest_addr = p2p_root;
-    }
-  if (srce_addr == 0xFFFF)
-    {
-      msg->srce_addr = p2p_root;
-      srce_addr = p2p_root;
-    }
+  if (msg->dest_addr == 0xFFFF)
+    msg->dest_addr = p2p_root;
+  if (msg->srce_addr == 0xFFFF)
+    msg->srce_addr = p2p_root;
 
   // Off-chip via P2P
 
-  if (dest_addr != srce_addr && dest_addr != p2p_addr &&
+  if (msg->dest_addr != msg->srce_addr && msg->dest_addr != p2p_addr &&
       (flags & SDPF_NR) == 0)
     {
-      if (p2p_up == 0 || rtr_p2p_get (dest_addr) == 6)
+      if (p2p_up == 0 || rtr_p2p_get (msg->dest_addr) == 6)
 	{
 	  return_msg (msg, RC_ROUTE);
 	  return;
 	}
 
-      uint rc = p2p_send_msg (dest_addr, msg);
+      uint rc = p2p_send_msg (msg->dest_addr, msg);
 
       if (rc == RC_OK)
 	sark_msg_free (msg);

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -664,9 +664,15 @@ void proc_route_msg (uint arg1, uint srce_ip)
 
   // Map (255, 255) to the root chip's coordinates
   if (dest_addr == 0xFFFF)
-    dest_addr = p2p_root;
+    {
+      msg->dest_addr = p2p_root;
+      dest_addr = p2p_root;
+    }
   if (srce_addr == 0xFFFF)
-    srce_addr = p2p_root;
+    {
+      msg->srce_addr = p2p_root;
+      srce_addr = p2p_root;
+    }
 
   // Off-chip via P2P
 


### PR DESCRIPTION
This replaces the source chip in an SDP response from a request to 255, 255 with the actual p2p address of the chip responding.  The version number bumping has also been included here, including the dev tag.

ST has already seen the changes included here - under his recommendation, I have removed the local variables for the source and destination addresses and replaced them with the ones from the message itself.
