### PR TITLE
Fix makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DIRS = sark spin1_api
 
-GNU ?= 1
+GNU = 1
 
 all: $(DIRS)
 	for d in $(DIRS); do (cd $$d; "$(MAKE)" GNU=$(GNU)) || exit $$?; done

--- a/README
+++ b/README
@@ -29,8 +29,8 @@ README file for SpiNNaker Low-Level Software Tools - Release 2.1.0
 3) make SARK and spin1_api for ARM or GNU tools
    (you will probably only want to do one of these)
 
-   > make		        # If you are using ARM tools
-   > make ARM=1		# If you are using GNU tools
+   > make GNU=0	        # If you are using ARM tools
+   > make        		# If you are using GNU tools
 
    Note that you may see some compiler warnings during these builds.
 

--- a/apps/pt_demo/Makefile
+++ b/apps/pt_demo/Makefile
@@ -1,5 +1,5 @@
 APPS = aggregator tracer
-GNU ?= 1
+GNU := 1
 
 all:
 	for app in $(APPS); do ("$(MAKE)" -f Makefile.spinn GNU=$(GNU) APP=$$app) || exit $$?; done

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -150,7 +150,7 @@ $(BUILD_DIR)%_build.c:
 
 $(BUILD_DIR)%.o: %.c
 	$(MKDIR) $(BUILD_DIR)
-	$(CC) $(CFLAGS) -DBLAH=BLAH -o $@ $<
+	$(CC) $(CFLAGS) -o $@ $<
 	
 $(BUILD_DIR)%.o: %.cpp
 	$(MKDIR) $(BUILD_DIR)

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -47,7 +47,7 @@ ifeq ($(GNU),1)
     CXX_NO_THUMB := $(GP)-gcc -c -mthumb-interwork -march=armv5te -std=c++11 -I $(SPINN_INC_DIR) -fno-rtti -fno-exceptions
     
     ifeq ($(LIB), 1)
-        CFLAGS += -Os -fdata-sections -ffunction-sections
+        CFLAGS += -fdata-sections -ffunction-sections
         LD := $(GP)-ld -i
     else
         LD := $(GP)-gcc -T$(SPINN_TOOLS_DIR)/sark.lnk -Wl,-e,cpu_reset -Wl,-static -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,--use-blx -nostartfiles -static

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -45,6 +45,11 @@ ifeq ($(GNU),1)
     AS := $(GP)-as --defsym GNU=1 -mthumb-interwork -march=armv5te
     CC_NO_THUMB  := $(GP)-gcc -c -mthumb-interwork -march=armv5te -std=gnu99 -I $(SPINN_INC_DIR)
     CXX_NO_THUMB := $(GP)-gcc -c -mthumb-interwork -march=armv5te -std=c++11 -I $(SPINN_INC_DIR) -fno-rtti -fno-exceptions
+    CC_THUMB  := $(CC_NO_THUMB) -mthumb -DTHUMB
+    CXX_THUMB := $(CXX_NO_THUMB) -mthumb -DTHUMB
+    
+    OSPACE := -Os
+    OTIME := -Ofast
     
     ifeq ($(LIB), 1)
         CFLAGS += -fdata-sections -ffunction-sections
@@ -54,19 +59,22 @@ ifeq ($(GNU),1)
         LFLAGS += -L $(SPINN_LIB_DIR)
     endif
     
-    CC_THUMB  := $(CC_NO_THUMB) -mthumb -DTHUMB
-    CXX_THUMB := $(CXX_NO_THUMB) -mthumb -DTHUMB
     AR := $(GP)-ar -rcs
     OC := $(GP)-objcopy
-    OD := $(GP)-objdump -dxt
+    OD := $(GP)-objdump -dxt >
     NM := $(GP)-nm
     SPINN_LIBS += $(SPINN_LIB_DIR)/libspin1_api.a
 
 else
     # ARM Compiler settings
     AS := armasm --keep --cpu=5te --apcs /interwork
-    CC_NO_THUMB := armcc -c --c99 --cpu=5te -Ospace --apcs /interwork --min_array_alignment=4 -I $(SPINN_INC_DIR)
+    CC_NO_THUMB := armcc -c --c99 --cpu=5te --apcs /interwork --min_array_alignment=4 -I $(SPINN_INC_DIR)
+    CXX_NO_THUMB := armcc -c --cpp11 --cpu=5te --apcs /interwork --min_array_alignment=4 -I $(SPINN_INC_DIR) --no_rtti --no_exceptions
     CC_THUMB := $(CC_NO_THUMB) --thumb -DTHUMB
+    CXX_THUMB := $(CXX_NO_THUMB) --thumb -DTHUMB
+    
+    OSPACE := -Ospace
+    OTIME := -Otime
     
     ifeq ($(LIB), 1)
         CFLAGS += --split_sections
@@ -104,35 +112,42 @@ endif
 
 
 # Primary target is an APLX file - built from the ELF
-#  1) Create a binary file which is the concatenation of RO and RW sections
-#  2) Make an APLX header from the ELF file with "mkaplx" and concatenate
+#  1) Make an APLX header from the ELF file with "mkaplx" and concatenate
 #     that with the binary to make the APLX file
