### PR TITLE
Added an Ethernet phase to ensure that the Ethernet is ready

### DIFF
--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -187,8 +187,10 @@ uint cmd_ver (sdp_msg_t *msg)
 {
   // Report P2P address of 255,255 until boot completes (as an indication of
   // system readiness)
-  uint p2p_addr = (netinit_phase == NETINIT_PHASE_DONE) ? sv->p2p_addr
-                                                        : 0xFFFF;
+  uint p2p_addr =
+      ((netinit_phase == NETINIT_PHASE_DONE) &&
+       (ethinit_phase == ETHINIT_PHASE_DONE)) ?
+      sv->p2p_addr : 0xFFFF;
 
   msg->arg1 = (p2p_addr << 16) + (sark.phys_cpu << 8) + sark.virt_cpu;
   msg->arg2 = 0xffff0000 + SDP_BUF_SIZE;

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -202,8 +202,21 @@ enum netinit_phase_e
   NETINIT_PHASE_BIFF,
   // Construct the P2P routing tables
   NETINIT_PHASE_P2P_TABLE,
+  // Setting the Ethernet address
+  NETINIT_PHASE_SET_ETHERNET_ADDR,
   // The boot process is complete and the system is ready for use
   NETINIT_PHASE_DONE = 0xFF,
+};
+
+// Phases of the Ethernet initialisation process, in order
+enum ethinit_phase_e
+{
+  // FIRST PHASE - wait for Ethernet to come up
+  ETHINIT_PHASE_WAIT_1,
+  // SECOND_PHASE - wait for Ethernet to come up
+  ETHINIT_PHASE_WAIT_2,
+  // Ethernet either up or timed out
+  ETHINIT_PHASE_DONE = 0xFF,
 };
 
 //------------------------------------------------------------------------------
@@ -355,6 +368,7 @@ extern uchar core_app[MAX_CPUS];
 extern uint app_mask[256];
 
 extern volatile enum netinit_phase_e netinit_phase;
+extern volatile enum ethinit_phase_e ethinit_phase;
 extern volatile uint ticks_since_last_p2pc_new;
 extern volatile uint ticks_since_last_p2pc_dims;
 extern volatile int p2p_addr_guess_x;


### PR DESCRIPTION
This fixes an issue with 4-chip boards that meant that they didn't always recognise that the Ethernet was connected before returning a valid chip id in sver.  This meant that although the Ethernet IP address was set, the Ethernet was marked as "down" (even though it was responding).

The fix adds an ethinit_phase similar to the netinit_phase that either checks that the Ethernet is up or times out (after 2 seconds as far as I can see).

This has been tested on a 4-chip board, a spalloc'd 48-chip board and a spalloc'd 6-board toroid and seems to work on all of them.
