### PR TITLE
Fix p2p link blacklisting

### DIFF
--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -519,7 +519,8 @@ void p2pb_nn_send(uint arg1, uint arg2)
   key |= chksum_64 (key, data);
 
   for (uint link = 0; link < NUM_LINKS; link++)
-    pkt_tx (PKT_NN + PKT_PL + (link << 18), data, key);
+    if (link_en & (1 << link))
+      pkt_tx (PKT_NN + PKT_PL + (link << 18), data, key);
 }
 
 // Update our current best guess of our coordinates based on a packet from a


### PR DESCRIPTION
This branch fixes a couple of bugs relating to blacklisting not being applied when constructing P2P routes.
- [x] ~~Sanity~~ correctness check by Luis (who spotted this)
- [x] Sanity check by ST
- [x] Sanity check by @rowleya

As an aside, along with be8fb58 this has been quite the flurry of silly mistakes in P2P blacklisting support. I think I may try and build a test suite for some of this stuff since it is quite sorely needed.