-#  3) Remove temporary files and "ls" the APLX file
-$(APP_OUTPUT_DIR)%.aplx: $(BUILD_DIR)%.elf
+#  2) "ls" the APLX file
+$(APP_OUTPUT_DIR)%.aplx: $(BUILD_DIR)%.bin $(BUILD_DIR)%.nm
 	$(MKDIR) $(APP_OUTPUT_DIR)
+	$(SPINN_TOOLS_DIR)/mkaplx $(BUILD_DIR)$*.nm | $(CAT) - $(BUILD_DIR)$*.bin > $@
+	$(LS) $@
+
+# Create a list of the objects in the file using nm
+$(BUILD_DIR)%.nm: $(BUILD_DIR)%.elf
+	$(NM) $< > $@
+	
+# Create a binary file which is the concatenation of RO and RW sections
+$(BUILD_DIR)%.bin: $(BUILD_DIR)%.elf
 ifeq ($(GNU),1)
 	$(OC) -O binary -j RO_DATA $< $(BUILD_DIR)RO_DATA.bin
 	$(OC) -O binary -j RW_DATA $< $(BUILD_DIR)RW_DATA.bin
-	$(SPINN_TOOLS_DIR)/mkbin $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin > $(BUILD_DIR)$*.bin
+	$(SPINN_TOOLS_DIR)/mkbin $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin > $@
+	$(RM) $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin
 else
-	$(OC) --bin --output $*.bin $<
+	$(OC) --bin --output $@ $<
 endif
-	$(SPINN_TOOLS_DIR)/mkaplx -nm $(NM) $< | $(CAT) - $(BUILD_DIR)$*.bin > $@
-	$(RM) $(BUILD_DIR)$*.bin $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin
-	$(LS) $@
 
 # Build the ELF file
 #  1) Make a "sark_build.c" file containing app. name and build time
 #     with "mkbuild" and compile it
 #  2) Link application object(s), build file and library to make the ELF
 #  3) Tidy up temporaries and create a list file
-$(BUILD_DIR)%.elf: $(OBJECTS) $(SCRIPT)
+$(BUILD_DIR)%.elf: $(OBJECTS) $(SCRIPT) $(BUILD_DIR)%_build.o
 	$(MKDIR) $(BUILD_DIR)
-	$(SPINN_TOOLS_DIR)/mkbuild $* > $(BUILD_DIR)sark_build.c
-	$(CC) -o $(BUILD_DIR)sark_build.o $(BUILD_DIR)sark_build.c
-	$(LD) $(LFLAGS) $(OBJECTS) $(BUILD_DIR)sark_build.o $(LIBRARIES) $(SPINN_LIBS) -o $@
-	$(RM) $(BUILD_DIR)sark_build.c $(BUILD_DIR)sark_build.o
-	$(OD) > $(BUILD_DIR)$*.txt $@
+	$(LD) $(LFLAGS) $(OBJECTS) $(BUILD_DIR)$*_build.o $(LIBRARIES) $(SPINN_LIBS) -o $@
+	$(OD) $(BUILD_DIR)$*.txt $@
+	
+# Build sark_build.o
+$(BUILD_DIR)%_build.c:
+	$(SPINN_TOOLS_DIR)/mkbuild $* > $@
 
 $(BUILD_DIR)%.o: %.c
 	$(MKDIR) $(BUILD_DIR)

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -91,6 +91,7 @@ else
 endif
 
 RM := rm -f
+RMDIR := rmdir
 CAT := cat
 LS := ls -l
 MKDIR := mkdir -p
@@ -136,10 +137,8 @@ else
 endif
 
 # Build the ELF file
-#  1) Make a "sark_build.c" file containing app. name and build time
-#     with "mkbuild" and compile it
-#  2) Link application object(s), build file and library to make the ELF
-#  3) Tidy up temporaries and create a list file
+#  1) Link application object(s), build file and library to make the ELF
+#  2) Create a list file
 $(BUILD_DIR)%.elf: $(OBJECTS) $(SCRIPT) $(BUILD_DIR)%_build.o
 	$(MKDIR) $(BUILD_DIR)
 	$(LD) $(LFLAGS) $(OBJECTS) $(BUILD_DIR)$*_build.o $(LIBRARIES) $(SPINN_LIBS) -o $@

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -150,7 +150,7 @@ $(BUILD_DIR)%_build.c:
 
 $(BUILD_DIR)%.o: %.c
 	$(MKDIR) $(BUILD_DIR)
-	$(CC) $(CFLAGS) -o $@ $<
+	$(CC) $(CFLAGS) -DBLAH=BLAH -o $@ $<
 	
 $(BUILD_DIR)%.o: %.cpp
 	$(MKDIR) $(BUILD_DIR)

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -10,7 +10,7 @@ API ?= 1
 THUMB ?= 0
 
 # Set to 1 to include debug info in ELF file
-DEBUG ?= 0
+DEBUG ?= 1
 
 # Set to 1 if making a library (advanced!)
 LIB ?= 0
@@ -24,11 +24,19 @@ ifndef SPINN_DIRS
 endif
 
 ifndef APP_OUTPUT_DIR
-    APP_OUTPUT_DIR = ./
+    APP_OUTPUT_DIR := ./
 endif
 
 ifndef BUILD_DIR
