### PR TITLE
Sdp timing fix

### DIFF
--- a/scamp/scamp-p2p.c
+++ b/scamp/scamp-p2p.c
@@ -376,9 +376,12 @@ uint p2p_send_msg (uint addr, sdp_msg_t *msg)
 	{
 	  uchar *p = desc->base + 3 * seq;
 
+          uint is_last_seq = (p >= desc->limit);
+          uint next_mask = mask >> 1;
+
 	  if (mask & 1)
 	    {
-              if ((p >= desc->limit) || ((mask >> 1) == 0))
+              if (is_last_seq || (next_mask == 0))
 		{
 		  desc->ack = 0;
 
@@ -402,13 +405,13 @@ uint p2p_send_msg (uint addr, sdp_msg_t *msg)
 	      p2p_send_data (data, addr);
 	    }
 
-	  if (p >= desc->limit)
+	  if (is_last_seq)
 	    {
 	      desc->done = 1;
 	      break;
 	    }
 
-	  mask = mask >> 1;
+	  mask = next_mask;
 
 	  if (mask == 0)
 	    break;


### PR DESCRIPTION
The order of steps 'send p2p packet' and 'schedule timeout' in p2p_send_msg was inverted to avoid a race between the acknowledge packet and the scheduling of the timeout. With the worng ordering, the acknowledge packet can arrive back before the timeout is scheduled and, therefore, the timeout is not cancelled. When the timer is finally scheduled it causes a spurious timeout, which propagates back to the original sender of the SDP message, which can be the host.

This problem doesn't seem to manifest when the host talks to the Ethernet port assoicated with the boot chip (usually 0,0) but manifests when the host talks to ohter Ethernet ports. I have not found a good explanation as to this difference. Still looking.

Thanks to @mundya for spotting the problem.
