### PR TITLE
Fix barriers used during boot.

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -12,7 +12,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"3.0.0"
-#define	SLLT_VER_NUM	0x030000
+#define	SLLT_VER_STR	"3.0.1-dev"
+#define	SLLT_VER_NUM	0x030001
 
 #endif

--- a/include/version.h
+++ b/include/version.h
@@ -12,7 +12,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"3.0.1-dev"
-#define	SLLT_VER_NUM	0x030001
+#define	SLLT_VER_STR	"3.0.0"
+#define	SLLT_VER_NUM	0x030000
 
 #endif

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1224,8 +1224,8 @@ void proc_100hz (uint a1, uint a2)
       // the machine are not aligned. As a result, some chips may be *almost*
       // 10ms ahead of others. Since it is important that blacklisting
       // information is broadcast ahead of P2P generation, leaving an extra
-      // "tick" before moving to the next state should deal with the problem.
-      // More ticks allow extra lee-way accounting for the fact that
+      // "tick" before moving to the next state should deal with the problem. A
+      // third tick is left to allow extra leeway accounting for the fact that
       // the timers are not necessarily *perfectly* aligned to within 10ms...
       
       netinit_biff_tick_counter++;
@@ -1245,7 +1245,7 @@ void proc_100hz (uint a1, uint a2)
                 }
             }
         }
-      else if (netinit_biff_tick_counter >= 20)
+      else if (netinit_biff_tick_counter >= 3)
         {
           netinit_p2p_tick_counter = 0;
           netinit_phase = NETINIT_PHASE_P2P_TABLE;

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -106,9 +106,10 @@ uint tag_tto = 9;	// 2.56s = 10ms * (1 << (9-1))
 // The network initialisation process phase currently in progress
 volatile enum netinit_phase_e netinit_phase;
 
-// Number of 10ms ticks ellapsed since a network initialisation broadcast
-// message was receieved
-volatile uint last_netinit_broadcast;
+// Number of 10ms ticks ellapsed since the last P2PC_NEW arrived
+volatile uint ticks_since_last_p2pc_new;
+// Number of 10ms ticks ellapsed since the last P2PC_DIMS arrived
+volatile uint ticks_since_last_p2pc_dims;
 
 // During NETINIT_PHASE_P2P_ADDR, the current best guess of P2P address. Note
 // that this value may be negative and may be much larger than realistic
@@ -1099,7 +1100,8 @@ void netinit_start(void)
   p2p_addr_table = sark_xalloc (sv->sys_heap, P2P_ADDR_TABLE_BYTES, 0, 0);
   sark_word_set (p2p_addr_table, 0, P2P_ADDR_TABLE_BYTES);
   
-  last_netinit_broadcast = 0;
+  ticks_since_last_p2pc_new = 0;
+  ticks_since_last_p2pc_dims = 0;
 }
 
 // Sets up a broadcast MC route by constructing a spanning tree of the  P2P