-    BUILD_DIR = build/
+    ifeq ($(GNU),1)
+        BUILD_DIR := build/gnu/
+    else
+        BUILD_DIR := build/arm/
+    endif
+endif
+
+ifeq ($(DEBUG),1)
+.SECONDARY: $(BUILD_DIR)$(APP).elf
 endif
 
 SPINN_LIB_DIR = $(SPINN_DIRS)/lib

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -1,22 +1,22 @@
 # Common includes for making SpiNNaker binaries
 
 # Set to 1 for GNU tools, 0 for ARM
-GNU ?= 1
+GNU := 1
 
 # Set to 1 if using SARK/API (0 for SARK)
-API ?= 1
+API := 1
 
 # Set to 1 to make Thumb code (0 for ARM)
-THUMB ?= 0
+THUMB := 0
 
 # Set to 1 to include debug info in ELF file
-DEBUG ?= 1
+DEBUG := 1
 
 # Set to 1 if making a library (advanced!)
-LIB ?= 0
+LIB := 0
 
 # Prefix for GNU tool binaries
-GP  ?= arm-none-eabi
+GP := arm-none-eabi
 
 # If SPINN_DIRS is not defined, this is an error!
 ifndef SPINN_DIRS

--- a/make/app.make
+++ b/make/app.make
@@ -15,4 +15,4 @@ include $(SPINN_DIRS)/make/Makefile.common
 all: $(APP_OUTPUT_DIR)$(APP).aplx
 	
 clean:
-	$(RM) $(OBJECTS) $(BUILD_DIR)$(APP).txt $(APP_OUTPUT_DIR)$(APP).aplx
+	$(RM) $(OBJECTS) $(BUILD_DIR)$(APP).txt $(APP_OUTPUT_DIR)$(APP).aplx $(BUILD_DIR)$(APP).elf

--- a/make/app.make
+++ b/make/app.make
@@ -10,11 +10,9 @@ ifndef OBJECTS
     OBJECTS = $(BUILD_DIR)$(APP).o
 endif
 
-LIBRARIES = -lspin1_api
-
 include $(SPINN_DIRS)/make/Makefile.common
 
 all: $(APP_OUTPUT_DIR)$(APP).aplx
 	
 clean:
-	$(RM) $(OBJECTS) $(BUILD_DIR)$(APP).elf $(BUILD_DIR)$(APP).txt $(APP_OUTPUT_DIR)$(APP).aplx
+	$(RM) $(OBJECTS) $(BUILD_DIR)$(APP).txt $(APP_OUTPUT_DIR)$(APP).aplx

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -16,7 +16,6 @@ else
 endif
 
 SARKLIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
-SARKINT := $(SPINN_LIB_DIR)/$(LIBNAME).o
 
 #-------------------------------------------------------------------------------
 
@@ -35,9 +34,9 @@ $(SARKLIB): $(SARKOBJ)
 	$(RM) $@
 	$(AR) $@ $^
 
-$(SARKINT): $(SARKOBJ)
+%/sark.o: $(SARKOBJ)
 	$(RM) $@
-	$(LD) -o $(SARKINT) $^
+	$(LD) -o $@ $^
 
 #-------------------------------------------------------------------------------
 
@@ -80,4 +79,4 @@ $(BUILD_DIR)/sark_isr.o: sark_isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR
 #-------------------------------------------------------------------------------
 
 clean:
-	$(RM) $(SARKLIB) $(SARKINT) $(SARKOBJ) $(SARK_ASM_OBJ)
+	$(RM) $(SARKLIB) $(SARKOBJ) $(SARK_ASM_OBJ)

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -1,6 +1,10 @@
 
 # Makefile for SARK
-BUILD_DIR := ../build
+ifeq ($(GNU),1)
+    BUILD_DIR := ../build/gnu
+else
+    BUILD_DIR := ../build/arm
+endif
 LIB := 1
 include ../make/Makefile.common
 
@@ -47,23 +51,29 @@ $(SARKLIB): $(SARKOBJ)
 ifeq ($(GNU),1)
 
 $(BUILD_DIR)/%.gas:	$(SPINN_INC_DIR)/%.h
+	$(MKDIR) $(BUILD_DIR)
 	$(SPINN_TOOLS_DIR)/h2asm $< | $(SPINN_TOOLS_DIR)/arm2gas > $@
 
 $(BUILD_DIR)/%.gas: %.s
+	$(MKDIR) $(BUILD_DIR)
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
 
 $(BUILD_DIR)/sark_alib.o: $(BUILD_DIR)/sark_alib.gas $(BUILD_DIR)/spinnaker.gas $(BUILD_DIR)/sark.gas
+	$(MKDIR) $(BUILD_DIR)
 	$(AS) -I $(BUILD_DIR) -o $@ $<
 
 else
 
 $(BUILD_DIR)/%.s: $(SPINN_INC_DIR)/%.h
+	$(MKDIR) $(BUILD_DIR)
 	$(SPINN_TOOLS_DIR)/h2asm $< > $@
 
 $(BUILD_DIR)/%.s: %.s
+	$(MKDIR) $(BUILD_DIR)
 	$(CP) $< $@
 
 $(BUILD_DIR)/sark_alib.o: $(BUILD_DIR)/sark_alib.s $(BUILD_DIR)/spinnaker.s $(BUILD_DIR)/sark.s
