### PR TITLE
'readlink -e' is not portable; 'pwd -P' *is* portable

### DIFF
--- a/setup
+++ b/setup
@@ -21,7 +21,7 @@ fi
 # used during the building of SpiNNaker applications. The subdirectory
 # "tools" contains locally developed tools for building applications.
 
-SPINN_DIRS="$(readlink -e "$(dirname "${BASH_SOURCE[0]}")")"
+SPINN_DIRS=`cd "$(dirname "${BASH_SOURCE[0]}")";pwd -P`
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Shell scripting is a terrible programming language, and it is very easy to make unportable code using it. This fixes one such spot.