### PR TITLE
Minor bug fixes

### DIFF
--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -754,7 +754,8 @@ void remap_phys_cores(uint phys_cores)
 
     boot_ap();
 
-    sark_word_set(sv_vcpu + num_cpus, 0, sizeof(vcpu_t));
+    sark_word_set(sv_vcpu + num_cpus, 0,
+		  (NUM_CPUS - num_cpus) * sizeof(vcpu_t));
 }
 
 //------------------------------------------------------------------------------
@@ -1370,7 +1371,7 @@ static uint pll_mult(uint freq)
 // Note that system bus is clocked at (cpu_freq * 2 / sys_div)
 // and router at (cpu_freq * 2 / rtr_div)
 //
-// To run CPUs at 150, SDRAM at 130, system bus and router at 100
+// To run CPUs at 200, SDRAM at 130, system bus and router at 133
 //
 void pll_init()
 {

--- a/tools/bmpc
+++ b/tools/bmpc
@@ -1605,7 +1605,7 @@ sub cmd_fstat
 
     eval
     {
-	my $d = $bmp->link_read ($fpga, 0x40000, 32, unpack => "V*");
+	my $d = $bmp->link_read ($fpga, 0x40000, 40, unpack => "V*");
 
 	printf "%-8s %10s\n", "Register", "Global";
 	printf "%-8s %10s\n", "--------", "------";
@@ -1616,6 +1616,9 @@ sub cmd_fstat
 	printf "%-8s 0x%08x\n", "SCRM", $d->[4];
 	printf "%-8s 0x%08x\n", "SLEN", $d->[5];
 	printf "%-8s 0x%08x\n", "LEDO", $d->[6];
+	printf "%-8s 0x%08x\n", "RXEQ", $d->[7];
+	printf "%-8s 0x%08x\n", "TXDS", $d->[8];
+	printf "%-8s 0x%08x\n", "TXPE", $d->[9];
 	printf "\n";
     };
 

--- a/tools/bmpc
+++ b/tools/bmpc
@@ -2002,7 +2002,7 @@ my $bmp_cmds =
 		 'User specified command'],
     reset =>     [\&cmd_reset,
 		 '<mask> [<delay.D>',
-		 'Reset Spinnakers'],
+		 'Reset Spinnakers and FPGAs'],
     ip =>        [\&cmd_ip,
 		 '',
 		 'Display subrack IP addresses'],

--- a/tools/mkaplx
+++ b/tools/mkaplx
@@ -139,7 +139,7 @@ if ($text)
     if ($boot)
     {
 	printf "\t\tdcd\tAPLX_RCOPY, 0x%08x, 0x%08x, 0x%08x\n", # boot_aplx
-          0x7f00, -128, 128;
+          0x7f00, -128 & 0xffffffff, 128;
 	printf "\t\tdcd\tAPLX_RCOPY, 0x%08x, 0x%08x, 0x%08x\n", # def_app
           0x7000, 512-128-16, 3584;
 	printf "\t\tdcd\tAPLX_EXEC,  0x%08x, 0x%08x, 0x%08x\n", # dis. int.

--- a/tools/ybug
+++ b/tools/ybug
@@ -2074,7 +2074,7 @@ my $spin_cmds =
         "Dump heaps"],
     reset =>     [\&cmd_reset,
         "",
-        "Reset Spinnakers via BMP"],
+        "Reset Spinnakers and FPGAs via BMP"],
     power =>     [\&cmd_power,
         "on|off",
         "Switch power on/off via BMP"],

--- a/tools/ybug
+++ b/tools/ybug
@@ -18,6 +18,7 @@ use warnings;
 my $crc32_enabled = 1;
 eval {
     require String::CRC32;
+    String::CRC32->import();
     print "CRC32 Enabled!\n";
     1;
 } or $crc32_enabled = 0;


### PR DESCRIPTION
Minor fixes to scamp-3.c:
- updated a comment to reflect the current CPU and router clock frequencies.
- fixed the state reporting of remapped cores when more that 1 core is taken out.

Minor fix to ybug:
- needed to import the crc32 module when "requiring" it.

Minor fix to mkaplx:
- when using the '-text' option, negative numbers may be printed as 64-bit quantities, which is not appropriate.
There may be a better fix than the one used ('and' with 0xffffffff).