+	$(MKDIR) $(BUILD_DIR)
 	$(AS) -o $@ $<
 
 endif

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -17,7 +17,8 @@ endif
 
 SARKLIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
-CFLAGS += $(OSIZE)
+SARKOPT ?= $(OSIZE)
+CFLAGS += $(SARKOPT)
 
 #-------------------------------------------------------------------------------
 

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -17,6 +17,8 @@ endif
 
 SARKLIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
+CFLAGS += $(OSIZE)
+
 #-------------------------------------------------------------------------------
 
 # SARK objects

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -5,10 +5,10 @@ ifeq ($(GNU),1)
 else
     BUILD_DIR := ../build/arm
 endif
-LIB := 1
+override LIB := 1
 include ../make/Makefile.common
 
-SARKOPT ?= $(OSPACE)
+SARKOPT := $(OSPACE)
 CFLAGS += -DSARK_API $(SARKOPT)
 
 #-------------------------------------------------------------------------------

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -4,7 +4,8 @@ BUILD_DIR := ../build
 LIB := 1
 include ../make/Makefile.common
 
-CFLAGS += -DSARK_API
+SARKOPT ?= $(OSPACE)
+CFLAGS += -DSARK_API $(SARKOPT)
 
 #-------------------------------------------------------------------------------
 ifeq ($(GNU),1)
@@ -17,8 +18,6 @@ endif
 
 SARKLIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
-SARKOPT ?= $(OSIZE)
-CFLAGS += $(SARKOPT)
 
 #-------------------------------------------------------------------------------
 

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -1,12 +1,13 @@
-BUILD_DIR := ../build/
+BUILD_DIR := build/
 APP := scamp-3
 THUMB := 1
 GNU ?= 0
 include ../make/Makefile.common
 
-OBJS := spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \
+OBJECTS = spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \
        scamp-p2p.o scamp-nn.o scamp-cmd.o scamp-boot.o scamp-isr.o \
        $(APP).o
+OBJS := $(OBJECTS:%.o=$(BUILD_DIR)%.o)
 
 ifeq ($(GNU),1)
     SARKLIB := $(SPINN_LIB_DIR)/libsark.a
@@ -16,86 +17,57 @@ else
 endif
 
 
-$(APP).boot: $(OBJS) $(SARKLIB) sark.aplx boot_aplx.bin $(APP).sct
-	$(SPINN_TOOLS_DIR)/mkbuild scamp > sark_build.c
-	$(CC) sark_build.c
-	perl mksv > scamp-3.sv
-	perl mkpad sark.aplx 3584 > sark_pad.aplx
-ifeq ($(GNU),1)
-	$(LD) $(OBJS) sark_build.o $(SARKLIB) -o $(APP).elf
-	$(OC) -O binary -j RO_DATA $(APP).elf RO_DATA.bin
-	$(OC) -O binary -j RW_DATA $(APP).elf RW_DATA.bin
-	$(SPINN_TOOLS_DIR)/mkbin RO_DATA.bin RW_DATA.bin > $(APP).bin
-	$(RM) RO_DATA.bin RW_DATA.bin
-	$(OD) $(APP).elf > $(APP).txt
-else
-	armlink --scatter=$(APP).sct --remove --entry cpu_reset $(OBJS) $(SARKLIB) \
-	  sark_build.o --output $(APP).elf 
-	fromelf $(APP).elf --bin --output $(APP).bin
-	fromelf $(APP).elf -cds --output $(APP).txt
-endif
-
-#	mkaplx -scamp $(APP).elf > scamp.tab
-#	cat scamp.tab boot_aplx.bin boot_aplx.bin scamp-3.sv sark_pad.aplx scamp-3.bin > $(APP).aplx
-
-	$(SPINN_TOOLS_DIR)/mkaplx -nm $(NM) -boot $(APP).elf > boot.tab
-	cat boot_aplx.bin boot.tab boot_aplx.bin scamp-3.sv sark_pad.aplx scamp-3.bin > $(APP).boot
-
-	$(RM) boot.tab scamp.tab scamp-3.bin scamp-3.sv sark_pad.aplx
-	$(RM) sark_build.c sark_build.o
+$(APP).boot: $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)$(APP).sv sark_pad.aplx $(BUILD_DIR)$(APP).bin
+#	$(SPINN_TOOLS_DIR)/mkaplx -scamp $(BUILD_DIR)$(APP).nm > $(BUILD_DIR)scamp.tab
+#	cat $(BUILD_DIR)scamp.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)scamp-3.sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)scamp-3.bin > $(APP).aplx
+	
+	cat $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP).sv sark_pad.aplx $(BUILD_DIR)$(APP).bin > $(APP).boot
 #	$(LS) $(APP).aplx
 	$(LS) $(APP).boot