@@ -1150,6 +1152,9 @@ void compute_st (void)
 // "proc_100hz" is put on the event queue every 10ms
 void proc_100hz (uint a1, uint a2)
 {
+  // Counter used to time how long we've been in certain netinit states.
+  static uint netinit_tick_counter = 0;
+  
   // Boot-up related packet sending and boot-phase advancing
   switch (netinit_phase)
   {
@@ -1160,11 +1165,10 @@ void proc_100hz (uint a1, uint a2)
       
       // If no new P2P addresses have been broadcast for a while we can assume
       // all chips are have a valid P2P address so it is now time to determine
-      // the system's dimensions.
-      if (last_netinit_broadcast++ > (uint)sv->netinit_bc_wait)
+			// the system's dimensions.
+			if (ticks_since_last_p2pc_new++ > (uint)sv->netinit_bc_wait)
         {
           netinit_phase = NETINIT_PHASE_P2P_DIMS;
-          last_netinit_broadcast = 0;
           
           p2p_min_x = (p2p_addr_guess_x < 0) ? p2p_addr_guess_x : 0;
           p2p_min_y = (p2p_addr_guess_y < 0) ? p2p_addr_guess_y : 0;
@@ -1180,7 +1184,7 @@ void proc_100hz (uint a1, uint a2)
       
       // If no new guesses have been broadcast for a while we can assume the
       // current guess is accurate so its time to move onto the next phase
-      if (last_netinit_broadcast++ > (uint)sv->netinit_bc_wait)
+      if (ticks_since_last_p2pc_dims++ > (uint)sv->netinit_bc_wait)
         {
           // If no coordinate discovered, just shut down this chip
           if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA)
@@ -1204,7 +1208,7 @@ void proc_100hz (uint a1, uint a2)
           // Work out the local Ethernet connected chip coordinates
           compute_eth ();
           
-          last_netinit_broadcast = 0;
+          netinit_tick_counter = 0;
           netinit_phase = NETINIT_PHASE_BIFF;
         }
       break;
@@ -1223,9 +1227,9 @@ void proc_100hz (uint a1, uint a2)
       // third tick is left to allow extra leeway accounting for the fact that
       // the timers are not necessarily *perfectly* aligned to within 10ms...
       
-      last_netinit_broadcast++;
+      netinit_tick_counter++;
       
-      if (last_netinit_broadcast == 1)
+      if (netinit_tick_counter == 1)
         {
           if (sv->board_info)
             {
@@ -1240,9 +1244,9 @@ void proc_100hz (uint a1, uint a2)
                 }
             }
         }
-      else if (last_netinit_broadcast >= 3)
+      else if (netinit_tick_counter >= 3)
         {
-          last_netinit_broadcast = 0;
+          netinit_tick_counter = 0;
           netinit_phase = NETINIT_PHASE_P2P_TABLE;
         }
       break;
@@ -1252,7 +1256,7 @@ void proc_100hz (uint a1, uint a2)
       // network load.
       {
         uint p2pb_period = ((p2p_dims >> 8) * (p2p_dims & 0xFF)) * P2PB_OFFSET_USEC;
-        if (last_netinit_broadcast == 0)
+        if (netinit_tick_counter == 0)
           {
             hop_table[p2p_addr] = 0;
             rtr_p2p_set (p2p_addr, 7);
@@ -1263,10 +1267,10 @@ void proc_100hz (uint a1, uint a2)
         // Once all P2P messages have had ample time to send (and the required
         // number of repeats have occurred), compute the level
         // config and signalling broadcast spanning tree.
-        if (last_netinit_broadcast++ >=
+        if (netinit_tick_counter++ >=
             ((p2pb_period / 10000) + 2))
           {
-            last_netinit_broadcast = 0;
+            netinit_tick_counter = 0;
             
             if (sv->p2pb_repeats-- == 0)
               {

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -568,7 +568,7 @@ void nn_rcv_p2pc_addr_pct(uint link, uint data, uint key)
   // If guess was updated, broadcast this fact
   if (updated)
     {
-      last_netinit_broadcast = 0;
+      ticks_since_last_p2pc_new = 0;
       p2pc_new_nn_send(p2p_addr_guess_x, p2p_addr_guess_y);
     }
 }
@@ -596,7 +596,7 @@ void nn_rcv_p2pc_new_pct(uint link, uint data, uint key)
   // Re-broadcast only newly discovered coordinates
   if (byte != new_byte)
     {
-      last_netinit_broadcast = 0;
+      ticks_since_last_p2pc_new = 0;
       p2pc_new_nn_send(x, y);
     }
 }
@@ -640,7 +640,7 @@ void nn_rcv_p2pc_dims_pct(uint link, uint data, uint key)
   // delay
   if (changed)
     {
-      last_netinit_broadcast = 0;
+      ticks_since_last_p2pc_dims = 0;
       p2pc_dims_nn_send(0, 0);
     }
 }

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -355,7 +355,8 @@ extern uchar core_app[MAX_CPUS];
 extern uint app_mask[256];
 
 extern volatile enum netinit_phase_e netinit_phase;
-extern volatile uint last_netinit_broadcast;
+extern volatile uint ticks_since_last_p2pc_new;
+extern volatile uint ticks_since_last_p2pc_dims;
 extern volatile int p2p_addr_guess_x;
 extern volatile int p2p_addr_guess_y;
 extern volatile int p2p_min_x;


### PR DESCRIPTION
@Steve-Temple and/or @rowleya would you mind reviewing this change? Thank you and sorry about the bug!

---

The bug fixed here is responsible for chips sometimes failing to come up during
boot, or coming up with the wrong P2P dimensions (but correct coordinates) or
coming up and not being reachable from just chip (0, 0).

During boot, SC&MP uses a pair of distributed processes to assign chip
coordinates and discover the dimensions of the system. These processes rely on
a system-wide barrier to function, which prior to this patch was broken.

The barrier mechanism works as illustrated in the following figure:

![SC&MP Barrier Diagram](http://jhnet.co.uk/misc/scamp_boot_barriers.png)

When a chip first powers up it enters the "address discovery" phase of the boot
process. During this process a broadcast message is sent every time a new chip
discovers (or refines) its coordinates. To determine once every chip knows its
coordinates, a timer is used to time how long has ellapsed since the last
broadcast message was received. Once `sv->netinit_bc_wait` 10ms ticks have
ellapsed without a broadcast arriving, the address discovery process is
considered to have finished. At this point all chips have reached the first
barrier.

After the first barrier, chips enter the "dimension discovery" phase in which
they broadcast their best guess of the system's dimensions whenever their best
guess changes. After a while everyone should know the system's dimensions and
broadcast messages should cease. After `sv->netinit_bc_wait` 10ms ticks have
ellapsed without further broadcasts arriving, the second barrier is considered
reached and boot continues (e.g. going on to do blacklisting and P2P table
generation).

The bug fixed by this commit is that a single timer was used to time how long
has ellapsed since the last broadcast arrived. Because timers around the system
aren't aligned and broadcast messages arrive at different times in different
parts of the system, the chips don't arrive at the barrier at exactly the same
moment globally. As a consequence, some chips may enter the next phase and
start sending new broadcast messages prior to others deciding they've reached
the barrier. Because a single timer was used, the slower chips essentially get
trapped in the first phase until traffic dies down again.

To fix the problem, this commit gives each phase its own dedicated timeout
timer. Packets arriving from a future phase (due to slight differences in
timing between chips) therefore don't cause you to get stuck behind a barrier.

All of the bizarre faults described at the start of this commit message are
knock-on effects of this barrier failure.
