### PR TITLE
Iobuf clearing

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -758,6 +758,19 @@ typedef struct vcpu     // 128 bytes
   uint user3;                   //!< 124 - User word 3
 } vcpu_t;
 
+/*!
+Struct containing information about each iobuf entry in the linked list of
+iobuf entries.
+*/
+
+typedef struct iobuf
+{
+  struct iobuf *next;
+  uint unix_time;
+  uint time_ms;
+  uint ptr;
+  uchar buf[];
+} iobuf_t;
 
 // For "sark_alib.s" (maintain sync with vcpu_t)
 

--- a/include/sark.h
+++ b/include/sark.h
@@ -758,20 +758,6 @@ typedef struct vcpu     // 128 bytes
   uint user3;                   //!< 124 - User word 3
 } vcpu_t;
 
-/*!
-Struct containing information about each iobuf entry in the linked list of
-iobuf entries.
-*/
-
-typedef struct iobuf
-{
-  struct iobuf *next;
-  uint unix_time;
-  uint time_ms;
-  uint ptr;
-  uchar buf[];
-} iobuf_t;
-
 // For "sark_alib.s" (maintain sync with vcpu_t)
 
 #define VCPU_SIZE           128 //!< Size of vcpu_t
@@ -1851,6 +1837,9 @@ to char array
 */
 
 void io_put_char (char *stream, uint c);
+
+//! \brief routine to support clearing of the iobuf for a given core
+void sark_reset_iobuf();
 
 //------------------------------------------------------------------------------
 

--- a/include/sark.h
+++ b/include/sark.h
@@ -758,6 +758,7 @@ typedef struct vcpu     // 128 bytes
   uint user3;                   //!< 124 - User word 3
 } vcpu_t;
 
+
 // For "sark_alib.s" (maintain sync with vcpu_t)
 
 #define VCPU_SIZE           128 //!< Size of vcpu_t
@@ -1838,8 +1839,11 @@ to char array
 
 void io_put_char (char *stream, uint c);
 
-//! \brief routine to support clearing of the iobuf for a given core
-void sark_reset_iobuf();
+/*! Routine to reset the iobuf for the core.
+Frees additional allocated iobuf blocks in the system heap.
+ */
+
+void sark_io_buf_reset (void);
 
 //------------------------------------------------------------------------------
 

--- a/sark/sark_io.c
+++ b/sark/sark_io.c
@@ -94,17 +94,17 @@ static iobuf_t *io_buf_init ()
 
 void sark_io_buf_reset (void)
 {
-    // locate first iobuf block
-    iobuf_t *initial_io_buf = sark.vcpu->iobuf;
+    // rewind to first iobuf block
+    io_buf = sark.vcpu->iobuf;
 
     // pointer to the rest of the block list, to be freed
-    iobuf_t *io_buf_to_free = initial_io_buf->next;
+    iobuf_t *io_buf_to_free = io_buf->next;
 
     // reset pointer to the rest of the block list
-    initial_io_buf->next = NULL;
+    io_buf->next = NULL;
 
     // reset pointers for writing
-    initial_io_buf->ptr = 0;
+    io_buf->ptr = 0;
     buf_ptr = 0;
 
     // if there are other iobuf blocks, cycle and free

--- a/sark/sark_io.c
+++ b/sark/sark_io.c
@@ -22,17 +22,6 @@
 
 //------------------------------------------------------------------------------
 
-
-typedef struct iobuf
-{
-  struct iobuf *next;
-  uint unix_time;
-  uint time_ms;
-  uint ptr;
-  uchar buf[];
-} iobuf_t;
-
-
 static uint sp_ptr;		// Buffer pointer for 'sprintf'
 static uint buf_ptr;		// Buffer pointer for IO_BUF
 


### PR DESCRIPTION
this change supports resetting the cores iobuf. 

its associated with branches in the following modules:
1. FEC
2. SpiNNMachine.
3. Spynnaker
4. Spinnaker tools.

branches to process before this one:
None

tests ran.
- [x] tested with new iobuf tests
- [x] tested wtih pynn examples
- [x] tested with multirun examples
- [x] tested with spalloc interface.
- [x] tested with local board.
deemed this was about enough tests, given the few direct things it effects.

- [x] reviewed by Alan
- [x] reviewed by Rowley
- [x] reviewed by luis.