+	
+$(BUILD_DIR)$(APP).elf: $(OBJS) $(SARK_LIB) $(BUILD_DIR)$(APP)_build.o $(APP).sct
+ifeq ($(GNU),1)
+	$(LD) $(OBJS) $(BUILD_DIR)_build.o $(SARKLIB) -o $(APP).elf
+else
+	armlink --scatter=$(APP).sct --remove --entry cpu_reset $(OBJS) $(SARKLIB) \
+	  $(BUILD_DIR)$(APP)_build.o --output $(BUILD_DIR)$(APP).elf 
+endif
+
+%_boot.tab: %.nm
+	$(SPINN_TOOLS_DIR)/mkaplx -boot $< > $@
+
+%.sv:
+	perl mksv > $@
+
+sark_pad.aplx: sark.aplx
+	perl mkpad $< 3584 > $@
 
 install: $(APP).boot # $(APP).aplx
 	$(MV) $(APP).boot ../tools/boot/scamp.boot
 #	$(MV) $(APP).aplx ../tools/boot/scamp.aplx
 
-boot_aplx.bin: boot_aplx.elf
-ifeq ($(GNU),1)
-	$(OC) -O binary -j RO_DATA boot_aplx.elf RO_DATA.bin
-	$(OC) -O binary -j RW_DATA boot_aplx.elf RW_DATA.bin
-	$(SPINN_TOOLS_DIR)/mkbin RO_DATA.bin RW_DATA.bin > boot_aplx.bin
-	$(RM) RO_DATA.bin RW_DATA.bin
-else
-	$(OC) --bin -o boot_aplx.bin boot_aplx.elf
-endif
-
-sark.aplx: sark.o $(SARKLIB)
-	mkbuild sark > sark_build.c
-	$(CC) sark_build.c
-	$(LD) sark.o sark_build.o $(SARKLIB) --output sark.elf
-ifeq ($(GNU),1)
-	$(OC) -O binary -j RO_DATA sark.elf RO_DATA.bin
-	$(OC) -O binary -j RW_DATA sark.elf RW_DATA.bin
-	$(SPINN_TOOLS_DIR)/mkbin RO_DATA.bin RW_DATA.bin > sark.bin
-	$(RM) RO_DATA.bin RW_DATA.bin
-	$(OD) > sark.txt sark.elf
-else
-	$(OC) --bin --output sark.bin sark.elf
-	$(OD) sark.txt sark.elf
-endif
-	$(SPINN_TOOLS_DIR)/mkaplx -nm $(NM) sark.elf | cat - sark.bin > sark.aplx
-	$(RM) sark_build.c sark_build.o sark.bin
+$(BUILD_DIR)sark.elf: $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB)
+	 $(LD) $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB) --output $@
 	
 ifeq ($(GNU),1)
-%.gas: %.s
+$(BUILD_DIR)%.gas: $(BUILD_DIR)%.s
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
 
-boot_aplx.elf: boot_aplx.gas spinnaker.gas sark.gas
-	$(AS) -I $(BUILD_DIR) -o boot_aplx.o $<
+$(BUILD_DIR)%.gas: %.s
+	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
+
+$(BUILD_DIR)boot_aplx.elf: $(BUILD_DIR)boot_aplx.gas $(BUILD_DIR)spinnaker.gas $(BUILD_DIR)sark.gas
+	$(AS) -I $(BUILD_DIR) -o $@ $<
 	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx -nostartfiles boot_aplx.o -o boot_aplx.elf
 		
 else
-boot_aplx.elf: boot_aplx.s spinnaker.s sark.s
-	$(AS) boot_aplx.s
-	armlink --ro_base 0 -o boot_aplx.elf boot_aplx.o
+$(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.s
+	$(AS) -I $(BUILD_DIR) boot_aplx.s -o $(BUILD_DIR)boot_aplx.o
+	armlink --ro_base 0 -o $@ $(BUILD_DIR)boot_aplx.o
 endif
 
-spinnaker.s: $(SPINN_INC_DIR)/spinnaker.h
-	h2asm $(SPINN_INC_DIR)/spinnaker.h > spinnaker.s
-
-sark.s: $(SPINN_INC_DIR)/sark.h
-	h2asm $(SPINN_INC_DIR)/sark.h > sark.s
+$(BUILD_DIR)%.s: $(SPINN_INC_DIR)/%.h
+	h2asm $< > $@
 
 scamp-isr.o: scamp-isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h scamp.h
 	$(CC_NO_THUMB) $(CFLAGS) scamp-isr.c
@@ -110,9 +82,4 @@ tar:
 	scamp/Makefile scamp/mkpad scamp/mksv
 
 clean:
-	$(RM) $(OBJS) boot_aplx.o boot_aplx.bin boot_aplx.elf 
-	$(RM) $(APP).txt $(APP).aplx $(APP).elf $(APP).bin $(APP).boot $(APP).tab
-	$(RM) spinnaker.s sark.s sark_build.c sark_build.o sark.o sark.txt sark.elf
-	$(RM) boot_aplx.gas spinnaker.gas sark.gas sark.aplx sark-pad.aplx
-
-
+	$(RM) $(BUILD_DIR)* sark_pad.aplx

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -17,20 +17,20 @@ else
 endif
 
 
-$(APP).boot: $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)$(APP).sv sark_pad.aplx $(BUILD_DIR)$(APP).bin
+$(APP).boot: $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin
 #	$(SPINN_TOOLS_DIR)/mkaplx -scamp $(BUILD_DIR)$(APP).nm > $(BUILD_DIR)scamp.tab
 #	cat $(BUILD_DIR)scamp.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)scamp-3.sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)scamp-3.bin > $(APP).aplx
 	
