### PR TITLE
Fix for "led" command in "bmpc" not working

### DIFF
--- a/tools/SpiNN/Cmd.pm
+++ b/tools/SpiNN/Cmd.pm
@@ -461,6 +461,7 @@ sub led
 
     $self->scp_cmd ($CMD_LED,
                     arg1 => $leds,
+		    arg2 => 1 << $self->{C},
                     %opts);
 }
 


### PR DESCRIPTION
"led" command in "bmpc" was broken as a required argument was not being provided via "Cmd.pm"
