### PR TITLE
fix_additional_section_on_divide

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -136,7 +136,7 @@ $(BUILD_DIR)%.nm: $(BUILD_DIR)%.elf
 # Create a binary file which is the concatenation of RO and RW sections
 $(BUILD_DIR)%.bin: $(BUILD_DIR)%.elf
 ifeq ($(GNU),1)
-	$(OC) -O binary -j RO_DATA $< $(BUILD_DIR)RO_DATA.bin
+	$(OC) -O binary -j RO_DATA -j EX_DATA $< $(BUILD_DIR)RO_DATA.bin
 	$(OC) -O binary -j RW_DATA $< $(BUILD_DIR)RW_DATA.bin
 	$(SPINN_TOOLS_DIR)/mkbin $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin > $@
 	$(RM) $(BUILD_DIR)RO_DATA.bin $(BUILD_DIR)RW_DATA.bin

--- a/sark/Makefile
+++ b/sark/Makefile
@@ -28,7 +28,7 @@ SARKLIB := $(SPINN_LIB_DIR)/$(LIBNAME).a
 # SARK objects
 
 SARKOBJS := sark_alib.o sark_base.o sark_event.o sark_timer.o \
-	sark_hw.o sark_isr.o sark_alloc.o sark_io.o sark_pkt.o
+	sark_hw.o sark_isr.o sark_alloc.o sark_io.o sark_pkt.o sark_div0.o
 SARK_ASM_OBJS := sark_alib.end spinnaker.end sark.end
 SARKOBJ = $(SARKOBJS:%.o=$(BUILD_DIR)/%.o)
 SARK_ASM_OBJ = $(SARK_ASM_OBJS:%.end=$(BUILD_DIR)/%.$(AS_END))
@@ -86,6 +86,9 @@ $(BUILD_DIR)/%.o: %.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h $(SPI
 	$(CC_THUMB) $(CFLAGS) -o $@ $<
 	
 $(BUILD_DIR)/sark_isr.o: sark_isr.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h $(SPINN_INC_DIR)/spin1_api.h
+	$(CC) $(CFLAGS) -o $@ $<
+	
+$(BUILD_DIR)/sark_div0.o: sark_div0.c $(SPINN_INC_DIR)/spinnaker.h $(SPINN_INC_DIR)/sark.h
 	$(CC) $(CFLAGS) -o $@ $<
 
 #-------------------------------------------------------------------------------

--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -825,3 +825,12 @@ void sark_int (void *pc)
 
 
 //------------------------------------------------------------------------------
+
+// Functions to handle division by 0 (simply RTE)
+void __aeabi_idiv0() {
+    rt_error(RTE_DIV0);
+}
+
+void __aeabi_ldiv0() {
+    rt_error(RTE_DIV0);
+}

--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -825,12 +825,3 @@ void sark_int (void *pc)
 
 
 //------------------------------------------------------------------------------
-
-// Functions to handle division by 0 (simply RTE)
-void __aeabi_idiv0() {
-    rt_error(RTE_DIV0);
-}
-
-void __aeabi_ldiv0() {
-    rt_error(RTE_DIV0);
-}

--- a/sark/sark_div0.c
+++ b/sark/sark_div0.c
@@ -1,0 +1,10 @@
+#include <sark.h>
+
+// Functions to handle division by 0 (simply RTE)
+void __aeabi_idiv0() {
+    rt_error(RTE_DIV0);
+}
+
+void __aeabi_ldiv0() {
+    rt_error(RTE_DIV0);
+}

--- a/tools/sark.lnk
+++ b/tools/sark.lnk
@@ -31,11 +31,6 @@ SECTIONS
 
     . = ITCM_BASE;
     
-    /DISCARD/ :
-    {
-        *(.ARM.exidx*);
-    }
-
     RO_DATA :
     {
           * (_alib_reset);
@@ -52,7 +47,14 @@ SECTIONS
     . = ALIGN (4);
 
     RO_LENGTH = . - ITCM_BASE;
+    
+    .ARM.exidx :
+    {
+        * (.ARM.exidx*);
+    } > ITCM
 
+    . = ALIGN (4);
+    
     . = DTCM_BASE;
 
     RW_DATA  :

--- a/tools/sark.lnk
+++ b/tools/sark.lnk
@@ -46,14 +46,18 @@ SECTIONS
 
     . = ALIGN (4);
 
-    RO_LENGTH = . - ITCM_BASE;
-    
-    .ARM.exidx :
+    /*
+      Attempt to deal with .ARM.exdix* sections. Ideally we probably
+      want to throw these away but for now they go into the RO binary
+      See also "objcopy" lines in make file...
+    */     
+
+    EX_DATA :
     {
         * (.ARM.exidx*);
     } > ITCM
 
-    . = ALIGN (4);
+    RO_LENGTH = . - ITCM_BASE;
     
     . = DTCM_BASE;
 

--- a/tools/sark.lnk
+++ b/tools/sark.lnk
@@ -30,6 +30,11 @@ SECTIONS
     APLX_ENTRY = 16;
 
     . = ITCM_BASE;
+    
+    /DISCARD/ :
+    {
+        *(.ARM.exidx*);
+    }
 
     RO_DATA :
     {


### PR DESCRIPTION
Ignore the additional section (.ARM.exidx) that seems to come when using divide.  Note that discarding this section seems to have no effect at all on the ability to divide.