-	cat $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP).sv sark_pad.aplx $(BUILD_DIR)$(APP).bin > $(APP).boot
+	cat $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin > $(APP).boot
 #	$(LS) $(APP).aplx
 	$(LS) $(APP).boot
 	
 $(BUILD_DIR)$(APP).elf: $(OBJS) $(SARK_LIB) $(BUILD_DIR)$(APP)_build.o $(APP).sct
 ifeq ($(GNU),1)
-	$(LD) $(OBJS) $(BUILD_DIR)_build.o $(SARKLIB) -o $(APP).elf
+	$(LD) $(OBJS) $(BUILD_DIR)$(APP)_build.o $(SARKLIB) -o $@
 else
 	armlink --scatter=$(APP).sct --remove --entry cpu_reset $(OBJS) $(SARKLIB) \
-	  $(BUILD_DIR)$(APP)_build.o --output $(BUILD_DIR)$(APP).elf 
+	  $(BUILD_DIR)$(APP)_build.o --output $@
 endif
 
 %_boot.tab: %.nm
@@ -39,15 +39,16 @@ endif
 %.sv:
 	perl mksv > $@
 
-sark_pad.aplx: sark.aplx
+$(BUILD_DIR)sark_pad.aplx: $(BUILD_DIR)sark.aplx
 	perl mkpad $< 3584 > $@
 
 install: $(APP).boot # $(APP).aplx
 	$(MV) $(APP).boot ../tools/boot/scamp.boot
 #	$(MV) $(APP).aplx ../tools/boot/scamp.aplx
 
-$(BUILD_DIR)sark.elf: $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB)
-	 $(LD) $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB) --output $@
+$(BUILD_DIR)$(BUILD_DIR)sark.elf: $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB)
+	$(MKDIR) $(BUILD_DIR)$(BUILD_DIR)
+	$(LD) $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB) --output $@
 	
 ifeq ($(GNU),1)
 $(BUILD_DIR)%.gas: $(BUILD_DIR)%.s
@@ -57,8 +58,8 @@ $(BUILD_DIR)%.gas: %.s
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
 
 $(BUILD_DIR)boot_aplx.elf: $(BUILD_DIR)boot_aplx.gas $(BUILD_DIR)spinnaker.gas $(BUILD_DIR)sark.gas
-	$(AS) -I $(BUILD_DIR) -o $@ $<
-	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx -nostartfiles boot_aplx.o -o boot_aplx.elf
+	$(AS) -I $(BUILD_DIR) -o $(BUILD_DIR)boot_aplx.o $<
+	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx -nostartfiles $(BUILD_DIR)boot_aplx.o -o $@
 		
 else
 $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.s
@@ -67,10 +68,11 @@ $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.
 endif
 
 $(BUILD_DIR)%.s: $(SPINN_INC_DIR)/%.h
+	$(MKDIR) $(BUILD_DIR)
 	h2asm $< > $@
 
-scamp-isr.o: scamp-isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h scamp.h
-	$(CC_NO_THUMB) $(CFLAGS) scamp-isr.c
+$(BUILD_DIR)scamp-isr.o: scamp-isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h scamp.h
+	$(CC_NO_THUMB) $(CFLAGS) scamp-isr.c -o $@
 
 tar:
 	tar -C .. -czf /tmp/scamp.tgz scamp/spinn_phy.c \
@@ -82,4 +84,6 @@ tar:
 	scamp/Makefile scamp/mkpad scamp/mksv
 
 clean:
-	$(RM) $(BUILD_DIR)* sark_pad.aplx
+	$(RM) $(BUILD_DIR)$(BUILD_DIR)*
+	$(RM) -r $(BUILD_DIR)$(BUILD_DIR)
+	$(RM) $(BUILD_DIR)* $(APP).boot

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -4,10 +4,10 @@ THUMB := 1
 GNU ?= 0
 include ../make/Makefile.common
 
-OBJECTS = spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \
-       scamp-p2p.o scamp-nn.o scamp-cmd.o scamp-boot.o scamp-isr.o \
-       $(APP).o
-OBJS := $(OBJECTS:%.o=$(BUILD_DIR)%.o)
+SCAMP_OBJS = spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \
+             scamp-p2p.o scamp-nn.o scamp-cmd.o scamp-boot.o scamp-isr.o \
+             $(APP).o
+OBJS := $(SCAMP_OBJS:%.o=$(BUILD_DIR)%.o)
 
 ifeq ($(GNU),1)
     SARKLIB := $(SPINN_LIB_DIR)/libsark.a
@@ -16,15 +16,25 @@ else
     SARKLIB := $(SPINN_LIB_DIR)/sark.a
 endif
 
-
+# Create the boot file (default)
 $(APP).boot: $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin
-#	$(SPINN_TOOLS_DIR)/mkaplx -scamp $(BUILD_DIR)$(APP).nm > $(BUILD_DIR)scamp.tab
-#	cat $(BUILD_DIR)scamp.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)scamp-3.sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)scamp-3.bin > $(APP).aplx
-	
 	cat $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin > $(APP).boot
-#	$(LS) $(APP).aplx
 	$(LS) $(APP).boot
-	
+
+# Create the aplx file (optional)
+$(APP).aplx: $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP)_boot.tab $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin
+	cat $(BUILD_DIR)$(APP)_scamp.tab $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)boot_aplx.bin $(BUILD_DIR)$(APP).sv $(BUILD_DIR)sark_pad.aplx $(BUILD_DIR)$(APP).bin > $(APP).aplx
+	$(LS) $(APP).aplx
+
+# Install the boot file (default)
+install: $(APP).boot
+	$(MV) $(APP).boot ../tools/boot/scamp.boot
+
+# Install the aplx file (optional)
+install-aplx: $(APP).aplx
+	$(MV) $(APP).aplx ../tools/boot/scamp.aplx
+
+# Build the SCAMP elf file - uses scatter file on ARM
 $(BUILD_DIR)$(APP).elf: $(OBJS) $(SARK_LIB) $(BUILD_DIR)$(APP)_build.o $(APP).sct
 ifeq ($(GNU),1)
 	$(LD) $(OBJS) $(BUILD_DIR)$(APP)_build.o $(SARKLIB) -o $@
@@ -33,23 +43,28 @@ else
 	  $(BUILD_DIR)$(APP)_build.o --output $@
 endif
 
+# Create an aplx header table for booting
 %_boot.tab: %.nm
 	$(SPINN_TOOLS_DIR)/mkaplx -boot $< > $@
 
+# Create an aplx header table for aplx
+%_scamp.tab: %.nm
+	$(SPINN_TOOLS_DIR)/mkaplx -scamp $< > $@
+
+# Create the sv structure from perl
 %.sv:
 	perl mksv > $@
 
+# Create the padded sark APLX
 $(BUILD_DIR)sark_pad.aplx: $(BUILD_DIR)sark.aplx
 	perl mkpad $< 3584 > $@
 
-install: $(APP).boot # $(APP).aplx
-	$(MV) $(APP).boot ../tools/boot/scamp.boot
-#	$(MV) $(APP).aplx ../tools/boot/scamp.aplx
-
+# Create the SARK elf file (uses own objects)
 $(BUILD_DIR)$(BUILD_DIR)sark.elf: $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB)
 	$(MKDIR) $(BUILD_DIR)$(BUILD_DIR)
 	$(LD) $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(SARKLIB) --output $@
-	
+
+# Create the boot_aplx elf file (uses a different linker script)
 ifeq ($(GNU),1)
 $(BUILD_DIR)%.gas: $(BUILD_DIR)%.s
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
@@ -67,10 +82,12 @@ $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.
 	armlink --ro_base 0 -o $@ $(BUILD_DIR)boot_aplx.o
 endif
 
+# Convert h file to s
 $(BUILD_DIR)%.s: $(SPINN_INC_DIR)/%.h
 	$(MKDIR) $(BUILD_DIR)
 	h2asm $< > $@
 
+# Compile the interrupt state registers without THUMB
 $(BUILD_DIR)scamp-isr.o: scamp-isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h scamp.h
 	$(CC_NO_THUMB) $(CFLAGS) scamp-isr.c -o $@
 

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -1,4 +1,8 @@
-BUILD_DIR := build/
+ifeq ($(GNU),1)
+    BUILD_DIR := build/gnu/
+else
+    BUILD_DIR := build/arm/
+endif
 APP := scamp-3
 THUMB := 1
 GNU ?= 0
@@ -67,23 +71,28 @@ $(BUILD_DIR)$(BUILD_DIR)sark.elf: $(BUILD_DIR)sark.o $(BUILD_DIR)sark_build.o $(
 # Create the boot_aplx elf file (uses a different linker script)
 ifeq ($(GNU),1)
 $(BUILD_DIR)%.gas: $(BUILD_DIR)%.s
+	$(MKDIR) $(BUILD_DIR)
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
 
 $(BUILD_DIR)%.gas: %.s
+	$(MKDIR) $(BUILD_DIR)
 	$(SPINN_TOOLS_DIR)/arm2gas $< > $@
 
 $(BUILD_DIR)boot_aplx.elf: $(BUILD_DIR)boot_aplx.gas $(BUILD_DIR)spinnaker.gas $(BUILD_DIR)sark.gas
+	$(MKDIR) $(BUILD_DIR)
 	$(AS) -I $(BUILD_DIR) -o $(BUILD_DIR)boot_aplx.o $<
 	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx -nostartfiles $(BUILD_DIR)boot_aplx.o -o $@
 		
 else
 $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.s
+	$(MKDIR) $(BUILD_DIR)
 	$(AS) -I $(BUILD_DIR) boot_aplx.s -o $(BUILD_DIR)boot_aplx.o
 	armlink --ro_base 0 -o $@ $(BUILD_DIR)boot_aplx.o
 endif
 
 # Convert h file to s
 $(BUILD_DIR)%.s: $(SPINN_INC_DIR)/%.h
+	$(MKDIR) $(BUILD_DIR)
 	$(MKDIR) $(BUILD_DIR)
 	h2asm $< > $@
 
@@ -101,6 +110,4 @@ tar:
 	scamp/Makefile scamp/mkpad scamp/mksv
 
 clean:
-	$(RM) $(BUILD_DIR)$(BUILD_DIR)*
-	$(RM) -r $(BUILD_DIR)$(BUILD_DIR)
-	$(RM) $(BUILD_DIR)* $(APP).boot
+	$(RM) -r $(BUILD_DIR)* $(APP).boot

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -1,11 +1,5 @@
-ifeq ($(GNU),1)
-    BUILD_DIR := build/gnu/
-else
-    BUILD_DIR := build/arm/
-endif
 APP := scamp-3
-THUMB := 1
-GNU ?= 0
+override THUMB := 1
 include ../make/Makefile.common
 
 SCAMP_OBJS = spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -5,8 +5,8 @@ ifeq ($(GNU),1)
 else
     BUILD_DIR := ../build/arm
 endif
-LIB := 1
 include ../make/Makefile.common
+LIB := 1
 
 #-------------------------------------------------------------------------------
 
@@ -23,7 +23,7 @@ endif
 
 APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
-APIOPT ?= $(OSPACE)
+APIOPT := $(OSPACE)
 CFLAGS += $(APIOPT)
 
 #-------------------------------------------------------------------------------

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -19,6 +19,8 @@ endif
 
 APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
+CFLAGS += $(OSIZE)
+
 #-------------------------------------------------------------------------------
 
 # APILIB (default target)

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -1,6 +1,10 @@
 
 # Makefile for spin1_api
-BUILD_DIR := ../build
+ifeq ($(GNU),1)
+    BUILD_DIR := ../build/gnu
+else
+    BUILD_DIR := ../build/arm
+endif
 LIB := 1
 include ../make/Makefile.common
 

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -19,7 +19,8 @@ endif
 
 APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
-CFLAGS += $(OSIZE)
+APIOPT ?= $(OSIZE)
+CFLAGS += $(APIOPT)
 
 #-------------------------------------------------------------------------------
 

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -19,7 +19,7 @@ endif
 
 APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
-APIOPT ?= $(OSIZE)
+APIOPT ?= $(OSPACE)
 CFLAGS += $(APIOPT)
 
 #-------------------------------------------------------------------------------

--- a/spin1_api/Makefile
+++ b/spin1_api/Makefile
@@ -13,10 +13,8 @@ HEADER := $(HEADERS:%.h=$(SPINN_INC_DIR)/%.h)
 
 ifeq ($(GNU),1)
   LIBNAME := libspin1_api
-  SARKOBJ := $(SPINN_LIB_DIR)/libsark.o 
 else
   LIBNAME := spin1_api
-  SARKOBJ := $(SPINN_LIB_DIR)/sark.o 
 endif
 
 APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
@@ -25,12 +23,12 @@ APILIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 
 # APILIB (default target)
 
-$(APILIB): $(SARKOBJ) $(APIOBJ)
+$(APILIB): $(BUILD_DIR)/sark.o $(APIOBJ)
 	$(RM) $@
 	$(AR) $@ $^
 
-$(SARKOBJ):
-	cd ../sark/; $(MAKE) $(SARKOBJ)
+$(BUILD_DIR)/sark.o:
+	cd ../sark/; $(MAKE) $@
 
 #-------------------------------------------------------------------------------
 
@@ -45,4 +43,4 @@ $(BUILD_DIR)/spin1_isr.o: spin1_isr.c $(HEADER)
 #-------------------------------------------------------------------------------
 
 clean:
-	$(RM) $(APILIB) $(APIOBJ)
+	$(RM) $(APILIB) $(APIOBJ) $(BUILD_DIR)/sark.o

--- a/tools/mkaplx
+++ b/tools/mkaplx
@@ -22,11 +22,11 @@ my @addrs;
 
 sub usage ()
 {
-    die "usage: mkaplx [-text] [-scamp] [-boot] [-nm nm] <ELF file> [<file> <addr>]*\n"
+    die "usage: mkaplx [-text] [-scamp] [-boot] <nm file> [<file> <addr>]*\n"
 }
 
 my $count = 0;
-my ($text, $scamp, $boot, $nm) = (0, 0, 0, "nm");
+my ($text, $scamp, $boot) = (0, 0, 0);
 
 
 # Process arguments
@@ -37,12 +37,9 @@ while (defined $ARGV[0] && $ARGV[0] =~ /^-.+/)
     $text = 1 if $flag eq "-text";
     $scamp = 1 if $flag eq "-scamp";
     $boot = 1 if $flag eq "-boot";
-    $nm = shift @ARGV if $flag eq "-nm";
 }
 
 usage () unless $#ARGV >= 0;
-
-print STDERR "Using $nm\n";
 
 my $file = shift @ARGV;
 
@@ -78,9 +75,9 @@ my ($RW_TO, $RW_FROM, $RW_LENGTH);
 my ($ZI_TO, $ZI_LENGTH);
 
 
-# Read ELF file symbols using "nm"
+# Read ELF file symbols from nm format
 
-open my $fh, "-|", "$nm $file" or die "Can't open pipe \"$nm $file\"\n";
+open my $fh, "<", "$file" or die "Can't open \"$file\"\n";
 binmode($fh);
 
 while (<$fh>)


### PR DESCRIPTION
Fixes some issues with the Makefiles spotted by Luis.  Also includes some rationalisation of the Makefiles to hopefully make some things easier to follow (if you can follow a Makefile anyway ;).  This makes the default compile flag for the api and sark Ospace or Os (for ARM and GNU tools), but allows overriding by specifying a APIOPT or SARKOPT flag.
