### PR TITLE
Removed tabs from C code

### DIFF
--- a/apps/heat_demo/heat_demo.c
+++ b/apps/heat_demo/heat_demo.c
@@ -41,9 +41,9 @@
 // ------------------------------------------------------------------------
 // core map choice
 // ------------------------------------------------------------------------
-#define MAP_2x2_on_4       TRUE		// Spin3 board
+#define MAP_2x2_on_4       TRUE         // Spin3 board
 //#define MAP_5x4_on_48      TRUE
-//#define MAP_8x8_on_48      TRUE	// Spin5 board
+//#define MAP_8x8_on_48      TRUE       // Spin5 board
 //#define MAP_12x12_on_144   TRUE
 //#define MAP_24x12_on_288   TRUE
 //#define MAP_24x24_on_576   TRUE
@@ -195,10 +195,10 @@ static volatile int *core_temp;
 #else
 #ifdef USE_SDRAM
 static volatile int * const core_temp =
-	(int *) (SPINN_SDRAM_BASE + 0x1000 + 16 * sizeof(uint));
+        (int *) (SPINN_SDRAM_BASE + 0x1000 + 16 * sizeof(uint));
 #else  //SYSRAM
 static volatile int * const core_temp =
-	(int *) (SPINN_SYSRAM_BASE + (SPINN_SYSRAM_SIZE / 2));
+        (int *) (SPINN_SYSRAM_BASE + (SPINN_SYSRAM_SIZE / 2));
 #endif
 #endif
 
@@ -232,99 +232,99 @@ void routing_table_init(void)
     init_arrived = NONE_ARRIVED;
 
     if (IS_NORTHERNMOST_CORE(coreID)) {
-	if (IS_NORTHERNMOST_CHIP(my_x, my_y)) {
-	    // don't send packets north
-	    // don't expect packets from north
-	    north_key = DONT_ROUTE_KEY;
-	    /* adjust for 16.16 fixed-point representation  */
-	    neighbours_temp[now][NORTH]  = NORTH_INIT;
-	    neighbours_temp[next][NORTH] = NORTH_INIT;
-	    init_arrived |= NORTH_ARRIVED;
-	} else {
-	    // send packets to chip to the north
-	    my_route |= ROUTE_TO_LINK(NORTH_LINK);
-	    // expect packets from chip to the north (southernmost core)
-	    route_from_north = TRUE;
-	    north_key = ROUTING_KEY(CHIP_TO_NORTH(chipID),
-		    SOUTHERNMOST_CORE(coreID));
-	}
+        if (IS_NORTHERNMOST_CHIP(my_x, my_y)) {
+            // don't send packets north
+            // don't expect packets from north
+            north_key = DONT_ROUTE_KEY;
+            /* adjust for 16.16 fixed-point representation  */
+            neighbours_temp[now][NORTH]  = NORTH_INIT;
+            neighbours_temp[next][NORTH] = NORTH_INIT;
+            init_arrived |= NORTH_ARRIVED;
+        } else {
+            // send packets to chip to the north
+            my_route |= ROUTE_TO_LINK(NORTH_LINK);
+            // expect packets from chip to the north (southernmost core)
+            route_from_north = TRUE;
+            north_key = ROUTING_KEY(CHIP_TO_NORTH(chipID),
+                    SOUTHERNMOST_CORE(coreID));
+        }
     } else {
-	// expect packets from north
-	north_key = ROUTING_KEY(chipID, CORE_TO_NORTH(coreID));
-	// send to north core
-	my_route |= ROUTE_TO_CORE(CORE_TO_NORTH(coreID));
+        // expect packets from north
+        north_key = ROUTING_KEY(chipID, CORE_TO_NORTH(coreID));
+        // send to north core
+        my_route |= ROUTE_TO_CORE(CORE_TO_NORTH(coreID));
     }
 
     if (IS_SOUTHERNMOST_CORE(coreID)) {
-	if (IS_SOUTHERNMOST_CHIP(my_x, my_y)) {
-	    // don't send packets south
-	    // don't expect packets from south
-	    south_key = DONT_ROUTE_KEY;
-	    /* adjust for 16.16 fixed-point representation  */
-	    neighbours_temp[now][SOUTH]  = SOUTH_INIT;
-	    neighbours_temp[next][SOUTH] = SOUTH_INIT;
-	    init_arrived |= SOUTH_ARRIVED;
-	} else {
-	    // send packets to chip to the south
-	    my_route |= ROUTE_TO_LINK(SOUTH_LINK);
-	    // expect packets from chip to the south (northernmost core)
-	    route_from_south = TRUE;
-	    south_key = ROUTING_KEY(CHIP_TO_SOUTH(chipID),
-		    NORTHERNMOST_CORE(coreID));
-	}
+        if (IS_SOUTHERNMOST_CHIP(my_x, my_y)) {
+            // don't send packets south
+            // don't expect packets from south
+            south_key = DONT_ROUTE_KEY;
+            /* adjust for 16.16 fixed-point representation  */
+            neighbours_temp[now][SOUTH]  = SOUTH_INIT;
+            neighbours_temp[next][SOUTH] = SOUTH_INIT;
+            init_arrived |= SOUTH_ARRIVED;
+        } else {
+            // send packets to chip to the south
+            my_route |= ROUTE_TO_LINK(SOUTH_LINK);
+            // expect packets from chip to the south (northernmost core)
+            route_from_south = TRUE;
+            south_key = ROUTING_KEY(CHIP_TO_SOUTH(chipID),
+                    NORTHERNMOST_CORE(coreID));
+        }
     } else {
-	// expect packets from south
-	south_key = ROUTING_KEY(chipID, CORE_TO_SOUTH(coreID));
-	// send to south core
-	my_route |= ROUTE_TO_CORE(CORE_TO_SOUTH(coreID));
+        // expect packets from south
+        south_key = ROUTING_KEY(chipID, CORE_TO_SOUTH(coreID));
+        // send to south core
+        my_route |= ROUTE_TO_CORE(CORE_TO_SOUTH(coreID));
     }
 
     if (IS_EASTERNMOST_CORE(coreID)) {
-	if (IS_EASTERNMOST_CHIP(my_x, my_y)) {
-	    // don't send packets east
-	    // don't expect packets from east
-	    east_key = DONT_ROUTE_KEY;
-	    /* adjust for 16.16 fixed-point representation  */
-	    neighbours_temp[now][EAST]  = EAST_INIT;
-	    neighbours_temp[next][EAST] = EAST_INIT;
-	    init_arrived |= EAST_ARRIVED;
-	} else {
-	    // send packets to chip to the east
-	    my_route |= ROUTE_TO_LINK(EAST_LINK);
-	    // expect packets from chip to the east (westernmost core)
-	    route_from_east = TRUE;
-	    east_key = ROUTING_KEY(CHIP_TO_EAST(chipID),
-		    WESTERNMOST_CORE(coreID));
-	}
+        if (IS_EASTERNMOST_CHIP(my_x, my_y)) {
+            // don't send packets east
+            // don't expect packets from east
+            east_key = DONT_ROUTE_KEY;
+            /* adjust for 16.16 fixed-point representation  */
+            neighbours_temp[now][EAST]  = EAST_INIT;
+            neighbours_temp[next][EAST] = EAST_INIT;
+            init_arrived |= EAST_ARRIVED;
+        } else {
+            // send packets to chip to the east
+            my_route |= ROUTE_TO_LINK(EAST_LINK);
+            // expect packets from chip to the east (westernmost core)
+            route_from_east = TRUE;
+            east_key = ROUTING_KEY(CHIP_TO_EAST(chipID),
+                    WESTERNMOST_CORE(coreID));
+        }
     } else {
-	// send to east core
-	my_route |= ROUTE_TO_CORE(CORE_TO_EAST(coreID));
-	// expect packets from east
-	east_key = ROUTING_KEY(chipID, CORE_TO_EAST(coreID));
+        // send to east core
+        my_route |= ROUTE_TO_CORE(CORE_TO_EAST(coreID));
+        // expect packets from east
+        east_key = ROUTING_KEY(chipID, CORE_TO_EAST(coreID));
     }
 
     if (IS_WESTERNMOST_CORE(coreID)) {
-	if (IS_WESTERNMOST_CHIP(my_x, my_y)) {
-	    // don't send packets west
-	    // don't expect packets from west
-	    west_key = DONT_ROUTE_KEY;
-	    /* adjust for 16.16 fixed-point representation  */
-	    neighbours_temp[now][WEST]  = WEST_INIT;
-	    neighbours_temp[next][WEST] = WEST_INIT;
-	    init_arrived |= WEST_ARRIVED;
-	} else {
-	    // send packets to chip to the west
-	    my_route |= ROUTE_TO_LINK(WEST_LINK);
-	    // expect packets from chip to the west (easternmost core)
-	    route_from_west = TRUE;
-	    west_key = ROUTING_KEY(CHIP_TO_WEST(chipID),
-		    EASTERNMOST_CORE(coreID));
-	}
+        if (IS_WESTERNMOST_CHIP(my_x, my_y)) {
+            // don't send packets west
+            // don't expect packets from west
+            west_key = DONT_ROUTE_KEY;
+            /* adjust for 16.16 fixed-point representation  */
+            neighbours_temp[now][WEST]  = WEST_INIT;
+            neighbours_temp[next][WEST] = WEST_INIT;
+            init_arrived |= WEST_ARRIVED;
+        } else {
+            // send packets to chip to the west
+            my_route |= ROUTE_TO_LINK(WEST_LINK);
+            // expect packets from chip to the west (easternmost core)
+            route_from_west = TRUE;
+            west_key = ROUTING_KEY(CHIP_TO_WEST(chipID),
+                    EASTERNMOST_CORE(coreID));
+        }
     } else {
-	// expect packets from west
-	west_key = ROUTING_KEY(chipID, CORE_TO_WEST(coreID));
-	// send to west core
-	my_route |= ROUTE_TO_CORE(CORE_TO_WEST(coreID));
+        // expect packets from west
+        west_key = ROUTING_KEY(chipID, CORE_TO_WEST(coreID));
+        // send to west core
+        my_route |= ROUTE_TO_CORE(CORE_TO_WEST(coreID));
     }
 
     /* prepare for first update */
@@ -338,47 +338,47 @@ void routing_table_init(void)
     /* set a MC routing table entry to send my packets to my neighbours */
     /* entries depend on coreID to avoid inter-core interference        */
 
-    uint e = rtr_alloc(5);		// Get 5 router entries
+    uint e = rtr_alloc(5);              // Get 5 router entries
     if (e == 0) {
-	rt_error(RTE_ABORT);
+        rt_error(RTE_ABORT);
     }
 
-    rtr_mc_set(e, 			// entry
-	    my_key,       	      	// key
-	    0xffffffff,	         	// mask
-	    my_route);            	// route
+    rtr_mc_set(e,                       // entry
+            my_key,                     // key
+            0xffffffff,                 // mask
+            my_route);                  // route
 
     /* set MC routing table entries to get packets from neighbour chips */
     /* north */
     if (route_from_north) {
-	rtr_mc_set(e + 1,     		// entry
-		north_key,            	// key
-		0xffffffff,           	// mask
-		ROUTE_TO_CORE(coreID));	// route
+        rtr_mc_set(e + 1,               // entry
+                north_key,              // key
+                0xffffffff,             // mask
+                ROUTE_TO_CORE(coreID)); // route
     }
 
     /* south */
     if (route_from_south) {
-	rtr_mc_set(e + 2,     		// entry
-		south_key,            	// key
-		0xffffffff,           	// mask
-		ROUTE_TO_CORE(coreID));	// route
+        rtr_mc_set(e + 2,               // entry
+                south_key,              // key
+                0xffffffff,             // mask
+                ROUTE_TO_CORE(coreID)); // route
     }
 
     /* east */
     if (route_from_east) {
-	rtr_mc_set(e + 3,     		// entry
-		east_key,             	// key
-		0xffffffff,           	// mask
-		ROUTE_TO_CORE(coreID));	// route
+        rtr_mc_set(e + 3,               // entry
+                east_key,               // key
+                0xffffffff,             // mask
+                ROUTE_TO_CORE(coreID)); // route
     }
 
     /* west */
     if (route_from_west) {
-	rtr_mc_set(e + 4,     		// entry
-		west_key,             	// key
-		0xffffffff,           	// mask
-		ROUTE_TO_CORE(coreID));	// route
+        rtr_mc_set(e + 4,               // entry
+                west_key,               // key
+                0xffffffff,             // mask
+                ROUTE_TO_CORE(coreID)); // route
     }
 
     /* ------------------------------------------------------------------- */
@@ -386,109 +386,109 @@ void routing_table_init(void)
     /* ------------------------------------------------------------------- */
     /* avoid duplication                                                   */
     if (leadAp) {
-	// setup routing entries for synchronization barrier
-	// setup the local (on-chip) routes
-	uint loc_route = core_map[my_x][my_y] & 0xfffffffe;
+        // setup routing entries for synchronization barrier
+        // setup the local (on-chip) routes
+        uint loc_route = core_map[my_x][my_y] & 0xfffffffe;
 
-	// TODO: needs fixing -- fault-tolerant tree
-	// setup off-chip routes -- check for borders!
-	uint off_route = 0;
+        // TODO: needs fixing -- fault-tolerant tree
+        // setup off-chip routes -- check for borders!
+        uint off_route = 0;
 
-	// north
-	if ((my_x == 0) && (my_y < (NUMBER_OF_YCHIPS - 1)) &&
-		((core_map[my_x][my_y + 1] & 0xfffffffe) != 0)) {
-	    off_route |= ROUTE_TO_LINK(NORTH_LINK);
-	}
+        // north
+        if ((my_x == 0) && (my_y < (NUMBER_OF_YCHIPS - 1)) &&
+                ((core_map[my_x][my_y + 1] & 0xfffffffe) != 0)) {
+            off_route |= ROUTE_TO_LINK(NORTH_LINK);
+        }
 
-	// east
-	if ((my_x < (NUMBER_OF_XCHIPS - 1)) && (my_y == 0) &&
-		((core_map[my_x + 1][my_y] & 0xfffffffe) != 0)) {
-	    off_route |= ROUTE_TO_LINK(EAST_LINK);
-	}
+        // east
+        if ((my_x < (NUMBER_OF_XCHIPS - 1)) && (my_y == 0) &&
+                ((core_map[my_x + 1][my_y] & 0xfffffffe) != 0)) {
+            off_route |= ROUTE_TO_LINK(EAST_LINK);
+        }
 
-	// north-east
-	if ((my_y < (NUMBER_OF_YCHIPS - 1)) &&
-		(my_x < (NUMBER_OF_XCHIPS - 1)) &&
-		((core_map[my_x + 1][my_y + 1] & 0xfffffffe) != 0)) {
-	    off_route |= ROUTE_TO_LINK(NORTH_EAST_LINK);
-	}
+        // north-east
+        if ((my_y < (NUMBER_OF_YCHIPS - 1)) &&
+                (my_x < (NUMBER_OF_XCHIPS - 1)) &&
+                ((core_map[my_x + 1][my_y + 1] & 0xfffffffe) != 0)) {
+            off_route |= ROUTE_TO_LINK(NORTH_EAST_LINK);
+        }
 
-	uint e = rtr_alloc(5);
-	if (e == 0) {
-	    rt_error(RTE_ABORT);
-	}
+        uint e = rtr_alloc(5);
+        if (e == 0) {
+            rt_error(RTE_ABORT);
+        }
 
-	// command entry (matches any command -- not just STOP!)
-	rtr_mc_set(e,				// entry
-		STOP_KEY,			// key
-		CMD_MASK,			// mask
-		(loc_route << 6) | off_route);	// route
+        // command entry (matches any command -- not just STOP!)
+        rtr_mc_set(e,                           // entry
+                STOP_KEY,                       // key
+                CMD_MASK,                       // mask
+                (loc_route << 6) | off_route);  // route
 
-	// northern border temperature
-	if (IS_NORTHERNMOST_CHIP(my_x, my_y)) {
-	    // send only to local northern-most cores
-	    rtr_mc_set(e+1,			// entry
-		    TEMP_NORTH_KEY,		// key
-		    0xffffffff,			// mask
-		    (loc_route & 0x11110) << 6 | off_route); // route
-	} else {
-	    // send only to other chips
-	    rtr_mc_set(e+1,			// entry
-		    TEMP_NORTH_KEY,		// key
-		    0xffffffff,			// mask
-		    off_route);			// route
-	}
+        // northern border temperature
+        if (IS_NORTHERNMOST_CHIP(my_x, my_y)) {
+            // send only to local northern-most cores
+            rtr_mc_set(e+1,                     // entry
+                    TEMP_NORTH_KEY,             // key
+                    0xffffffff,                 // mask
+                    (loc_route & 0x11110) << 6 | off_route); // route
+        } else {
+            // send only to other chips
+            rtr_mc_set(e+1,                     // entry
+                    TEMP_NORTH_KEY,             // key
+                    0xffffffff,                 // mask
+                    off_route);                 // route
+        }
 
-	// eastern border temperature
-	if (IS_EASTERNMOST_CHIP(my_x, my_y)) {
-	    // send only to local eastern-most cores
-	    rtr_mc_set(e+2,			// entry
-		    TEMP_EAST_KEY,		// key
-		    0xffffffff,			// mask
-		    (loc_route & 0x1e000) << 6 | off_route); // route
-	} else {
-	    // send only to other chips
-	    rtr_mc_set(e+2,			// entry
-		    TEMP_EAST_KEY,		// key
-		    0xffffffff,			// mask
-		    off_route);			// route
-	}
+        // eastern border temperature
+        if (IS_EASTERNMOST_CHIP(my_x, my_y)) {
+            // send only to local eastern-most cores
+            rtr_mc_set(e+2,                     // entry
+                    TEMP_EAST_KEY,              // key
+                    0xffffffff,                 // mask
+                    (loc_route & 0x1e000) << 6 | off_route); // route
+        } else {
+            // send only to other chips
+            rtr_mc_set(e+2,                     // entry
+                    TEMP_EAST_KEY,              // key
+                    0xffffffff,                 // mask
+                    off_route);                 // route
+        }
 
-	// southern border temperature
-	// NOTE: currently temperatures never travel south!
-	if (IS_SOUTHERNMOST_CHIP(my_x, my_y)) {
-	    // send only to local southern-most cores
-	    rtr_mc_set(e+3,			// entry
-		    TEMP_SOUTH_KEY,		// key
-		    0xffffffff,			// mask
-		    (loc_route & 0x02222) << 6 | off_route); // route
-	} else {
-	    // send only to other chips
-	    rtr_mc_set(e+3,			// entry
-		    TEMP_SOUTH_KEY,		// key
-		    0xffffffff,			// mask
-		    off_route);			// route
-	}
+        // southern border temperature
+        // NOTE: currently temperatures never travel south!
+        if (IS_SOUTHERNMOST_CHIP(my_x, my_y)) {
+            // send only to local southern-most cores
+            rtr_mc_set(e+3,                     // entry
+                    TEMP_SOUTH_KEY,             // key
+                    0xffffffff,                 // mask
+                    (loc_route & 0x02222) << 6 | off_route); // route
+        } else {
+            // send only to other chips
+            rtr_mc_set(e+3,                     // entry
+                    TEMP_SOUTH_KEY,             // key
+                    0xffffffff,                 // mask
+                    off_route);                 // route
+        }
 
-	// western border temperature
-	// NOTE: currently temperatures never travel west!
-	if (IS_WESTERNMOST_CHIP(my_x, my_y)) {
-	    // send only to local western-most cores
-	    rtr_mc_set(e+4,			// entry
-		    TEMP_WEST_KEY,		// key
-		    0xffffffff,			// mask
-		    (loc_route & 0x0001e) << 6 | off_route); // route
-	} else {
-	    // send only to other chips
-	    rtr_mc_set(e+4,			// entry
-		    TEMP_WEST_KEY,		// key
-		    0xffffffff,			// mask
-		    off_route);			// route
-	}
+        // western border temperature
+        // NOTE: currently temperatures never travel west!
+        if (IS_WESTERNMOST_CHIP(my_x, my_y)) {
+            // send only to local western-most cores
+            rtr_mc_set(e+4,                     // entry
+                    TEMP_WEST_KEY,              // key
+                    0xffffffff,                 // mask
+                    (loc_route & 0x0001e) << 6 | off_route); // route
+        } else {
+            // send only to other chips
+            rtr_mc_set(e+4,                     // entry
+                    TEMP_WEST_KEY,              // key
+                    0xffffffff,                 // mask
+                    off_route);                 // route
+        }
 
-	// configure router to use emergency routing
-	rtr_conf = rtr[RTR_CONTROL];  // save for later
-	rtr[RTR_CONTROL] = (rtr_conf & 0x0000ffff) | 0x31310000;
+        // configure router to use emergency routing
+        rtr_conf = rtr[RTR_CONTROL];  // save for later
+        rtr[RTR_CONTROL] = (rtr_conf & 0x0000ffff) | 0x31310000;
     }
 }
 /*
@@ -564,11 +564,11 @@ void report_temp(uint ticks)
     // send results to host
     // only the lead application core does this
     if (leadAp) {
-	// spread out the reporting to avoid SDP packet drop
-	//##    if ((ticks % (NUMBER_OF_XCHIPS * NUMBER_OF_YCHIPS)) == my_chip)
-	if ((ticks % 64) == board_loc) {
-	    send_temps_to_host();
-	}
+        // spread out the reporting to avoid SDP packet drop
+        //##    if ((ticks % (NUMBER_OF_XCHIPS * NUMBER_OF_YCHIPS)) == my_chip)
+        if ((ticks % 64) == board_loc) {
+            send_temps_to_host();
+        }
     }
 }
 /*
@@ -623,74 +623,74 @@ void receive_data(uint key, uint payload)
 #ifdef DEBUG
     dbg_keys_recv[dbg_packs_recv++] = key;
     if (dbg_packs_recv == DEBUG_KEYS) {
-	dbg_packs_recv = 0;
+        dbg_packs_recv = 0;
     }
 #endif
 
     if (key == north_key) {
-	if (arrived[now] & NORTH_ARRIVED) {
-	    neighbours_temp[next][NORTH] = payload;
-	    arrived[next] |= NORTH_ARRIVED;
-	} else {
-	    neighbours_temp[now][NORTH] = payload;
-	    arrived[now] |= NORTH_ARRIVED;
-	}
+        if (arrived[now] & NORTH_ARRIVED) {
+            neighbours_temp[next][NORTH] = payload;
+            arrived[next] |= NORTH_ARRIVED;
+        } else {
+            neighbours_temp[now][NORTH] = payload;
+            arrived[now] |= NORTH_ARRIVED;
+        }
     } else if (key == south_key) {
-	if (arrived[now] & SOUTH_ARRIVED) {
-	    neighbours_temp[next][SOUTH] = payload;
-	    arrived[next] |= SOUTH_ARRIVED;
-	} else {
-	    neighbours_temp[now][SOUTH] = payload;
-	    arrived[now] |= SOUTH_ARRIVED;
-	}
+        if (arrived[now] & SOUTH_ARRIVED) {
+            neighbours_temp[next][SOUTH] = payload;
+            arrived[next] |= SOUTH_ARRIVED;
+        } else {
+            neighbours_temp[now][SOUTH] = payload;
+            arrived[now] |= SOUTH_ARRIVED;
+        }
     } else if (key == east_key) {
-	if (arrived[now] & EAST_ARRIVED) {
-	    neighbours_temp[next][EAST] = payload;
-	    arrived[next] |= EAST_ARRIVED;
-	} else {
-	    neighbours_temp[now][EAST] = payload;
-	    arrived[now] |= EAST_ARRIVED;
-	}
+        if (arrived[now] & EAST_ARRIVED) {
+            neighbours_temp[next][EAST] = payload;
+            arrived[next] |= EAST_ARRIVED;
+        } else {
+            neighbours_temp[now][EAST] = payload;
+            arrived[now] |= EAST_ARRIVED;
+        }
     } else if (key == west_key) {
-	if (arrived[now] & WEST_ARRIVED) {
-	    neighbours_temp[next][WEST] = payload;
-	    arrived[next] |= WEST_ARRIVED;
-	} else {
-	    neighbours_temp[now][WEST] = payload;
-	    arrived[now] |= WEST_ARRIVED;
-	}
+        if (arrived[now] & WEST_ARRIVED) {
+            neighbours_temp[next][WEST] = payload;
+            arrived[next] |= WEST_ARRIVED;
+        } else {
+            neighbours_temp[now][WEST] = payload;
+            arrived[now] |= WEST_ARRIVED;
+        }
     } else if (key == TEMP_NORTH_KEY) {
-	if (IS_NORTHERNMOST_CHIP(my_x, my_y) &&
-		IS_NORTHERNMOST_CORE(coreID)) {
-	    neighbours_temp[now][NORTH]  = payload;
-	    neighbours_temp[next][NORTH] = payload;
+        if (IS_NORTHERNMOST_CHIP(my_x, my_y) &&
+                IS_NORTHERNMOST_CORE(coreID)) {
+            neighbours_temp[now][NORTH]  = payload;
+            neighbours_temp[next][NORTH] = payload;
         }
     } else if (key == TEMP_EAST_KEY) {
-	if (IS_EASTERNMOST_CHIP(my_x, my_y) && IS_EASTERNMOST_CORE(coreID)) {
-	    neighbours_temp[now][EAST]  = payload;
-	    neighbours_temp[next][EAST] = payload;
-	}
+        if (IS_EASTERNMOST_CHIP(my_x, my_y) && IS_EASTERNMOST_CORE(coreID)) {
+            neighbours_temp[now][EAST]  = payload;
+            neighbours_temp[next][EAST] = payload;
+        }
     } else if (key == TEMP_SOUTH_KEY) {
-	if (IS_SOUTHERNMOST_CHIP(my_x, my_y) &&
-		IS_SOUTHERNMOST_CORE(coreID)) {
-	    neighbours_temp[now][SOUTH]  = payload;
-	    neighbours_temp[next][SOUTH] = payload;
-	}
+        if (IS_SOUTHERNMOST_CHIP(my_x, my_y) &&
+                IS_SOUTHERNMOST_CORE(coreID)) {
+            neighbours_temp[now][SOUTH]  = payload;
+            neighbours_temp[next][SOUTH] = payload;
+        }
     } else if (key == TEMP_WEST_KEY) {
-	if (IS_WESTERNMOST_CHIP(my_x, my_y) && IS_WESTERNMOST_CORE(coreID)) {
-	    neighbours_temp[now][WEST]  = payload;
-	    neighbours_temp[next][WEST] = payload;
-	}
+        if (IS_WESTERNMOST_CHIP(my_x, my_y) && IS_WESTERNMOST_CORE(coreID)) {
+            neighbours_temp[now][WEST]  = payload;
+            neighbours_temp[next][WEST] = payload;
+        }
     } else if (key == STOP_KEY) {
-	spin1_exit(0);
+        spin1_exit(0);
     } else if (key == PAUSE_KEY) {
-	updating = FALSE;
+        updating = FALSE;
     } else if (key == RESUME_KEY) {
-	updating = TRUE;
+        updating = TRUE;
     } else {
-	// unexpected packet!
+        // unexpected packet!
 #ifdef DEBUG
-	io_printf(IO_STD, "!\n");
+        io_printf(IO_STD, "!\n");
 #endif
     }
 }
@@ -730,60 +730,60 @@ void update(uint ticks, uint b)
     sark.vcpu->user0++;
 
     if (updating) {
-	/* report if not all neighbours' data arrived */
+        /* report if not all neighbours' data arrived */
 #ifdef DEBUG
-	if (arrived[now] != ALL_ARRIVED) {
-	    io_printf(IO_STD, "@\n");
-	    dbg_timeouts++;
+        if (arrived[now] != ALL_ARRIVED) {
+            io_printf(IO_STD, "@\n");
+            dbg_timeouts++;
         }
 #endif
 
-	// if a core does not receive temperature from a neighbour
-	// it uses it's own as an estimate for the neighbour's.
-	if (arrived[now] != ALL_ARRIVED) {
-	    if (!(arrived[now] & NORTH_ARRIVED)) {
-		neighbours_temp[now][NORTH] = my_temp;
-	    }
+        // if a core does not receive temperature from a neighbour
+        // it uses it's own as an estimate for the neighbour's.
+        if (arrived[now] != ALL_ARRIVED) {
+            if (!(arrived[now] & NORTH_ARRIVED)) {
+                neighbours_temp[now][NORTH] = my_temp;
+            }
 
-	    if (!(arrived[now] & SOUTH_ARRIVED)) {
-		neighbours_temp[now][SOUTH] = my_temp;
-	    }
+            if (!(arrived[now] & SOUTH_ARRIVED)) {
+                neighbours_temp[now][SOUTH] = my_temp;
+            }
 
-	    if (!(arrived[now] & EAST_ARRIVED)) {
-		neighbours_temp[now][EAST] = my_temp;
-	    }
+            if (!(arrived[now] & EAST_ARRIVED)) {
+                neighbours_temp[now][EAST] = my_temp;
+            }
 
-	    if (!(arrived[now] & WEST_ARRIVED)) {
-		neighbours_temp[now][WEST] = my_temp;
-	    }
-	}
+            if (!(arrived[now] & WEST_ARRIVED)) {
+                neighbours_temp[now][WEST] = my_temp;
+            }
+        }
 
-	/* compute new temperature */
-	/* adjust for 16.16 fixed-point representation  */
-	int tmp1 = neighbours_temp[now][EAST] + neighbours_temp[now][WEST]
-		- 2 * my_temp;
-	int tmp2 = neighbours_temp[now][NORTH] + neighbours_temp[now][SOUTH]
-		- 2 * my_temp;
-	/* adjust for 16.16 fixed-point representation  */
-	int tmp3 = (int) (((long long) cx_adj * (long long) tmp1) >> 16);
-	int tmp4 = (int) (((long long) cy_adj * (long long) tmp2) >> 16);
-	my_temp = my_temp + tmp3 + tmp4;
+        /* compute new temperature */
+        /* adjust for 16.16 fixed-point representation  */
+        int tmp1 = neighbours_temp[now][EAST] + neighbours_temp[now][WEST]
+                - 2 * my_temp;
+        int tmp2 = neighbours_temp[now][NORTH] + neighbours_temp[now][SOUTH]
+                - 2 * my_temp;
+        /* adjust for 16.16 fixed-point representation  */
+        int tmp3 = (int) (((long long) cx_adj * (long long) tmp1) >> 16);
+        int tmp4 = (int) (((long long) cy_adj * (long long) tmp2) >> 16);
+        my_temp = my_temp + tmp3 + tmp4;
 
 #ifdef POSITIVE_TEMP
-	// avoids a problem with negative temps in the visualiser!
-	my_temp = (my_temp > 0) ? my_temp : 0;
+        // avoids a problem with negative temps in the visualiser!
+        my_temp = (my_temp > 0) ? my_temp : 0;
 #endif
 
-	/* send new data to neighbours */
-	spin1_send_mc_packet(my_key, my_temp, WITH_PAYLOAD);
+        /* send new data to neighbours */
+        spin1_send_mc_packet(my_key, my_temp, WITH_PAYLOAD);
 
-	/* prepare for next iteration */
-	arrived[now] = init_arrived;
-	now  = 1 - now;
-	next = 1 - next;
+        /* prepare for next iteration */
+        arrived[now] = init_arrived;
+        now  = 1 - now;
+        next = 1 - next;
 
-	/* report current temp */
-	report_temp(ticks);
+        /* report current temp */
+        report_temp(ticks);
     }
 }
 /*
@@ -811,39 +811,39 @@ void host_data(uint mailbox, uint port)
 #ifdef DEBUG
     io_printf(IO_STD, "cmd: %d\n", msg->cmd_rc);
     if (msg->cmd_rc == 1) {
-	io_printf(IO_STD, "N: %7.3f\n", data[0]);
-	io_printf(IO_STD, "E: %7.3f\n", data[1]);
-	io_printf(IO_STD, "S: %7.3f\n", data[2]);
-	io_printf(IO_STD, "W: %7.3f\n", data[3]);
+        io_printf(IO_STD, "N: %7.3f\n", data[0]);
+        io_printf(IO_STD, "E: %7.3f\n", data[1]);
+        io_printf(IO_STD, "S: %7.3f\n", data[2]);
+        io_printf(IO_STD, "W: %7.3f\n", data[3]);
     }
 #endif
 
     switch (msg->cmd_rc) {
     case 0: // stop
-	spin1_send_mc_packet(STOP_KEY, 0, NO_PAYLOAD);
-	break;
+        spin1_send_mc_packet(STOP_KEY, 0, NO_PAYLOAD);
+        break;
 
     case 1: // new border temperatures
-	spin1_send_mc_packet(TEMP_NORTH_KEY, data[0], WITH_PAYLOAD);
-	spin1_send_mc_packet(TEMP_EAST_KEY,  data[1], WITH_PAYLOAD);
-	spin1_send_mc_packet(TEMP_SOUTH_KEY, data[2], WITH_PAYLOAD);
-	spin1_send_mc_packet(TEMP_WEST_KEY,  data[3], WITH_PAYLOAD);
-	break;
+        spin1_send_mc_packet(TEMP_NORTH_KEY, data[0], WITH_PAYLOAD);
+        spin1_send_mc_packet(TEMP_EAST_KEY,  data[1], WITH_PAYLOAD);
+        spin1_send_mc_packet(TEMP_SOUTH_KEY, data[2], WITH_PAYLOAD);
+        spin1_send_mc_packet(TEMP_WEST_KEY,  data[3], WITH_PAYLOAD);
+        break;
 
     case 2: // pause
-	spin1_send_mc_packet(PAUSE_KEY, 0, NO_PAYLOAD);
-	break;
+        spin1_send_mc_packet(PAUSE_KEY, 0, NO_PAYLOAD);
+        break;
 
     case 3: // resume
-	spin1_send_mc_packet(RESUME_KEY, 0, NO_PAYLOAD);
-	break;
+        spin1_send_mc_packet(RESUME_KEY, 0, NO_PAYLOAD);
+        break;
 
     default:
-	// unexpected packet!
+        // unexpected packet!
 #ifdef DEBUG
-	io_printf(IO_STD, "!SDP\n");
+        io_printf(IO_STD, "!SDP\n");
 #endif
-	break;
+        break;
     }
 
     spin1_msg_free(msg);
@@ -883,55 +883,55 @@ void c_main(void)
 
     // operate only if in core map!
     if ((my_x < NUMBER_OF_XCHIPS) && (my_y < NUMBER_OF_YCHIPS)
-	    && ((core_map[my_x][my_y] & (1 << coreID)) != 0)) {
-	// set the core map for the simulation
-	//##    spin1_application_core_map(NUMBER_OF_XCHIPS, NUMBER_OF_YCHIPS, core_map);
+            && ((core_map[my_x][my_y] & (1 << coreID)) != 0)) {
+        // set the core map for the simulation
+        //##    spin1_application_core_map(NUMBER_OF_XCHIPS, NUMBER_OF_YCHIPS, core_map);
 
-	// set timer tick value to 1ms (in microseconds)
-	// slow down simulation to alow users to appreciate changes
-	spin1_set_timer_tick(TIMER_TICK_PERIOD);
+        // set timer tick value to 1ms (in microseconds)
+        // slow down simulation to alow users to appreciate changes
+        spin1_set_timer_tick(TIMER_TICK_PERIOD);
 
-	// register callbacks
-	spin1_callback_on(MCPL_PACKET_RECEIVED, receive_data, 0);
-	spin1_callback_on(TIMER_TICK, update, 0);
-	spin1_callback_on(SDP_PACKET_RX, host_data, 0);
+        // register callbacks
+        spin1_callback_on(MCPL_PACKET_RECEIVED, receive_data, 0);
+        spin1_callback_on(TIMER_TICK, update, 0);
+        spin1_callback_on(SDP_PACKET_RX, host_data, 0);
 
-	// initialise routing tables
-	routing_table_init();
+        // initialise routing tables
+        routing_table_init();
 
-	// initialise SDP message buffer
-	sdp_init();
+        // initialise SDP message buffer
+        sdp_init();
 
-	// initialise temperatures (for absent cores!)
+        // initialise temperatures (for absent cores!)
 
-	core_temp = (volatile int *) sv->sysram_base; //##
+        core_temp = (volatile int *) sv->sysram_base; //##
 
-	if (leadAp) {
-	    for (uint i = 1; i <= 16; i++) {
-		core_temp[i - 1] = 0;
-	    }
-	}
+        if (leadAp) {
+            for (uint i = 1; i <= 16; i++) {
+                core_temp[i - 1] = 0;
+            }
+        }
 
 #ifdef DEBUG
-	// initialise variables
-	dbg_keys_recv = spin1_malloc(DEBUG_KEYS * 4 * sizeof(uint));
-	// record start time somewhere in SDRAM
-	dbg_stime = (uint *) (SPINN_SDRAM_BASE + 4 * coreID);
-	*dbg_stime = sv->clock_ms;
+        // initialise variables
+        dbg_keys_recv = spin1_malloc(DEBUG_KEYS * 4 * sizeof(uint));
+        // record start time somewhere in SDRAM
+        dbg_stime = (uint *) (SPINN_SDRAM_BASE + 4 * coreID);
+        *dbg_stime = sv->clock_ms;
 #endif
 
-	// kick-start the update process
-	spin1_schedule_callback(send_first_value, 0, 0, 3);
+        // kick-start the update process
+        spin1_schedule_callback(send_first_value, 0, 0, 3);
 
-	// go
-	spin1_start(SYNC_WAIT);		//##
+        // go
+        spin1_start(SYNC_WAIT);         //##
 
-	// restore router configuration
-	rtr[RTR_CONTROL] = rtr_conf;
+        // restore router configuration
+        rtr[RTR_CONTROL] = rtr_conf;
 
 #ifdef VERBOSE
-	// report results
-	report_results();
+        // report results
+        report_results();
 #endif
     }
 

--- a/apps/interrupt/interrupt.c
+++ b/apps/interrupt/interrupt.c
@@ -20,13 +20,13 @@ uint ticks;
 
 INT_HANDLER timer_int_han(void)
 {
-    tc[T1_INT_CLR] = (uint) tc;			// Clear interrupt in timer
+    tc[T1_INT_CLR] = (uint) tc;                 // Clear interrupt in timer
 
-    sark_led_set(LED_FLIP(1));			// Flip a LED
+    sark_led_set(LED_FLIP(1));                  // Flip a LED
 
-    io_printf(IO_BUF, "Tick %d\n", ++ticks);	// Write message to buffer
+    io_printf(IO_BUF, "Tick %d\n", ++ticks);    // Write message to buffer
 
-    vic[VIC_VADDR] = (uint) vic;		// Tell VIC we're done
+    vic[VIC_VADDR] = (uint) vic;                // Tell VIC we're done
 }
 
 
@@ -37,10 +37,10 @@ INT_HANDLER timer_int_han(void)
 
 void timer_setup(uint period)
 {
-    tc[T1_CONTROL] = 0xe2;			// Set up count-down mode
-    tc[T1_LOAD] = sark.cpu_clk * period;	// Load time in microsecs
+    tc[T1_CONTROL] = 0xe2;                      // Set up count-down mode
+    tc[T1_LOAD] = sark.cpu_clk * period;        // Load time in microsecs
 
-    sark_vic_set(SLOT_0, TIMER1_INT, 1, timer_int_han);	// Set VIC slot 0
+    sark_vic_set(SLOT_0, TIMER1_INT, 1, timer_int_han); // Set VIC slot 0
 }
 
 
@@ -49,9 +49,9 @@ void timer_setup(uint period)
 
 void c_main(void)
 {
-    io_printf(IO_STD, "Timer interrupt example\n");	// Say hello
+    io_printf(IO_STD, "Timer interrupt example\n");     // Say hello
 
-    timer_setup(500000);		// This is 500,000 us (0.5 secs)
+    timer_setup(500000);                // This is 500,000 us (0.5 secs)
 
-    cpu_sleep();			// Send core to sleep
+    cpu_sleep();                        // Send core to sleep
 }

--- a/apps/life/life.c
+++ b/apps/life/life.c
@@ -30,80 +30,80 @@
 
 #include <spin1_api.h>
 
-#define XMAX 2					// chip array width in chips
-#define YMAX 2					// chip array height in chips
-#define TOROID FALSE				// chip array = toroid?
+#define XMAX 2                                  // chip array width in chips
+#define YMAX 2                                  // chip array height in chips
+#define TOROID FALSE                            // chip array = toroid?
 
-#define EAST 1					// inter-chip link definitions
-#define NORTH 4					// NB diagonal links not used!
+#define EAST 1                                  // inter-chip link definitions
+#define NORTH 4                                 // NB diagonal links not used!
 #define WEST 8
 #define SOUTH 32
 
-uint alive;					// this cell's state
-uint last_alive = 2;				// previous state
-uint count[2];					// live neighbour count [for each gen]
-uint gen;					// generation (used for parity)
-uint myKey;					// key for sending
+uint alive;                                     // this cell's state
+uint last_alive = 2;                            // previous state
+uint count[2];                                  // live neighbour count [for each gen]
+uint gen;                                       // generation (used for parity)
+uint myKey;                                     // key for sending
 
 
 void tick_callback(
-	uint ticks,
-	uint dummy)
+        uint ticks,
+        uint dummy)
 {
-    if (ticks % 250 == (myKey & 255)) {		// Every 0.25 secs, time skewed for SDP
-	alive = (count[gen] | alive) == 3;	// Life automaton rule
-	count[gen] = 0;				// clear count for next gen
-	gen = !gen;				// onto next generation
+    if (ticks % 250 == (myKey & 255)) {         // Every 0.25 secs, time skewed for SDP
+        alive = (count[gen] | alive) == 3;      // Life automaton rule
+        count[gen] = 0;                         // clear count for next gen
+        gen = !gen;                             // onto next generation
 
-	spin1_send_mc_packet(myKey, gen+(alive<<1), WITH_PAYLOAD); // send state to neighbours
+        spin1_send_mc_packet(myKey, gen+(alive<<1), WITH_PAYLOAD); // send state to neighbours
 
-	if (alive != last_alive) {
-	    char *s = (alive) ? "white" : "black"; // Make a colour string
-	    io_printf(IO_STD, "#%s;#fill;\n", s); // And print it
-	    last_alive = alive;
-	}
+        if (alive != last_alive) {
+            char *s = (alive) ? "white" : "black"; // Make a colour string
+            io_printf(IO_STD, "#%s;#fill;\n", s); // And print it
+            last_alive = alive;
+        }
     }
 }
 
 
 void packet_in(
-	uint key,
-	uint data)				// data = gen + 2*alive
+        uint key,
+        uint data)                              // data = gen + 2*alive
 {
-    count[data & 1] += data >> 1;		// count[gen mod 2] += alive
+    count[data & 1] += data >> 1;               // count[gen mod 2] += alive
 }
 
 
-uint toH []   = {WEST, EAST};			// edge directions
-uint toV []   = {SOUTH, NORTH};			// to & from, Horizontal & Vertical
+uint toH []   = {WEST, EAST};                   // edge directions
+uint toV []   = {SOUTH, NORTH};                 // to & from, Horizontal & Vertical
 uint fromH [] = {EAST, WEST};
 uint fromV [] = {NORTH, SOUTH};
 
-uint route = 0;					// route bit vector
-int x, y;					// core x, y coordinates
+uint route = 0;                                 // route bit vector
+int x, y;                                       // core x, y coordinates
 
 
-uint edge(					// check for core at edge of chip
-	uint z)
+uint edge(                                      // check for core at edge of chip
+        uint z)
 {
     return (z == 0) || (z == 3);
 }
 
 
-void add_route_to_core(				// filters out off-chip neighbours
-	int i,
-	int j)
+void add_route_to_core(                         // filters out off-chip neighbours
+        int i,
+        int j)
 {
-    if (i >- 1 && i < 4  && j >- 1 && j < 4	// check for end of row & col
-	  && !(i == x && j == y)) {
-	route += 1 << (i + 4*j + 7);		// don't route to self
+    if (i >- 1 && i < 4  && j >- 1 && j < 4     // check for end of row & col
+          && !(i == x && j == y)) {
+        route += 1 << (i + 4*j + 7);            // don't route to self
     }
 }
 
 
-uint next_chip(					// find next chip, modulo array size
-	uint chip,
-	uint dir)
+uint next_chip(                                 // find next chip, modulo array size
+        uint chip,
+        uint dir)
 {
     uint cX = chip >> 8;
     uint cY = chip & 255;
@@ -111,16 +111,16 @@ uint next_chip(					// find next chip, modulo array size
     // do the modulo sums
 
     if (dir & SOUTH) {
-	cY = cY ? cY - 1 : YMAX - 1;
+        cY = cY ? cY - 1 : YMAX - 1;
     }
     if (dir & NORTH) {
-	cY = (cY + 1) % YMAX;
+        cY = (cY + 1) % YMAX;
     }
     if (dir & WEST) {
-	cX = cX ? cX - 1 : XMAX - 1;
+        cX = cX ? cX - 1 : XMAX - 1;
     }
     if (dir & EAST) {
-	cX = (cX + 1) % XMAX;
+        cX = (cX + 1) % XMAX;
     }
 
     return (cX << 8) + cY;
@@ -128,127 +128,127 @@ uint next_chip(					// find next chip, modulo array size
 
 
 void add_route_to_chip(
-	uint chip,
-	uint dir)				// dir specifies possible directions
+        uint chip,
+        uint dir)                               // dir specifies possible directions
 {
     if (TOROID) {
-	route += dir;
+        route += dir;
     } else {
-	uint nc = next_chip(chip, dir);		// toroidal routing on...
-	uint cX  = chip >> 8;
-	uint cY  = chip & 255;			// ...non-toroidal system
-	uint ncX = nc >> 8;
-	uint ncY = nc & 255;			// uses default routing to get back
+        uint nc = next_chip(chip, dir);         // toroidal routing on...
+        uint cX  = chip >> 8;
+        uint cY  = chip & 255;                  // ...non-toroidal system
+        uint ncX = nc >> 8;
+        uint ncY = nc & 255;                    // uses default routing to get back
 
-	if (cX != ncX) {
-	    route += toH[ncX > cX];
-	}
-	if (cY != ncY) {
-	  route += toV[ncY > cY];
-	}
+        if (cX != ncX) {
+            route += toH[ncX > cX];
+        }
+        if (cY != ncY) {
+          route += toV[ncY > cY];
+        }
     }
 }
 
 
-void set_mc_table_entry(			// route from (chip, core)
-	uint chip,
-	uint core)
+void set_mc_table_entry(                        // route from (chip, core)
+        uint chip,
+        uint core)
 {
     uint e = rtr_alloc(1);
     if (e == 0) {
-	rt_error(RTE_ABORT);
+        rt_error(RTE_ABORT);
     }
 
     rtr_mc_set(e, (chip << 8) + core, 0xffffffff, route);
-    route = 0;					// clear route for next use
+    route = 0;                                  // clear route for next use
 }
 
 
-void set_up_routing_tables(			// this is the tricky bit!
-	uint chip,
-	uint core)
+void set_up_routing_tables(                     // this is the tricky bit!
+        uint chip,
+        uint core)
 {
-    x = (core - 1) & 3;				// core x, y coordinates
+    x = (core - 1) & 3;                         // core x, y coordinates
     y = (core - 1) >> 2;
 
     // first set up routes for internally-generated packets
 
-    for (int i = x - 1; i < x + 2; i++) {	// column left, same, right
-	for (int j = y - 1; j < y + 2; j++) {
-	    add_route_to_core(i, j);		// row below, same, above
-	}
+    for (int i = x - 1; i < x + 2; i++) {       // column left, same, right
+        for (int j = y - 1; j < y + 2; j++) {
+            add_route_to_core(i, j);            // row below, same, above
+        }
     }
 
     if (edge(x)) {
-	add_route_to_chip(chip, toH[x & 1]);	// send off-chip where appropriate
+        add_route_to_chip(chip, toH[x & 1]);    // send off-chip where appropriate
     }
     if (edge(y)) {
-	add_route_to_chip(chip, toV[y & 1]);
+        add_route_to_chip(chip, toV[y & 1]);
     }
 
-    set_mc_table_entry(chip, core);		// write local Router table entry
+    set_mc_table_entry(chip, core);             // write local Router table entry
 
     // then handle incoming packets from other chips...
     // ...each core handles routes from corresponding cores on other chips
 
-    if (edge(y)) {				// top & bottom
-	for (int i = x - 1; i < x + 2; i++) {	// route to opposite row
-	    add_route_to_core(i, 3 - y);
-	}
+    if (edge(y)) {                              // top & bottom
+        for (int i = x - 1; i < x + 2; i++) {   // route to opposite row
+            add_route_to_core(i, 3 - y);
+        }
 
-	if (edge(x)) {
-	    add_route_to_chip(chip, toH[x & 1]);// forward diagonal connection
-	}
+        if (edge(x)) {
+            add_route_to_chip(chip, toH[x & 1]);// forward diagonal connection
+        }
 
-	set_mc_table_entry(next_chip(chip, fromV[y & 1]), core);
+        set_mc_table_entry(next_chip(chip, fromV[y & 1]), core);
     }
 
-    if (edge(x)) {				// left & right
-	for (int j = y - 1; j < y + 2; j++) {	// route to opposite col
-	    add_route_to_core(3 - x, j);
-	}
+    if (edge(x)) {                              // left & right
+        for (int j = y - 1; j < y + 2; j++) {   // route to opposite col
+            add_route_to_core(3 - x, j);
+        }
 
-	set_mc_table_entry(next_chip(chip, fromH[x & 1]), core);
+        set_mc_table_entry(next_chip(chip, fromH[x & 1]), core);
     }
 
-    if (edge(x) && edge(y)) {			// incoming diagonal connection
-	add_route_to_core(3 - x, 3 - y);	// receive from opposite corner
-	set_mc_table_entry(next_chip(chip, fromH[x & 1] + fromV[y & 1]), core);
+    if (edge(x) && edge(y)) {                   // incoming diagonal connection
+        add_route_to_core(3 - x, 3 - y);        // receive from opposite corner
+        set_mc_table_entry(next_chip(chip, fromH[x & 1] + fromV[y & 1]), core);
     }
 }
 
 
 void init_Life_state(
-	uint chip,
-	uint core)
+        uint chip,
+        uint core)
 {
     if (chip == 0 && (core == 5 || core == 6 || core == 7
-	    || core == 11 || core == 14)) {
-	count[0] = 3;				// initial state
+            || core == 11 || core == 14)) {
+        count[0] = 3;                           // initial state
     }
 }
 
 
 void c_main(void)
 {
-    uint chip = spin1_get_chip_id();		// get chip ID
-    uint core = spin1_get_core_id();		// ...& core ID
-    myKey = (chip << 8) + core;			// key for my output packets
+    uint chip = spin1_get_chip_id();            // get chip ID
+    uint core = spin1_get_core_id();            // ...& core ID
+    myKey = (chip << 8) + core;                 // key for my output packets
 
     if ((chip >> 8) < XMAX && (chip & 255) < YMAX) { // only start required cores
-	io_printf(IO_BUF, "Started core %d %d %d\n",
-		chip >> 8, chip & 255, core);	// signal core running
+        io_printf(IO_BUF, "Started core %d %d %d\n",
+                chip >> 8, chip & 255, core);   // signal core running
 
-	set_up_routing_tables(chip, core);	// configure routing
-	init_Life_state(chip, core);		// Initialise Life state
+        set_up_routing_tables(chip, core);      // configure routing
+        init_Life_state(chip, core);            // Initialise Life state
 
-	spin1_set_timer_tick(1000);		// 1ms timer tick
-	spin1_callback_on(TIMER_TICK, tick_callback, 1);	// timer callback
-	spin1_callback_on(MCPL_PACKET_RECEIVED, packet_in, -1);	// incoming packet callback
+        spin1_set_timer_tick(1000);             // 1ms timer tick
+        spin1_callback_on(TIMER_TICK, tick_callback, 1);        // timer callback
+        spin1_callback_on(MCPL_PACKET_RECEIVED, packet_in, -1); // incoming packet callback
 
-	spin1_start(SYNC_NOWAIT);		// start event-driven operation
+        spin1_start(SYNC_NOWAIT);               // start event-driven operation
 
-	io_printf(IO_BUF, "Terminated core %d %d %d\n",
-		chip >> 8, chip & 255, core);	// print if event_exit used...
+        io_printf(IO_BUF, "Terminated core %d %d %d\n",
+                chip >> 8, chip & 255, core);   // print if event_exit used...
     }
 }

--- a/apps/pt_demo/drawer.c
+++ b/apps/pt_demo/drawer.c
@@ -60,8 +60,8 @@ void display(void)
 
 
 void reshape(
-	int width,
-	int height)
+        int width,
+        int height)
 {
     windowWidth = MIN(width, frameWidth);
     windowHeight = MIN(height, frameHeight);
@@ -71,125 +71,125 @@ void reshape(
 
 
 void special(
-	int key,
-	int x,
-	int y)
+        int key,
+        int x,
+        int y)
 {
     switch (key) {
     case GLUT_KEY_UP:
-	turningUpDown = -1;
-	break;
+        turningUpDown = -1;
+        break;
     case GLUT_KEY_DOWN:
-	turningUpDown = 1;
-	break;
+        turningUpDown = 1;
+        break;
     case GLUT_KEY_RIGHT:
-	rolling = -1;
-	break;
+        rolling = -1;
+        break;
     case GLUT_KEY_LEFT:
-	rolling = 1;
-	break;
+        rolling = 1;
+        break;
     }
 }
 
 
 void specialUp(
-	int key,
-	int x,
-	int y)
+        int key,
+        int x,
+        int y)
 {
     switch (key) {
     case GLUT_KEY_UP:
-	turningUpDown = 0;
-	break;
+        turningUpDown = 0;
+        break;
     case GLUT_KEY_DOWN:
-	turningUpDown = 0;
-	break;
+        turningUpDown = 0;
+        break;
     case GLUT_KEY_RIGHT:
-	rolling = 0;
-	break;
+        rolling = 0;
+        break;
     case GLUT_KEY_LEFT:
-	rolling = 0;
-	break;
+        rolling = 0;
+        break;
     }
 }
 
 
 void keyPressed(
-	unsigned char key,
-	int x,
-	int y)
+        unsigned char key,
+        int x,
+        int y)
 {
     switch (key) {
     case 'w':
-	moving = 1;
-	break;
+        moving = 1;
+        break;
     case 's':
-	moving = -1;
-	break;
+        moving = -1;
+        break;
     case 'a':
-	turningLeftRight = -1;
-	break;
+        turningLeftRight = -1;
+        break;
     case 'd':
-	turningLeftRight = 1;
-	break;
+        turningLeftRight = 1;
+        break;
     case 'q':
-	strafing = 1;
-	break;
+        strafing = 1;
+        break;
     case 'e':
-	strafing = -1;
-	break;
+        strafing = -1;
+        break;
     }
 }
 
 
 void keyReleased(
-	unsigned char key,
-	int x,
-	int y)
+        unsigned char key,
+        int x,
+        int y)
 {
     switch (key) {
     case 'w':
-	moving = 0;
-	break;
+        moving = 0;
+        break;
     case 's':
-	moving = 0;
-	break;
+        moving = 0;
+        break;
     case 'a':
-	turningLeftRight = 0;
-	break;
+        turningLeftRight = 0;
+        break;
     case 'd':
-	turningLeftRight = 0;
-	break;
+        turningLeftRight = 0;
+        break;
     case 'q':
-	strafing = 0;
-	break;
+        strafing = 0;
+        break;
     case 'e':
-	strafing = 0;
-	break;
+        strafing = 0;
+        break;
     }
 }
 
 
 Vector3 fVectorNormalise(
-	Vector3 in)
+        Vector3 in)
 {
     float magnitudeReciprocal = 1.0 / sqrt(in.x*in.x + in.y*in.y + in.z*in.z);
     Vector3 result = {
-	    in.x * magnitudeReciprocal,
-	    in.y * magnitudeReciprocal,
-	    in.z * magnitudeReciprocal};
+            in.x * magnitudeReciprocal,
+            in.y * magnitudeReciprocal,
+            in.z * magnitudeReciprocal};
     return result;
 }
 
 
 Vector3 fVectorCrossProduct(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    a.y * b.z - a.z * b.y,
-	    a.z * b.x - a.x * b.z,
-	    a.x * b.y - a.y * b.x};
+            a.y * b.z - a.z * b.y,
+            a.z * b.x - a.x * b.z,
+            a.x * b.y - a.y * b.x};
     return result;
 }
 
@@ -197,9 +197,9 @@ Vector3 fVectorCrossProduct(
 // Rotate the first vector around the second
 
 Vector3 fVectorRotate(
-	Vector3 rotated,
-	Vector3 rotateAbout,
-	float amount)
+        Vector3 rotated,
+        Vector3 rotateAbout,
+        float amount)
 {
     float c = cos(amount);
     float s = sin(amount);
@@ -208,16 +208,16 @@ Vector3 fVectorRotate(
     Vector3 result;
 
     result.x = rotated.x * (t * rotateAbout.x * rotateAbout.x + c) +
-	    rotated.y * (t * rotateAbout.x * rotateAbout.y + s * rotateAbout.z) +
-	    rotated.z * (t * rotateAbout.x * rotateAbout.z - s * rotateAbout.y);
+            rotated.y * (t * rotateAbout.x * rotateAbout.y + s * rotateAbout.z) +
+            rotated.z * (t * rotateAbout.x * rotateAbout.z - s * rotateAbout.y);
 
     result.y = rotated.x * (t * rotateAbout.x * rotateAbout.y - s * rotateAbout.z) +
-	    rotated.y * (t * rotateAbout.y * rotateAbout.y + c) +
-	    rotated.z * (t * rotateAbout.y * rotateAbout.z + s * rotateAbout.x);
+            rotated.y * (t * rotateAbout.y * rotateAbout.y + c) +
+            rotated.z * (t * rotateAbout.y * rotateAbout.z + s * rotateAbout.x);
 
     result.z = rotated.x * (t * rotateAbout.z * rotateAbout.x + s * rotateAbout.y) +
-	    rotated.y * (t * rotateAbout.y * rotateAbout.z - s * rotateAbout.x) +
-	    rotated.z * (t * rotateAbout.z * rotateAbout.z + c);
+            rotated.y * (t * rotateAbout.y * rotateAbout.z - s * rotateAbout.x) +
+            rotated.z * (t * rotateAbout.z * rotateAbout.z + c);
 
     result = fVectorNormalise(result);
     return result;
@@ -225,7 +225,7 @@ Vector3 fVectorRotate(
 
 
 void calculateMovement(
-	int timestep)
+        int timestep)
 {
     // Forward movement
 
@@ -267,31 +267,31 @@ void idleFunctionLoop(void)
     // Calculate movement ten times a second
 
     if (currTime > prevTime + 10000) {
-	int timeSinceLastUpdate = currTime - prevTime;
-	calculateMovement(timeSinceLastUpdate);
+        int timeSinceLastUpdate = currTime - prevTime;
+        calculateMovement(timeSinceLastUpdate);
 
-	prevTime = currTime;
-	display();
+        prevTime = currTime;
+        display();
     }
 }
 
 
 int main(
-	int argc,
-	char **argv)
+        int argc,
+        char **argv)
 {
 
 #ifdef WIN32
     WSADATA wsaData;
     if (WSAStartup(MAKEWORD(1, 1), &wsaData) != 0) {
-	fprintf(stderr, "WSAStartup failed.\n");
-	exit(1);
+        fprintf(stderr, "WSAStartup failed.\n");
+        exit(1);
     }
 #endif
 
-    pthread_t p1;			// this sets up the thread that can come back to here from type
+    pthread_t p1;                       // this sets up the thread that can come back to here from type
 
-    init_udp_server_spinnaker();	//initialization of the port for receiving SpiNNaker frames
+    init_udp_server_spinnaker();        //initialization of the port for receiving SpiNNaker frames
 
     frameHeight = (argc > 1 ? atoi(argv[1]) : 256);
     frameWidth = (int) (((int) horizontalFieldOfView * frameHeight) / verticalFieldOfView);
@@ -303,30 +303,30 @@ int main(
 
     int i;
     for (i = 0; i < frameWidth * frameHeight; i++) {
-	receivedFrame[i] = 0;
+        receivedFrame[i] = 0;
     }
 
     pthread_create(&p1, NULL, input_thread, NULL); // away it goes
 
-    glutInit(&argc, argv);		// Initialise OpenGL
-    glutInitDisplayMode(GLUT_DOUBLE);	// Set the display mode
+    glutInit(&argc, argv);              // Initialise OpenGL
+    glutInitDisplayMode(GLUT_DOUBLE);   // Set the display mode
     glutInitWindowSize(frameWidth, frameHeight); // Set the window size
-    glutInitWindowPosition(0, 0);	// Set the window position
-    glutCreateWindow("Path Tracer");	// Create the window
+    glutInitWindowPosition(0, 0);       // Set the window position
+    glutCreateWindow("Path Tracer");    // Create the window
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
     glEnable(GL_DEPTH_TEST);
 
-    glutDisplayFunc(display);		// Register the "display" function
-    glutReshapeFunc(reshape);		// Register the "reshape" function
+    glutDisplayFunc(display);           // Register the "display" function
+    glutReshapeFunc(reshape);           // Register the "reshape" function
     glutSpecialFunc(special);
     glutSpecialUpFunc(specialUp);
     glutKeyboardFunc(keyPressed);
     glutKeyboardUpFunc(keyReleased);
     glutIdleFunc(idleFunctionLoop);
 
-    glutMainLoop();			// Enter the main OpenGL loop
+    glutMainLoop();                     // Enter the main OpenGL loop
 
     return 0;
 }

--- a/apps/pt_demo/tracer.c
+++ b/apps/pt_demo/tracer.c
@@ -4,7 +4,7 @@
 // August 2012
 // ----------------------------------------------------------------------------
 
-#define API	// Undef to use SARK event library
+#define API     // Undef to use SARK event library
 
 #include <sark.h>
 #include <spin1_api.h>
@@ -33,7 +33,7 @@ const uint fourthByte = 0xff000000;
 
 
 int abs(
-	int a)
+        int a)
 {
     return (a<0 ? -a : a);
 }
@@ -49,17 +49,17 @@ int abs(
 // Multiplies two numbers between -1.0 and 1.0
 
 int fp_unit_mul(
-	int a,
-	int b)
+        int a,
+        int b)
 {
     int sign = (a<0?-1:1)*(b<0?-1:1);
     unsigned int a1 = (unsigned int)(a<0?-a:a);
     unsigned int b1 = (unsigned int)(b<0?-b:b);
 
     if ((a1>>16) > 0) {
-	return sign*b1;
+        return sign*b1;
     } else if ((b1>>16) > 0) {
-	return sign*a1;
+        return sign*a1;
     }
 
     unsigned int  lowera = (a1 & lower16);
@@ -77,7 +77,7 @@ int fp_unit_mul2(int a, int b)
     unsigned int b1 = (unsigned int) (b<0?-b:b);
 
     if ((b1>>16) > 0) {
-	return sign*a1;
+        return sign*a1;
     }
 
     int lowera = (a1 & lower16);
@@ -91,7 +91,7 @@ int fp_unit_mul2(int a, int b)
 int fp_frac(int a, int b)
 {
     if ((b>>16) > 0) {
-	return a;
+        return a;
     }
 
     int sign = (a<0?-1:1);
@@ -146,12 +146,12 @@ int fp_recip(int a)
 // 0.5 and 1.0, then call the function above to use Newton's method
 
 int fp_recip_gen(
-	int a,
-	int id)
+        int a,
+        int id)
 {
     if (a == 0) {
-	rt_error(RTE_DIV0); //##
-	//##        io_printf(IO_STD, "Fixed-point arithmetic error: div by 0 in fp_recip_gen %d.\n", id);
+        rt_error(RTE_DIV0); //##
+        //##        io_printf(IO_STD, "Fixed-point arithmetic error: div by 0 in fp_recip_gen %d.\n", id);
     }
 
     int sign = (a<0 ? -1 : 1);
@@ -160,12 +160,12 @@ int fp_recip_gen(
     int shifted = 0;
 
     while (a1 > 65536) {
-	a1 >>= 1;
-	shifted -= 1;
+        a1 >>= 1;
+        shifted -= 1;
     }
     while (a1 <= 32768) {
-	a1 <<= 1;
-	shifted +=1;
+        a1 <<= 1;
+        shifted +=1;
     }
     a1 = fp_recip(a1);
     a1 = (shifted>0 ? (a1<<shifted) : (a1>>-shifted));
@@ -178,28 +178,28 @@ int fp_recip_gen(
 // arguments until it lies in this range.
 
 int fp_div(
-	int num,
-	int denom)
+        int num,
+        int denom)
 {
     if (denom == 0) {
-	rt_error(RTE_DIV0); //##
-	//##  io_printf(IO_STD, "Fixed-point arithmetic error: div by 0 in fp_div.\n");
+        rt_error(RTE_DIV0); //##
+        //##  io_printf(IO_STD, "Fixed-point arithmetic error: div by 0 in fp_div.\n");
     }
 
     // fp_recip works only on positive values
     if (denom < 0) {
-	num = -num;
-	denom = -denom;
+        num = -num;
+        denom = -denom;
     }
 
     // fp_recip works only on values in range 0.5 to 1.0
-    while (denom > 65536) {	// while greater than 1
-	num >>= 1;
-	denom >>= 1;
+    while (denom > 65536) {     // while greater than 1
+        num >>= 1;
+        denom >>= 1;
     }
-    while (denom <= 32768) {	// while less than half
-	num <<= 1;
-	denom <<= 1;
+    while (denom <= 32768) {    // while less than half
+        num <<= 1;
+        denom <<= 1;
     }
 
     return fp_mul(num, fp_recip(denom));
@@ -211,7 +211,7 @@ int fp_div(
 // should start here)
 
 int fp_sqrt(
-	int x)
+        int x)
 {
     unsigned int root, remHi, remLo, testDiv, count;
 
@@ -221,13 +221,13 @@ int fp_sqrt(
     count = 15 + (16>>1);
 
     do {
-	// Get 2 bits of arg
-	remHi = (remHi << 2) | (remLo >> 30); remLo <<= 2;
-	root <<= 1;                 // Get ready for the next bit in the root
-	testDiv = (root << 1) + 1;  // Test radical
-	if (remHi >= testDiv) {
-	    remHi -= testDiv;
-	    root += 1;
+        // Get 2 bits of arg
+        remHi = (remHi << 2) | (remLo >> 30); remLo <<= 2;
+        root <<= 1;                 // Get ready for the next bit in the root
+        testDiv = (root << 1) + 1;  // Test radical
+        if (remHi >= testDiv) {
+            remHi -= testDiv;
+            root += 1;
         }
     } while (count-- != 0);
     return root;
@@ -256,7 +256,7 @@ int cos_lookup[101] = {65536, 65527, 65503, 65463, 65406, 65333, 65245, 65140,
 // the looked-up value, the look-up index, or both are flipped.
 
 int fp_cos(
-	int a)
+        int a)
 {
     int lookup_size = 100;
     int factor = 65535 / (lookup_size*4 - 1);
@@ -279,13 +279,13 @@ int fp_cos(
     // Flip the value and/or index as required
     int sign = 1;
     if (index >= lookup_size && index < lookup_size*2) {
-	index = lookup_size - 1 - (index % lookup_size);
-	sign = -1;
+        index = lookup_size - 1 - (index % lookup_size);
+        sign = -1;
     } else if (index >= lookup_size*2 && index < lookup_size*3) {
-	index = index % lookup_size;
-	sign = -1;
+        index = index % lookup_size;
+        sign = -1;
     } else if (index >= lookup_size*3 && index < lookup_size*4) {
-	index = lookup_size - 1 - (index % lookup_size);
+        index = lookup_size - 1 - (index % lookup_size);
     }
     int value = sign * cos_lookup[index];
 
@@ -293,19 +293,19 @@ int fp_cos(
     // Flip the value and/or index as required
     int sign2 = 1;
     if (index2 >= lookup_size && index2 < lookup_size*2) {
-	index2 = lookup_size - (index2 % lookup_size);
-	sign2 = -1;
+        index2 = lookup_size - (index2 % lookup_size);
+        sign2 = -1;
     } else if (index2 >= lookup_size*2 && index2 < lookup_size*3) {
-	index2 = index2 % lookup_size;
-	sign2 = -1;
+        index2 = index2 % lookup_size;
+        sign2 = -1;
     } else if (index2 >= lookup_size*3 && index2 < lookup_size*4) {
-	index2 = lookup_size - (index2 % lookup_size);
+        index2 = lookup_size - (index2 % lookup_size);
     }
     int value2 = sign2 * cos_lookup[index2];
 
     // Interpolate between the two values
     return (value2*indexFraction) / factor +
-	  (value*(factor-indexFraction)) / factor;
+          (value*(factor-indexFraction)) / factor;
 }
 
 // End of arithmetic.c
@@ -319,20 +319,20 @@ typedef struct {
 } Vector3;
 
 typedef struct {
-    Vector3	origin;
-    Vector3	direction;	// unit vector
+    Vector3     origin;
+    Vector3     direction;      // unit vector
 } Ray;
 
 typedef struct {
-    Vector3	position;
-    int		radius;
-    Vector3	colourT;	// transmitted colour (0->1)
-    Vector3	colourE;	// emitted colour     (0->255)
-    int		specularity;
-    int		specularTightness;
-    int		transparency;
-    int		refractiveIndex;
-    int		reflectivity;
+    Vector3     position;
+    int         radius;
+    Vector3     colourT;        // transmitted colour (0->1)
+    Vector3     colourE;        // emitted colour     (0->255)
+    int         specularity;
+    int         specularTightness;
+    int         transparency;
+    int         refractiveIndex;
+    int         reflectivity;
 } Sphere;
 
 // geometry.c
@@ -340,34 +340,34 @@ typedef struct {
 //-------- Vector functions ---------------------------------------------------
 
 Vector3 vecInvert(
-	Vector3 a)
+        Vector3 a)
 {
     Vector3 result = {
-	    -a.x,
-	    -a.y,
-	    -a.z };
+            -a.x,
+            -a.y,
+            -a.z };
     return result;
 }
 
 Vector3 vecAdd(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    a.x + b.x,
-	    a.y + b.y,
-	    a.z + b.z };
+            a.x + b.x,
+            a.y + b.y,
+            a.z + b.z };
     return result;
 }
 
 Vector3 vecSub(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    a.x - b.x,
-	    a.y - b.y,
-	    a.z - b.z };
+            a.x - b.x,
+            a.y - b.y,
+            a.z - b.z };
     return result;
 }
 
@@ -382,22 +382,22 @@ Vector3 vecSub(
 Vector3 vecScalarFrac(Vector3 a, int b)
 {
     Vector3 result = {
-	    fp_frac(a.x, b),
-	    fp_frac(a.y, b),
-	    fp_frac(a.z, b) };
+            fp_frac(a.x, b),
+            fp_frac(a.y, b),
+            fp_frac(a.z, b) };
     return result;
 }
 
 // Multiply a vector by a scalar value
 
 Vector3 vecScalarMul(
-	Vector3 a,
-	int b)
+        Vector3 a,
+        int b)
 {
     Vector3 result = {
-	    fp_mul(a.x, b),
-	    fp_mul(a.y, b),
-	    fp_mul(a.z, b) };
+            fp_mul(a.x, b),
+            fp_mul(a.y, b),
+            fp_mul(a.z, b) };
     return result;
 }
 
@@ -405,62 +405,62 @@ Vector3 vecScalarMul(
 // are between 0.0 and 1.0
 
 Vector3 vecFrac(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    fp_frac(a.x, b.x),
-	    fp_frac(a.y, b.y),
-	    fp_frac(a.z, b.z) };
+            fp_frac(a.x, b.x),
+            fp_frac(a.y, b.y),
+            fp_frac(a.z, b.z) };
     return result;
 }
 
 // Element-wise multiplication of two vectors
 
 Vector3 vecMul(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    fp_mul(a.x, b.x),
-	    fp_mul(a.y, b.y),
-	    fp_mul(a.z, b.z) };
+            fp_mul(a.x, b.x),
+            fp_mul(a.y, b.y),
+            fp_mul(a.z, b.z) };
     return result;
 }
 
 int vecMagnitude(
-	Vector3 in)
+        Vector3 in)
 {
     return fp_sqrt(
-	    fp_mul(in.x, in.x) + fp_mul(in.y, in.y) + fp_mul(in.z, in.z));
+            fp_mul(in.x, in.x) + fp_mul(in.y, in.y) + fp_mul(in.z, in.z));
 }
 
 Vector3 vecNorm(
-	Vector3 in,
-	int id)
+        Vector3 in,
+        int id)
 {
     int vecMagnitudeReciprocal = fp_recip_gen(vecMagnitude(in), id);
 
     if (vecMagnitudeReciprocal > (1<<16)) {
-	Vector3 result = {
-		fp_mul(in.x, vecMagnitudeReciprocal),
-		fp_mul(in.y, vecMagnitudeReciprocal),
-		fp_mul(in.z, vecMagnitudeReciprocal) };
-	return result;
+        Vector3 result = {
+                fp_mul(in.x, vecMagnitudeReciprocal),
+                fp_mul(in.y, vecMagnitudeReciprocal),
+                fp_mul(in.z, vecMagnitudeReciprocal) };
+        return result;
     } else {
-	Vector3 result = {
-		fp_frac(in.x, vecMagnitudeReciprocal),
-		fp_frac(in.y, vecMagnitudeReciprocal),
-		fp_frac(in.z, vecMagnitudeReciprocal) };
-	return result;
+        Vector3 result = {
+                fp_frac(in.x, vecMagnitudeReciprocal),
+                fp_frac(in.y, vecMagnitudeReciprocal),
+                fp_frac(in.z, vecMagnitudeReciprocal) };
+        return result;
     }
 }
 
 // The dot product of two vectors
 
 int vecDotProd(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     return fp_mul(a.x, b.x) + fp_mul(a.y, b.y) + fp_mul(a.z, b.z);
 }
@@ -468,43 +468,43 @@ int vecDotProd(
 // The dot product of two vectors that we know to be unit vectors
 
 int vecUnitDotProd(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     return fp_unit_mul(a.x, b.x) +
-	    fp_unit_mul(a.y, b.y) + fp_unit_mul(a.z, b.z);
+            fp_unit_mul(a.y, b.y) + fp_unit_mul(a.z, b.z);
 }
 
 // The dot product of two vectors where b is known to be a unit vector
 
 int vecUnitDotProd2(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     return fp_unit_mul2(a.x, b.x) +
-	    fp_unit_mul2(a.y, b.y) + fp_unit_mul2(a.z, b.z);
+            fp_unit_mul2(a.y, b.y) + fp_unit_mul2(a.z, b.z);
 }
 
 // The cross product of two vectors
 
 Vector3 vecCrossProd(
-	Vector3 a,
-	Vector3 b)
+        Vector3 a,
+        Vector3 b)
 {
     Vector3 result = {
-	    fp_mul(a.y, b.z) - fp_mul(a.z, b.y),
-	    fp_mul(a.z, b.x) - fp_mul(a.x, b.z),
-	    fp_mul(a.x, b.y) - fp_mul(a.y, b.x) };
+            fp_mul(a.y, b.z) - fp_mul(a.z, b.y),
+            fp_mul(a.z, b.x) - fp_mul(a.x, b.z),
+            fp_mul(a.x, b.y) - fp_mul(a.y, b.x) };
     return result;
 }
 
 // Rotate the first vector around the second (amount is in degrees)
 
 Vector3 vecRotate(
-	Vector3 rotated,
-	Vector3 rotateAbout,
-	int amount,
-	int id)
+        Vector3 rotated,
+        Vector3 rotateAbout,
+        int amount,
+        int id)
 {
     amount = fp_mul(amount, FP_PI)/180;
     int c = fp_cos(amount);
@@ -515,25 +515,25 @@ Vector3 vecRotate(
 
     Vector3 result;
     result.x =
-	    fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.x)) + c)
-	    + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.y))
-		    + fp_mul(s, rotateAbout.z))
-	    + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.z))
-		    - fp_mul(s, rotateAbout.y));
+            fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.x)) + c)
+            + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.y))
+                    + fp_mul(s, rotateAbout.z))
+            + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.z))
+                    - fp_mul(s, rotateAbout.y));
 
     result.y =
-	    fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.y))
-		    - fp_mul(s, rotateAbout.z))
-	    + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.y)) + c)
-	    + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.z))
-		    + fp_mul(s, rotateAbout.x));
+            fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.x, rotateAbout.y))
+                    - fp_mul(s, rotateAbout.z))
+            + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.y)) + c)
+            + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.z))
+                    + fp_mul(s, rotateAbout.x));
 
     result.z =
-	    fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.z, rotateAbout.x))
-		    + fp_mul(s, rotateAbout.y))
-	    + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.z))
-		    - fp_mul(s, rotateAbout.x))
-	    + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.z, rotateAbout.z)) + c);
+            fp_mul(rotated.x, fp_mul(t, fp_mul(rotateAbout.z, rotateAbout.x))
+                    + fp_mul(s, rotateAbout.y))
+            + fp_mul(rotated.y, fp_mul(t, fp_mul(rotateAbout.y, rotateAbout.z))
+                    - fp_mul(s, rotateAbout.x))
+            + fp_mul(rotated.z, fp_mul(t, fp_mul(rotateAbout.z, rotateAbout.z)) + c);
 
     return vecNorm(result, id);
 }
@@ -541,14 +541,14 @@ Vector3 vecRotate(
 // Clamp the elements of a vector between a lower and upper value
 
 Vector3 vecClamp(
-	Vector3 in,
-	int loClamp,
-	int hiClamp)
+        Vector3 in,
+        int loClamp,
+        int hiClamp)
 {
     Vector3 clamped = {
-	    (in.x > hiClamp) ? hiClamp : ((in.x < loClamp) ? loClamp : in.x),
-	    (in.y > hiClamp) ? hiClamp : ((in.y < loClamp) ? loClamp : in.y),
-	    (in.z > hiClamp) ? hiClamp : ((in.z < loClamp) ? loClamp : in.z) };
+            (in.x > hiClamp) ? hiClamp : ((in.x < loClamp) ? loClamp : in.x),
+            (in.y > hiClamp) ? hiClamp : ((in.y < loClamp) ? loClamp : in.y),
+            (in.z > hiClamp) ? hiClamp : ((in.z < loClamp) ? loClamp : in.z) };
 
     return clamped;
 }
@@ -560,24 +560,24 @@ Vector3 vecClamp(
 // entering or exiting the object)
 
 Vector3 vecRefract(
-	Vector3 n1,
-	Vector3 s,
-	int mu1,
-	int mu2)
+        Vector3 n1,
+        Vector3 s,
+        int mu1,
+        int mu2)
 {
-    int n1DotS	      = vecUnitDotProd(n1, s);
+    int n1DotS        = vecUnitDotProd(n1, s);
     Vector3 firstTerm = vecScalarMul(s, n1DotS);
     int sqrtTerm      = fp_sqrt(fp_mul(mu2, mu2) -
-	    fp_mul(mu1, mu1) + fp_mul(n1DotS, n1DotS));
+            fp_mul(mu1, mu1) + fp_mul(n1DotS, n1DotS));
 
     Vector3 result =
-	    vecAdd(vecSub(n1, firstTerm), vecScalarMul(s, sqrtTerm));
+            vecAdd(vecSub(n1, firstTerm), vecScalarMul(s, sqrtTerm));
 
     return result;
 }
 
 int vecSum(
-	Vector3 inVector)
+        Vector3 inVector)
 {
     return inVector.x + inVector.y + inVector.z;
 }
@@ -592,10 +592,10 @@ int vecSum(
 // interacting with the same surface
 
 Ray rayNudge(
-	Ray ray)
+        Ray ray)
 {
     ray.origin =
-	    vecAdd(ray.origin, vecScalarFrac(ray.direction, 1<<10));
+            vecAdd(ray.origin, vecScalarFrac(ray.direction, 1<<10));
     return ray;
 }
 
@@ -608,37 +608,37 @@ Ray rayNudge(
 // it happens. If it doesn't, return -1
 
 int sphereIntersection(
-	Sphere sphere,
-	Ray ray)
+        Sphere sphere,
+        Ray ray)
 {
     // The intersection algorithm assumes that the ray starts at the origin,
     // so translate the sphere first.
     sphere.position = vecSub(sphere.position, ray.origin);
 
     int directionDotPosition =
-	    vecUnitDotProd2(sphere.position, ray.direction);
+            vecUnitDotProd2(sphere.position, ray.direction);
     int sqrtTerm = fp_mul(directionDotPosition, directionDotPosition)
-	    - vecDotProd(sphere.position, sphere.position)
-	    + fp_mul(sphere.radius, sphere.radius);
+            - vecDotProd(sphere.position, sphere.position)
+            + fp_mul(sphere.radius, sphere.radius);
 
     int result = -1; // Return value for no intersection
 
     if (sqrtTerm >= 0) { // If there is an intersection (more likely 2)
-	sqrtTerm = fp_sqrt(sqrtTerm);
-	// There are usually two solutions, for the two intersection points
-	// between the ray and sphere.
-	int solution1 = directionDotPosition + sqrtTerm;
-	int solution2 = directionDotPosition - sqrtTerm;
+        sqrtTerm = fp_sqrt(sqrtTerm);
+        // There are usually two solutions, for the two intersection points
+        // between the ray and sphere.
+        int solution1 = directionDotPosition + sqrtTerm;
+        int solution2 = directionDotPosition - sqrtTerm;
 
-	// We want the nearest non-negative (behind the ray origin) intersection
-	if (solution1 >= 0) {
-	    result = solution1;
-	    if (solution2 >= 0 && solution2 < solution1) {
-		result = solution2;
-	    }
+        // We want the nearest non-negative (behind the ray origin) intersection
+        if (solution1 >= 0) {
+            result = solution1;
+            if (solution2 >= 0 && solution2 < solution1) {
+                result = solution2;
+            }
         } else if (solution2 >= 0) {
             result = solution2;
-	}
+        }
     }
 
     return result;
@@ -655,26 +655,26 @@ int sphereIntersection(
 typedef struct {
   // these are unit vectors and represent the direction to the four
   // corners of the view plane from the camera
-    Vector3	topLeft;
-    Vector3	topRight;
-    Vector3	bottomLeft;
-    Vector3	bottomRight;
+    Vector3     topLeft;
+    Vector3     topRight;
+    Vector3     bottomLeft;
+    Vector3     bottomRight;
 } ViewPlane;
 
 typedef struct {
-    Vector3	position;
-    Vector3	lookDirection;
-    Vector3	upDirection;
+    Vector3     position;
+    Vector3     lookDirection;
+    Vector3     upDirection;
 
-    int		horizontalFieldOfView;
-    int		verticalFieldOfView;
-    int		horizontalPixels;
-    int		verticalPixels;
+    int         horizontalFieldOfView;
+    int         verticalFieldOfView;
+    int         horizontalPixels;
+    int         verticalPixels;
 
-    int		antialiasing;
+    int         antialiasing;
 
-    Vector3	rightDirection;
-    ViewPlane	viewPlane;  // The two view angles are used to construct the viewplane
+    Vector3     rightDirection;
+    ViewPlane   viewPlane;  // The two view angles are used to construct the viewplane
 } Camera;
 
 // scene.c
@@ -683,7 +683,7 @@ typedef struct {
 // construct a view plane in front of the camera and calculate a right vector
 
 Camera setupCamera(
-	Camera camera)
+        Camera camera)
 {
     Vector3 rightDirection = vecCrossProd(camera.lookDirection, camera.upDirection);
     camera.rightDirection = rightDirection;
@@ -733,10 +733,10 @@ int random1(void)
 
 
 int diffuseBDRF(
-	Vector3 in,
-	Vector3 out,
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal)
+        Vector3 in,
+        Vector3 out,
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal)
 {
     return vecDotProd(surfaceNormal, out);
 }
@@ -744,10 +744,10 @@ int diffuseBDRF(
 // Cosine-weighted diffuse reflection
 
 Ray diffuseReflectanceFunction(
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	Vector3 inwardVector,
-	int *BDRF)
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        Vector3 inwardVector,
+        int *BDRF)
 {
     Ray outwardRay;
     outwardRay.origin = collisionPoint;
@@ -756,33 +756,33 @@ Ray diffuseReflectanceFunction(
     outwardRay.direction.y = random1();
     outwardRay.direction.z = random1();
     while (vecSum(outwardRay.direction) < 1000) {
-	outwardRay.direction.x = random1();
-	outwardRay.direction.y = random1();
-	outwardRay.direction.z = random1();
+        outwardRay.direction.x = random1();
+        outwardRay.direction.y = random1();
+        outwardRay.direction.z = random1();
     }
     outwardRay.direction = vecNorm(outwardRay.direction, 1005);
 
     outwardRay.direction = vecAdd(outwardRay.direction,
-	    vecScalarMul(surfaceNormal, 270<<8));
+            vecScalarMul(surfaceNormal, 270<<8));
     outwardRay.direction = vecNorm(outwardRay.direction, 1006);
 
     outwardRay = rayNudge(outwardRay);
 
     *BDRF = diffuseBDRF(inwardVector, outwardRay.direction, collisionPoint,
-	    surfaceNormal);
+            surfaceNormal);
 
     return outwardRay;
 }
 
 int specularBDRF(
-	Vector3 in,
-	Vector3 out,
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	int tightness)
+        Vector3 in,
+        Vector3 out,
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        int tightness)
 {
     Vector3 reflectedOut = vecSub(out,
-	    vecScalarMul(surfaceNormal, 2*vecUnitDotProd(out, surfaceNormal)));
+            vecScalarMul(surfaceNormal, 2*vecUnitDotProd(out, surfaceNormal)));
 
     int phongTerm   = vecUnitDotProd(in, reflectedOut);
 
@@ -790,7 +790,7 @@ int specularBDRF(
     // having to get abs of value because dot product is probably using an inverted vector
     int i;
     for (i=0; i<tightness; i++) {
-	phongTerm = fp_frac(phongTerm, phongTerm);
+        phongTerm = fp_frac(phongTerm, phongTerm);
     }
 
     return phongTerm;
@@ -800,11 +800,11 @@ int specularBDRF(
 // Perfectly specular reflection
 
 Ray specularReflectanceFunction (
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	Vector3 inwardVector,
-	int tightness,
-	int *BDRF)
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        Vector3 inwardVector,
+        int tightness,
+        int *BDRF)
 {
     // First, find a vector that's perpendicular to the surface normal (there are an infinite number of these...)
     // All methods require conditional logic.  One method is to find the element of the surface normal vector that's closest to zero
@@ -812,18 +812,18 @@ Ray specularReflectanceFunction (
     // The dot product of this vector and the surface normal is perpendicular to the surface normal.
     int minimumElement = 0;
     if (abs(surfaceNormal.y) < abs(surfaceNormal.x)) {
-	minimumElement = 1;
+        minimumElement = 1;
     }
     if (abs(surfaceNormal.z) < abs(surfaceNormal.x)
-	    && abs(surfaceNormal.z) < abs(surfaceNormal.y)) {
-	minimumElement = 2;
+            && abs(surfaceNormal.z) < abs(surfaceNormal.y)) {
+        minimumElement = 2;
     }
     Vector3 crossProdVector = {
-	    (minimumElement==0 ? (1<<16) : 0),
-	    (minimumElement==1 ? (1<<16) : 0),
-	    (minimumElement==2 ? (1<<16) : 0)};
+            (minimumElement==0 ? (1<<16) : 0),
+            (minimumElement==1 ? (1<<16) : 0),
+            (minimumElement==2 ? (1<<16) : 0)};
     Vector3 perpendicularVector = vecNorm(
-	    vecCrossProd(surfaceNormal, crossProdVector), 1040);
+            vecCrossProd(surfaceNormal, crossProdVector), 1040);
 
     // Set the outward ray to be the same as the surface normal
     Ray outwardRay;
@@ -835,29 +835,29 @@ Ray specularReflectanceFunction (
     int theta = random2();
     int i;
     for (i=0; i<tightness; i++) {
-	theta = fp_mul(theta, theta);
+        theta = fp_mul(theta, theta);
     }
 
     outwardRay.direction = vecRotate(outwardRay.direction,
-	    perpendicularVector, theta*60, 1030);
+            perpendicularVector, theta*60, 1030);
 
     // Rotate the outward ray about the surface normal by phi (0 to 360)
     outwardRay.direction = vecNorm(
-	    vecRotate(outwardRay.direction, surfaceNormal, random2()*360, 1031),
-	    1007);
+            vecRotate(outwardRay.direction, surfaceNormal, random2()*360, 1031),
+            1007);
 
     *BDRF = specularBDRF(inwardVector, outwardRay.direction, collisionPoint,
-	    surfaceNormal, tightness);
+            surfaceNormal, tightness);
 
     // Voila: perfectly diffuse reflection
     return outwardRay;
 }
 
 int mirrorBDRF(
-	Vector3 in,
-	Vector3 out,
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal)
+        Vector3 in,
+        Vector3 out,
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal)
 {
     return (1<<16);
 }
@@ -866,14 +866,14 @@ int mirrorBDRF(
 // Perfect mirror reflection
 
 Ray mirrorReflectanceFunction(
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	Vector3 inwardVector,
-	int *BDRF)
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        Vector3 inwardVector,
+        int *BDRF)
 {
     Ray reflectedRay = {collisionPoint,
-	    vecNorm(vecSub(inwardVector, vecScalarMul(surfaceNormal,
-		    2*vecUnitDotProd(inwardVector, surfaceNormal))), 1008) };
+            vecNorm(vecSub(inwardVector, vecScalarMul(surfaceNormal,
+                    2*vecUnitDotProd(inwardVector, surfaceNormal))), 1008) };
     reflectedRay = rayNudge(reflectedRay); // Nudge the ray along to stop it re-interacting with the same surface
 
     *BDRF = mirrorBDRF(inwardVector, reflectedRay.direction, collisionPoint, surfaceNormal);
@@ -882,34 +882,34 @@ Ray mirrorReflectanceFunction(
 }
 
 int refractiveBDRF(
-	Vector3 in,
-	Vector3 out,
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal)
+        Vector3 in,
+        Vector3 out,
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal)
 {
     return (1<<16);
 }
 
 Ray refractiveReflectanceFunction(
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	Vector3 inwardVector,
-	int inverted,
-	int refractiveIndex1,
-	int refractiveIndex2,
-	int *BDRF)
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        Vector3 inwardVector,
+        int inverted,
+        int refractiveIndex1,
+        int refractiveIndex2,
+        int *BDRF)
 {
     // Do entry refraction (inverted surface normal?)
     if (inverted) {
-	surfaceNormal = vecInvert(surfaceNormal);
+        surfaceNormal = vecInvert(surfaceNormal);
     }
 
     Ray transmittedRay = {collisionPoint,
-	    vecRefract(inwardVector, surfaceNormal, refractiveIndex1, refractiveIndex2)};
+            vecRefract(inwardVector, surfaceNormal, refractiveIndex1, refractiveIndex2)};
     transmittedRay = rayNudge(transmittedRay);
 
     *BDRF = refractiveBDRF(inwardVector, transmittedRay.direction,
-	    collisionPoint, surfaceNormal);
+            collisionPoint, surfaceNormal);
 
     return transmittedRay;
 }
@@ -918,27 +918,27 @@ Ray refractiveReflectanceFunction(
 // ray, produce an outward ray (probabilistic)
 
 Ray reflectanceFunction(
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal,
-	Vector3 inwardVector,
-	Sphere sphere,
-	int *BDRF)
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal,
+        Vector3 inwardVector,
+        Sphere sphere,
+        int *BDRF)
 {
     Ray outwardRay;
 
     if (random2() < sphere.specularity) {
-	outwardRay = specularReflectanceFunction(collisionPoint,
-		surfaceNormal, inwardVector, sphere.specularTightness, BDRF);
+        outwardRay = specularReflectanceFunction(collisionPoint,
+                surfaceNormal, inwardVector, sphere.specularTightness, BDRF);
     } else if (random2() < sphere.transparency) {
-	outwardRay = refractiveReflectanceFunction(collisionPoint,
-		surfaceNormal, inwardVector, 1, (1<<16),
-		sphere.refractiveIndex, BDRF);
+        outwardRay = refractiveReflectanceFunction(collisionPoint,
+                surfaceNormal, inwardVector, 1, (1<<16),
+                sphere.refractiveIndex, BDRF);
     } else if (random2() < sphere.reflectivity) {
-	outwardRay = mirrorReflectanceFunction(collisionPoint, surfaceNormal,
-		inwardVector, BDRF);
+        outwardRay = mirrorReflectanceFunction(collisionPoint, surfaceNormal,
+                inwardVector, BDRF);
     } else {
-	outwardRay = diffuseReflectanceFunction(collisionPoint, surfaceNormal,
-		inwardVector, BDRF);
+        outwardRay = diffuseReflectanceFunction(collisionPoint, surfaceNormal,
+                inwardVector, BDRF);
     }
 
     return outwardRay;
@@ -947,25 +947,25 @@ Ray reflectanceFunction(
 // given two vectors and a material, return the BDRF
 
 int materialBDRF(
-	Vector3 inward,
-	Vector3 outward,
-	Sphere sphere,
-	Vector3 collisionPoint,
-	Vector3 surfaceNormal)
+        Vector3 inward,
+        Vector3 outward,
+        Sphere sphere,
+        Vector3 collisionPoint,
+        Vector3 surfaceNormal)
 {
     int BDRF;
 
     if (random2() < sphere.specularity) {
-	BDRF = specularBDRF(inward, outward, collisionPoint, surfaceNormal,
-		sphere.specularTightness);
+        BDRF = specularBDRF(inward, outward, collisionPoint, surfaceNormal,
+                sphere.specularTightness);
     } else if (random2() < sphere.transparency) {
-	BDRF = fp_mul(sphere.specularity, specularBDRF(inward, outward,
-		collisionPoint, surfaceNormal, sphere.specularTightness));
+        BDRF = fp_mul(sphere.specularity, specularBDRF(inward, outward,
+                collisionPoint, surfaceNormal, sphere.specularTightness));
     } else if (random2() < sphere.reflectivity) {
-	BDRF = fp_mul(sphere.specularity, specularBDRF(inward, outward,
-		collisionPoint, surfaceNormal, sphere.specularTightness));
+        BDRF = fp_mul(sphere.specularity, specularBDRF(inward, outward,
+                collisionPoint, surfaceNormal, sphere.specularTightness));
     } else {
-	BDRF = diffuseBDRF(inward, outward, collisionPoint, surfaceNormal);
+        BDRF = diffuseBDRF(inward, outward, collisionPoint, surfaceNormal);
     }
 
     return BDRF;
@@ -975,11 +975,11 @@ Vector3 nilColour = {-1, -1, -1};
 Vector3 black     = {0, 0, 0};
 
 Vector3 traceRay(
-	Ray ray,
-	int depth,
-	int terminationDepth,
-	Sphere *spheres,
-	int numberOfSpheres)
+        Ray ray,
+        int depth,
+        int terminationDepth,
+        Sphere *spheres,
+        int numberOfSpheres)
 {
     // Determine the closest intersecting sphere.
     int closestIntersection = 0;
@@ -987,48 +987,48 @@ Vector3 traceRay(
 
     int i;  // Check intersection will all spheres
     for (i=0; i<numberOfSpheres; i++) {
-	int sphereIntersect = sphereIntersection(spheres[i], ray);
-	// Find nearest positive intersection
-	if (sphereIntersect > 0 &&
-		(sphereIntersect < closestIntersection
-			|| closestIntersection == 0)) {
-	    closestIntersection = sphereIntersect;
-	    intersectingObject = i;
+        int sphereIntersect = sphereIntersection(spheres[i], ray);
+        // Find nearest positive intersection
+        if (sphereIntersect > 0 &&
+                (sphereIntersect < closestIntersection
+                        || closestIntersection == 0)) {
+            closestIntersection = sphereIntersect;
+            intersectingObject = i;
         }
     }
 
     // If we hit something
     if (intersectingObject != -1) {
-	int BDRF = 0;
+        int BDRF = 0;
 
-	int nonSpecular = (1<<16) - spheres[intersectingObject].specularity;
-	int directLightingFactor = fp_mul((1<<16) -
-		fp_mul(spheres[intersectingObject].reflectivity, nonSpecular),
-		(1<<16) - fp_mul(spheres[intersectingObject].transparency, nonSpecular));
+        int nonSpecular = (1<<16) - spheres[intersectingObject].specularity;
+        int directLightingFactor = fp_mul((1<<16) -
+                fp_mul(spheres[intersectingObject].reflectivity, nonSpecular),
+                (1<<16) - fp_mul(spheres[intersectingObject].transparency, nonSpecular));
 
-	Vector3 colour = {0, 0, 0};
+        Vector3 colour = {0, 0, 0};
 
-	Vector3 collisionPoint = vecAdd(ray.origin, vecScalarMul(ray.direction, closestIntersection));
-	Vector3 surfaceNormal  = vecSub(collisionPoint, spheres[intersectingObject].position);
-	if (vecMagnitude(surfaceNormal) > 0) {
-	    surfaceNormal  = vecNorm(surfaceNormal, 1009);
-	} else {
-	    return nilColour;
-	}
+        Vector3 collisionPoint = vecAdd(ray.origin, vecScalarMul(ray.direction, closestIntersection));
+        Vector3 surfaceNormal  = vecSub(collisionPoint, spheres[intersectingObject].position);
+        if (vecMagnitude(surfaceNormal) > 0) {
+            surfaceNormal  = vecNorm(surfaceNormal, 1009);
+        } else {
+            return nilColour;
+        }
 
-	Vector3 inwardVector   = ray.direction;
+        Vector3 inwardVector   = ray.direction;
 
-	// Catch exit refraction case
-	if (vecMagnitude(vecSub(ray.origin, spheres[intersectingObject].position))
-		< spheres[intersectingObject].radius) {
-	    return traceRay(refractiveReflectanceFunction(collisionPoint,
-		    surfaceNormal, inwardVector, 0,
-		    spheres[intersectingObject].refractiveIndex, (1<<16), &BDRF),
-		    depth+1, terminationDepth, spheres, numberOfSpheres);
-        } else {	// not exit refraction, do all else
+        // Catch exit refraction case
+        if (vecMagnitude(vecSub(ray.origin, spheres[intersectingObject].position))
+                < spheres[intersectingObject].radius) {
+            return traceRay(refractiveReflectanceFunction(collisionPoint,
+                    surfaceNormal, inwardVector, 0,
+                    spheres[intersectingObject].refractiveIndex, (1<<16), &BDRF),
+                    depth+1, terminationDepth, spheres, numberOfSpheres);
+        } else {        // not exit refraction, do all else
             // If we hit a light, then BINGO, stop bouncing around
             if (vecMagnitude(spheres[intersectingObject].colourE) > 50) {
-        	return spheres[intersectingObject].colourE;
+                return spheres[intersectingObject].colourE;
             }
 
             // Calculate direct lighting
@@ -1036,56 +1036,56 @@ Vector3 traceRay(
             Vector3 directLighting = {0, 0, 0};
             int lightIndex;
             for (lightIndex=0; lightIndex<numberOfSpheres; lightIndex++) {
-        	if (vecMagnitude(spheres[lightIndex].colourE) < 10) {
-        	    continue; // not a light
-		}
-
-        	int lightVisible = 1; // Occlusion check
-
-        	// instead of using the light centre, pick a random point on it's surface
-        	Vector3 surfacePoint = {random1(), random1(), random1()};
-        	while (vecSum(surfacePoint) < 1000) {
-        	    surfacePoint.x = random1();
-        	    surfacePoint.y = random1();
-        	    surfacePoint.z = random1();
+                if (vecMagnitude(spheres[lightIndex].colourE) < 10) {
+                    continue; // not a light
                 }
-        	surfacePoint = vecNorm(surfacePoint, 1010);
-        	surfacePoint = vecAdd(spheres[lightIndex].position,
-        		vecScalarMul(surfacePoint, spheres[lightIndex].radius));
 
-        	Vector3 shadowRayDirection	= vecSub(surfacePoint, collisionPoint);
-        	int shadowRayLength		= vecMagnitude(shadowRayDirection);
-        	shadowRayDirection		= vecNorm(shadowRayDirection, 1011);
-        	Ray shadowRay = {collisionPoint, shadowRayDirection};
-        	shadowRay = rayNudge(shadowRay); // Nudge the ray along to stop it re-interacting with the same surface
+                int lightVisible = 1; // Occlusion check
 
-        	int visibility = 1<<16; // used to accumulate shadows from TRANSPARENT objects
+                // instead of using the light centre, pick a random point on it's surface
+                Vector3 surfacePoint = {random1(), random1(), random1()};
+                while (vecSum(surfacePoint) < 1000) {
+                    surfacePoint.x = random1();
+                    surfacePoint.y = random1();
+                    surfacePoint.z = random1();
+                }
+                surfacePoint = vecNorm(surfacePoint, 1010);
+                surfacePoint = vecAdd(spheres[lightIndex].position,
+                        vecScalarMul(surfacePoint, spheres[lightIndex].radius));
 
-        	int occludingObjectIndex;
-        	for (occludingObjectIndex=0; occludingObjectIndex<numberOfSpheres; occludingObjectIndex++) { // Check all objects for occlusion
-        	    if (lightIndex == occludingObjectIndex) { // a light can't occlude itself
-        		continue;
-		    }
-        	    // shadowIntersect < 0 if there is no intersection, otherwise it is the length along the ray at which the intersection happens
-        	    int shadowIntersect = sphereIntersection(spheres[occludingObjectIndex], shadowRay);
+                Vector3 shadowRayDirection      = vecSub(surfacePoint, collisionPoint);
+                int shadowRayLength             = vecMagnitude(shadowRayDirection);
+                shadowRayDirection              = vecNorm(shadowRayDirection, 1011);
+                Ray shadowRay = {collisionPoint, shadowRayDirection};
+                shadowRay = rayNudge(shadowRay); // Nudge the ray along to stop it re-interacting with the same surface
 
-        	    if (shadowIntersect >= 0 && shadowIntersect < shadowRayLength) { // If the light is ocluded
-        		if (spheres[occludingObjectIndex].transparency < 10) { // If the occluding object is opaque, stop checking
-        		    lightVisible = 0; // Opaque object blocks light
-        		    break;
+                int visibility = 1<<16; // used to accumulate shadows from TRANSPARENT objects
+
+                int occludingObjectIndex;
+                for (occludingObjectIndex=0; occludingObjectIndex<numberOfSpheres; occludingObjectIndex++) { // Check all objects for occlusion
+                    if (lightIndex == occludingObjectIndex) { // a light can't occlude itself
+                        continue;
+                    }
+                    // shadowIntersect < 0 if there is no intersection, otherwise it is the length along the ray at which the intersection happens
+                    int shadowIntersect = sphereIntersection(spheres[occludingObjectIndex], shadowRay);
+
+                    if (shadowIntersect >= 0 && shadowIntersect < shadowRayLength) { // If the light is ocluded
+                        if (spheres[occludingObjectIndex].transparency < 10) { // If the occluding object is opaque, stop checking
+                            lightVisible = 0; // Opaque object blocks light
+                            break;
                         }
-        		visibility = fp_frac(visibility,
-        			(2*spheres[occludingObjectIndex].transparency)/3); // Transparent object blocks some light
+                        visibility = fp_frac(visibility,
+                                (2*spheres[occludingObjectIndex].transparency)/3); // Transparent object blocks some light
                     }
                 }
-        	if (lightVisible) {
-        	    // Direct lighting
-        	    BDRF = materialBDRF(ray.direction, shadowRay.direction,
-        		    spheres[intersectingObject],  collisionPoint,
-			    surfaceNormal);
-        	    directLighting = vecAdd(directLighting,
-        		    vecScalarMul(vecScalarFrac(vecFrac(spheres[lightIndex].colourE,
-        			    spheres[intersectingObject].colourT), visibility), BDRF));
+                if (lightVisible) {
+                    // Direct lighting
+                    BDRF = materialBDRF(ray.direction, shadowRay.direction,
+                            spheres[intersectingObject],  collisionPoint,
+                            surfaceNormal);
+                    directLighting = vecAdd(directLighting,
+                            vecScalarMul(vecScalarFrac(vecFrac(spheres[lightIndex].colourE,
+                                    spheres[intersectingObject].colourT), visibility), BDRF));
                 }
             }
             // end of direct lighting calculation
@@ -1094,35 +1094,35 @@ Vector3 traceRay(
 
             // Calculate the indirect lighting
             if (depth < terminationDepth) {
-        	int sample, numberOfSamples;
-        	numberOfSamples = (depth==0 ? 4 : 1); // Take samples from ten directions on the first bounce, as those first bounces are more important
+                int sample, numberOfSamples;
+                numberOfSamples = (depth==0 ? 4 : 1); // Take samples from ten directions on the first bounce, as those first bounces are more important
 
-        	Vector3 indirectLighting = {0, 0, 0};
+                Vector3 indirectLighting = {0, 0, 0};
 
-        	for (sample = 0; sample<numberOfSamples; sample++) {
-        	    // new ray, according to the BRDF
-        	    Ray reflectedRay = reflectanceFunction(collisionPoint,
-        		    surfaceNormal, inwardVector,
-			    spheres[intersectingObject], &BDRF);
+                for (sample = 0; sample<numberOfSamples; sample++) {
+                    // new ray, according to the BRDF
+                    Ray reflectedRay = reflectanceFunction(collisionPoint,
+                            surfaceNormal, inwardVector,
+                            spheres[intersectingObject], &BDRF);
 
-        	    indirectLighting = vecAdd(indirectLighting,
-        		    vecScalarMul(vecMul(spheres[intersectingObject].colourT,
-				  traceRay(reflectedRay, depth + 1,
-					  terminationDepth, spheres,
-					  numberOfSpheres)), BDRF));
+                    indirectLighting = vecAdd(indirectLighting,
+                            vecScalarMul(vecMul(spheres[intersectingObject].colourT,
+                                  traceRay(reflectedRay, depth + 1,
+                                          terminationDepth, spheres,
+                                          numberOfSpheres)), BDRF));
                 }
 
-        	indirectLighting.x /= numberOfSamples;
-        	indirectLighting.y /= numberOfSamples;
-        	indirectLighting.z /= numberOfSamples;
+                indirectLighting.x /= numberOfSamples;
+                indirectLighting.y /= numberOfSamples;
+                indirectLighting.z /= numberOfSamples;
 
-        	colour = vecAdd(colour, indirectLighting);
+                colour = vecAdd(colour, indirectLighting);
             }
 
             return colour;
         }
     } else {
-	return vecClamp(black, 0, (255<<16));
+        return vecClamp(black, 0, (255<<16));
     }
 }
 
@@ -1155,18 +1155,18 @@ int aaInc = 1;
 
 // Do the full ray trace.  NodeID is used to determine the first pixel we care about.  Number of nodes is used to determine how far we jump
 void trace(int horizontalPixels, int verticalPixels, int horizontalFieldOfView,
-	int verticalFieldOfView, int antialiasing, int x, int y, int z,
-	int lookX, int lookY, int lookZ, int upX, int upY, int upZ,
-	int nodeID, int numberOfNodes)
+        int verticalFieldOfView, int antialiasing, int x, int y, int z,
+        int lookX, int lookY, int lookZ, int upX, int upY, int upZ,
+        int nodeID, int numberOfNodes)
 {
     int numberOfSpheres = sizeof(spheres) / sizeof(Sphere);
 
     // Camera
     Camera camera = {
-	{x, y, z},
-	{lookX, lookY, lookZ},
-	{upX, upY, upZ},
-	horizontalFieldOfView, verticalFieldOfView
+        {x, y, z},
+        {lookX, lookY, lookZ},
+        {upX, upY, upZ},
+        horizontalFieldOfView, verticalFieldOfView
     };
     camera.horizontalPixels = horizontalPixels;
     camera.verticalPixels   = verticalPixels;
@@ -1186,82 +1186,82 @@ void trace(int horizontalPixels, int verticalPixels, int horizontalFieldOfView,
     int iFirst = 0;
     int jFirst = nodeID;
     while (jFirst >= camera.verticalPixels) {
-	jFirst -= camera.verticalPixels;
-	iFirst += 1;
+        jFirst -= camera.verticalPixels;
+        iFirst += 1;
     }
     int overshoot = jFirst;
 
     // Main loop
     i = iFirst;
     while (i < camera.horizontalPixels) {
-	if (i == iFirst && actualAA <= camera.antialiasing) {
-	    aaInc++;
-	    if (aaInc>=2) {
-		actualAA++;
-		antialiasingStartPoint  = -(1<<16) + (1<<16)/camera.antialiasing; // antialiasing isn't bitshifted, so normal divide
-		antialiasingStepSize    = (2<<16)/camera.antialiasing;
-		aaInc=0;
+        if (i == iFirst && actualAA <= camera.antialiasing) {
+            aaInc++;
+            if (aaInc>=2) {
+                actualAA++;
+                antialiasingStartPoint  = -(1<<16) + (1<<16)/camera.antialiasing; // antialiasing isn't bitshifted, so normal divide
+                antialiasingStepSize    = (2<<16)/camera.antialiasing;
+                aaInc=0;
             }
-	    //io_printf(IO_STD, "%dx%d antialiasing, pass %d.\n", actualAA, actualAA, aaInc);
+            //io_printf(IO_STD, "%dx%d antialiasing, pass %d.\n", actualAA, actualAA, aaInc);
         }
 
-	uint iSegment1 = (i&upper8) >> 8; // for MC transmission
-	uint iSegment2 = (i&lower8) << 24;
+        uint iSegment1 = (i&upper8) >> 8; // for MC transmission
+        uint iSegment2 = (i&lower8) << 24;
 
-	// This gets a little messy because of the antialiasing, but we're really just iterating over sub-pixels, casting rays, and averaging over pixels
-	int k;
-	for (k=0; k<actualAA; k++) {
-	    horizontalInterpolations1[k] = vecAdd(vecScalarMul(topRightMinusTopLeft,
-		    ((i<<16)+(antialiasingStartPoint+antialiasingStepSize*k))/camera.horizontalPixels), camera.viewPlane.topLeft);
-	    horizontalInterpolations2[k] = vecAdd(vecScalarMul(bottomRightMinusBottomLeft,
-		    ((i<<16)+(antialiasingStartPoint+antialiasingStepSize*k))/camera.horizontalPixels), camera.viewPlane.bottomLeft);
+        // This gets a little messy because of the antialiasing, but we're really just iterating over sub-pixels, casting rays, and averaging over pixels
+        int k;
+        for (k=0; k<actualAA; k++) {
+            horizontalInterpolations1[k] = vecAdd(vecScalarMul(topRightMinusTopLeft,
+                    ((i<<16)+(antialiasingStartPoint+antialiasingStepSize*k))/camera.horizontalPixels), camera.viewPlane.topLeft);
+            horizontalInterpolations2[k] = vecAdd(vecScalarMul(bottomRightMinusBottomLeft,
+                    ((i<<16)+(antialiasingStartPoint+antialiasingStepSize*k))/camera.horizontalPixels), camera.viewPlane.bottomLeft);
         }
 
-	j = overshoot;
-	while (j < camera.verticalPixels) {
-	    Vector3 accumulatedColour = {0, 0, 0}; // to accumulate colours from sub-pixels (antialiasing)
-	    int numberSuccessful = 0;
+        j = overshoot;
+        while (j < camera.verticalPixels) {
+            Vector3 accumulatedColour = {0, 0, 0}; // to accumulate colours from sub-pixels (antialiasing)
+            int numberSuccessful = 0;
 
-	    for (k=0; k<actualAA; k++) {
-		// For repeated use in vertical interpolation
-		Vector3 horizontal2MinusHorizontal1 =
-			vecSub(horizontalInterpolations2[k], horizontalInterpolations1[k]);
+            for (k=0; k<actualAA; k++) {
+                // For repeated use in vertical interpolation
+                Vector3 horizontal2MinusHorizontal1 =
+                        vecSub(horizontalInterpolations2[k], horizontalInterpolations1[k]);
 
-		int va; // vertical antialiasing
-		for (va=0; va<actualAA; va++) {
-		    Vector3 rayDirection = vecNorm(vecAdd(vecScalarMul(horizontal2MinusHorizontal1,
-			    ((j<<16)+(antialiasingStartPoint+antialiasingStepSize*va))/camera.verticalPixels),
-			    horizontalInterpolations1[k]), 1012);
-		    Ray ray = {camera.position, rayDirection};
+                int va; // vertical antialiasing
+                for (va=0; va<actualAA; va++) {
+                    Vector3 rayDirection = vecNorm(vecAdd(vecScalarMul(horizontal2MinusHorizontal1,
+                            ((j<<16)+(antialiasingStartPoint+antialiasingStepSize*va))/camera.verticalPixels),
+                            horizontalInterpolations1[k]), 1012);
+                    Ray ray = {camera.position, rayDirection};
 
-		    Vector3 result = traceRay(ray, 0, 4, spheres, numberOfSpheres);
-		    if (result.x != -1) {
-			accumulatedColour = vecAdd(accumulatedColour, result);
-			numberSuccessful += 1;
+                    Vector3 result = traceRay(ray, 0, 4, spheres, numberOfSpheres);
+                    if (result.x != -1) {
+                        accumulatedColour = vecAdd(accumulatedColour, result);
+                        numberSuccessful += 1;
                     }
                 }
             }
 
-	    if (numberSuccessful != 0) {
-		Vector3 colour = vecScalarFrac(vecScalarFrac(accumulatedColour, (1<<16)/(numberSuccessful)), 1);
+            if (numberSuccessful != 0) {
+                Vector3 colour = vecScalarFrac(vecScalarFrac(accumulatedColour, (1<<16)/(numberSuccessful)), 1);
 
-		colour = vecClamp(colour, 0, 255);
+                colour = vecClamp(colour, 0, 255);
 
-		uint key     = (j<<16) | proc001Key | iSegment1;
-		uint payload = iSegment2 | (((uint)colour.x)<<16) | (((uint)colour.y)<<8) | ((uint)colour.z);
+                uint key     = (j<<16) | proc001Key | iSegment1;
+                uint payload = iSegment2 | (((uint)colour.x)<<16) | (((uint)colour.y)<<8) | ((uint)colour.z);
 
 #ifdef API
-		spin1_send_mc_packet(key, payload, 1);
+                spin1_send_mc_packet(key, payload, 1);
 #else
-		pkt_tx_kd(key, payload);
+                pkt_tx_kd(key, payload);
 #endif // API
             }
 
-	    // End of inner loop
-	    j += numberOfNodes;
-	    if (j >= camera.verticalPixels) {
-		overshoot = j - (j/camera.verticalPixels)*camera.verticalPixels;
-	    }
+            // End of inner loop
+            j += numberOfNodes;
+            if (j >= camera.verticalPixels) {
+                overshoot = j - (j/camera.verticalPixels)*camera.verticalPixels;
+            }
         }
 
         i++;
@@ -1279,76 +1279,76 @@ void sdp_packet_callback(uint msg, uint port)
     io_printf(IO_BUF, "SDP cmd %d\n", sdp_msg->cmd_rc);
 
     if (sdp_msg->cmd_rc == 4) { // if it's a trace message
-	int camx = 0, camy = 0, camz = 0, lookx = 0, looky = 0, lookz = 0, upx = 0;
-	int upy = 0, upz = 0, width = 0, height = 0, hField = 0, vField = 0;
-	int antialiasing = 0, nodeID=0, numberOfNodes=16;
+        int camx = 0, camy = 0, camz = 0, lookx = 0, looky = 0, lookz = 0, upx = 0;
+        int upy = 0, upz = 0, width = 0, height = 0, hField = 0, vField = 0;
+        int antialiasing = 0, nodeID=0, numberOfNodes=16;
 
-	for (int i=0; i<(sdp_msg->length-24)/4; i++) {
-	    int var = 0;
-	    var += (sdp_msg->data[i*4]<<0);
-	    var += (sdp_msg->data[i*4+1]<<8);
-	    var += (sdp_msg->data[i*4+2]<<16);
-	    var += (sdp_msg->data[i*4+3]<<24);
+        for (int i=0; i<(sdp_msg->length-24)/4; i++) {
+            int var = 0;
+            var += (sdp_msg->data[i*4]<<0);
+            var += (sdp_msg->data[i*4+1]<<8);
+            var += (sdp_msg->data[i*4+2]<<16);
+            var += (sdp_msg->data[i*4+3]<<24);
 
-	    switch (i) {
-	    case 0: camx = var; break;
-	    case 1: camy = var; break;
-	    case 2: camz = var; break;
-	    case 3: lookx = var; break;
-	    case 4: looky = var; break;
-	    case 5: lookz = var; break;
-	    case 6: upx = var; break;
-	    case 7: upy = var; break;
-	    case 8: upz = var; break;
-	    case 9: width = var; break;
-	    case 10: height = var; break;
-	    case 11: hField = var; break;
-	    case 12: vField = var; break;
-	    case 13: antialiasing = var; break;
-	    case 14: nodeID = var; break;
-	    case 15: numberOfNodes = var; break;
+            switch (i) {
+            case 0: camx = var; break;
+            case 1: camy = var; break;
+            case 2: camz = var; break;
+            case 3: lookx = var; break;
+            case 4: looky = var; break;
+            case 5: lookz = var; break;
+            case 6: upx = var; break;
+            case 7: upy = var; break;
+            case 8: upz = var; break;
+            case 9: width = var; break;
+            case 10: height = var; break;
+            case 11: hField = var; break;
+            case 12: vField = var; break;
+            case 13: antialiasing = var; break;
+            case 14: nodeID = var; break;
+            case 15: numberOfNodes = var; break;
             }
         }
 
-	//io_printf(IO_STD, "x %d \ny %d \nz  %d \nx  %d \ny  %d \nz  %d \nx  %d \ny  %d \nz  %d \nw  %d \nh  %d \nhF  %d \nvF  %d \naa  %d \nid  %d \nnum  %d \n ",
-	//          camx, camy, camz, lookx, looky, lookz, upx, upy, upz, width, height, hField, vField, antialiasing, nodeID, numberOfNodes);
+        //io_printf(IO_STD, "x %d \ny %d \nz  %d \nx  %d \ny  %d \nz  %d \nx  %d \ny  %d \nz  %d \nw  %d \nh  %d \nhF  %d \nvF  %d \naa  %d \nid  %d \nnum  %d \n ",
+        //          camx, camy, camz, lookx, looky, lookz, upx, upy, upz, width, height, hField, vField, antialiasing, nodeID, numberOfNodes);
 
-	//io_printf(IO_STD, "I am core %d %d %d.  I've been told I'm node %d of %d.\n",
-	//          (spin1_get_chip_id()&secondByte)>>8, spin1_get_chip_id()&firstByte, spin1_get_core_id(), nodeID, numberOfNodes);
+        //io_printf(IO_STD, "I am core %d %d %d.  I've been told I'm node %d of %d.\n",
+        //          (spin1_get_chip_id()&secondByte)>>8, spin1_get_chip_id()&firstByte, spin1_get_core_id(), nodeID, numberOfNodes);
 
-	sark_delay_us(1000 * sark_core_id());
+        sark_delay_us(1000 * sark_core_id());
 
-	sdp_msg->cmd_rc     = 5; // trace ack
-	uchar temp_port     = sdp_msg->srce_port;
-	ushort temp_addr    = sdp_msg->srce_addr;
-	sdp_msg->srce_port = sdp_msg->dest_port;
-	sdp_msg->srce_addr = sdp_msg->dest_addr;
-	sdp_msg->dest_port = temp_port;
-	sdp_msg->dest_addr = temp_addr;
-	sdp_msg->length    = SDP_HEADER_SIZE;
-	sark_msg_send(sdp_msg, 10); // reply
+        sdp_msg->cmd_rc     = 5; // trace ack
+        uchar temp_port     = sdp_msg->srce_port;
+        ushort temp_addr    = sdp_msg->srce_addr;
+        sdp_msg->srce_port = sdp_msg->dest_port;
+        sdp_msg->srce_addr = sdp_msg->dest_addr;
+        sdp_msg->dest_port = temp_port;
+        sdp_msg->dest_addr = temp_addr;
+        sdp_msg->length    = SDP_HEADER_SIZE;
+        sark_msg_send(sdp_msg, 10); // reply
 
 #ifdef API
-	spin1_callback_off(SDP_PACKET_RX);
+        spin1_callback_off(SDP_PACKET_RX);
 #else
-	event_enable(EVENT_SDP, 0);
+        event_enable(EVENT_SDP, 0);
 #endif
-	sark_delay_us(800000 + 32000 * sark_core_id());
+        sark_delay_us(800000 + 32000 * sark_core_id());
 
-	trace(width, height, hField, vField, antialiasing, camx, camy, camz,
-		lookx, looky, lookz, upx, upy, upz, nodeID, numberOfNodes);
+        trace(width, height, hField, vField, antialiasing, camx, camy, camz,
+                lookx, looky, lookz, upx, upy, upz, nodeID, numberOfNodes);
     } else if (sdp_msg->cmd_rc == 6) { // status request
-	sark_delay_us(1000 * sark_core_id());
+        sark_delay_us(1000 * sark_core_id());
 
-	sdp_msg->cmd_rc     = 7; // status ack
-	uchar temp_port     = sdp_msg->srce_port;
-	ushort temp_addr    = sdp_msg->srce_addr;
-	sdp_msg->srce_port = sdp_msg->dest_port;
-	sdp_msg->srce_addr = sdp_msg->dest_addr;
-	sdp_msg->dest_port = temp_port;
-	sdp_msg->dest_addr = temp_addr;
+        sdp_msg->cmd_rc     = 7; // status ack
+        uchar temp_port     = sdp_msg->srce_port;
+        ushort temp_addr    = sdp_msg->srce_addr;
+        sdp_msg->srce_port = sdp_msg->dest_port;
+        sdp_msg->srce_addr = sdp_msg->dest_addr;
+        sdp_msg->dest_port = temp_port;
+        sdp_msg->dest_addr = temp_addr;
 
-	sark_msg_send(sdp_msg, 10); // reply
+        sark_msg_send(sdp_msg, 10); // reply
     }
 
     sark_msg_free(sdp_msg);
@@ -1358,7 +1358,7 @@ void sdp_packet_callback(uint msg, uint port)
 void load_mc_routing_tables()
 {
     if (sark_core_id() != sark_app_lead()) {
-	return;
+        return;
     }
 
     //!!  uint xy = sark_chip_id();
@@ -1371,7 +1371,7 @@ void load_mc_routing_tables()
 
     uint e = rtr_alloc(1);
     if (e == 0) {
-	rt_error(RTE_ABORT);
+        rt_error(RTE_ABORT);
     }
 
     // Routing table entry for sending pixel packets to core 1 of the root chip

--- a/apps/random/random.c
+++ b/apps/random/random.c
@@ -16,7 +16,7 @@
 
 void queue_proc(uint colour, uint time)
 {
-    char *s = (colour) ? "white" : "black";	// Make a colour string
+    char *s = (colour) ? "white" : "black";     // Make a colour string
 
     io_printf(IO_STD, "#%s;#fill;#red;%d\n", s, time); // And print it
 }
@@ -32,13 +32,13 @@ void queue_proc(uint colour, uint time)
 
 void timer_proc(uint colour, uint b)
 {
-    uint rand = sark_rand() & 255;		// Get next random period
+    uint rand = sark_rand() & 255;              // Get next random period
 
-    colour = !colour;				// Flip the colour
+    colour = !colour;                           // Flip the colour
 
     event_queue_proc(queue_proc, colour, rand, PRIO_0); // Queue printing
 
-    io_printf(IO_BUF, "Timer next %d\n", rand);	// Do buffered printing
+    io_printf(IO_BUF, "Timer next %d\n", rand); // Do buffered printing
 
     // Reschedule ourselves again
 
@@ -60,16 +60,16 @@ void timer_proc(uint colour, uint b)
 
 void c_main(void)
 {
-    uint core = sark_core_id();				// Get core ID
-    io_printf(IO_BUF, "Started core %d\n", core);	// and print it
+    uint core = sark_core_id();                         // Get core ID
+    io_printf(IO_BUF, "Started core %d\n", core);       // and print it
 
     sark_srand((sark_chip_id() << 8) + core * sv->time_ms); // Init randgen
 
-    event_register_timer(SLOT_0);		// Set up the timer event mechanism
+    event_register_timer(SLOT_0);               // Set up the timer event mechanism
 
     event_queue_proc(timer_proc, 0, 0, PRIO_0); // Queue the first timer call
 
-    uint rc = event_start(0, 0, SYNC_NOWAIT);	// Start event handling
+    uint rc = event_start(0, 0, SYNC_NOWAIT);   // Start event handling
 
     io_printf(IO_BUF, "Terminated rc %d\n", rc);// Printed if event_stop used...
 }

--- a/apps/ring/ring.c
+++ b/apps/ring/ring.c
@@ -14,7 +14,7 @@
 #include <sark.h>
 
 
-uint core;	// Core ID of this core
+uint core;      // Core ID of this core
 
 
 // This "proc" is called when a scheduled timer delay elapses.  It
@@ -29,9 +29,9 @@ void timer_proc(uint count, uint none)
     io_printf(IO_BUF, "# timer_proc %d\n", count);
 
     if (count > 128) {
-	event_stop(0);
+        event_stop(0);
     } else {
-	pkt_tx_kd(core, count + 1);
+        pkt_tx_kd(core, count + 1);
     }
 }
 
@@ -67,7 +67,7 @@ void c_main(void)
 
     // Say hello...
     io_printf(IO_BUF, "# App \"%s\" on core %d (AppID %d)\n",
-	    app_name, core, app_id);
+            app_name, core, app_id);
 
     // Initialise User variables
     sark.vcpu->user0 = sark.vcpu->user1 = 0;
@@ -77,7 +77,7 @@ void c_main(void)
 
     uint e = rtr_alloc(1);
     if (e == 0) {
-	rt_error(RTE_ABORT);
+        rt_error(RTE_ABORT);
     }
 
     uint next = (core == 16) ? 1 : core + 1;
@@ -91,7 +91,7 @@ void c_main(void)
 
     // If we are core 1 then set things going by placing an event on the queue
     if (core == 1) {
-	event_queue_proc(timer_proc, 0, 0, PRIO_0);
+        event_queue_proc(timer_proc, 0, 0, PRIO_0);
     }
 
     // Start event processing but wait for SYNC0

--- a/apps/sdping/sdping.c
+++ b/apps/sdping/sdping.c
@@ -54,24 +54,24 @@ void process_sdp(uint m, uint port)
 
     io_printf(IO_STD, "SDP len %d, port %d - %s\n", msg->length, port, msg->data);
 
-    if (port == 1) {		// Port 1 - echo to sender
-	swap_sdp_hdr(msg);
-	(void) spin1_send_sdp_msg(msg, 10);
-    } else if (port == 2) {	// Port 2 - send via IPTAG 1
-	msg->tag = 1;				// IPTag 1
-	msg->dest_port = PORT_ETH;		// Ethernet
-	msg->dest_addr = sv->dbg_addr; 		// Root chip
-	msg->flags = 0x07;			// Flags = 7
-	msg->srce_port = spin1_get_core_id();	// Source port
-	msg->srce_addr = spin1_get_chip_id();	// Source addr
+    if (port == 1) {            // Port 1 - echo to sender
+        swap_sdp_hdr(msg);
+        (void) spin1_send_sdp_msg(msg, 10);
+    } else if (port == 2) {     // Port 2 - send via IPTAG 1
+        msg->tag = 1;                           // IPTag 1
+        msg->dest_port = PORT_ETH;              // Ethernet
+        msg->dest_addr = sv->dbg_addr;          // Root chip
+        msg->flags = 0x07;                      // Flags = 7
+        msg->srce_port = spin1_get_core_id();   // Source port
+        msg->srce_addr = spin1_get_chip_id();   // Source addr
 
-	(void) spin1_send_sdp_msg(msg, 10);
+        (void) spin1_send_sdp_msg(msg, 10);
     }
 
     spin1_msg_free(msg);
 
     if (port == 7) {
-	spin1_exit(0);
+        spin1_exit(0);
     }
 }
 

--- a/apps/simple/simple.c
+++ b/apps/simple/simple.c
@@ -81,13 +81,13 @@ void app_init()
 
     uint e = rtr_alloc(1);
     if (e == 0) {
-	rt_error(RTE_ABORT);
+        rt_error(RTE_ABORT);
     }
 
-    rtr_mc_set(e,			// entry
-	    coreID, 			// key
-	    0xffffffff,			// mask
-	    MC_CORE_ROUTE(coreID));	// route
+    rtr_mc_set(e,                       // entry
+            coreID,                     // key
+            0xffffffff,                 // mask
+            MC_CORE_ROUTE(coreID));     // route
 
     /* ------------------------------------------------------------------- */
     /* initialize the application processor resources                      */
@@ -99,29 +99,29 @@ void app_init()
 
     // Allocate a buffer in System RAM
     sysram_buffer = (uint *) sark_xalloc(sv->sysram_heap,
-	    BUFFER_SIZE * sizeof(uint), 0, ALLOC_LOCK);
+            BUFFER_SIZE * sizeof(uint), 0, ALLOC_LOCK);
 
     // and a buffer somewhere in SDRAM
     sdram_buffer = (uint *) sark_xalloc(sv->sdram_heap,
-	    BUFFER_SIZE * sizeof(uint), 0, ALLOC_LOCK);
+            BUFFER_SIZE * sizeof(uint), 0, ALLOC_LOCK);
 
     // and a buffer in DTCM
     dtcm_buffer = (uint *) sark_alloc(BUFFER_SIZE, sizeof(uint));
 
     if (dtcm_buffer == NULL ||  sdram_buffer == NULL || sysram_buffer == NULL) {
-	test_DMA = FALSE;
-	io_printf(IO_BUF, "[core %d] error - cannot allocate buffer\n", coreID);
+        test_DMA = FALSE;
+        io_printf(IO_BUF, "[core %d] error - cannot allocate buffer\n", coreID);
     } else {
-	test_DMA = TRUE;
-	// initialize sections of DTCM, system RAM and SDRAM
-	for (uint i = 0; i < BUFFER_SIZE; i++) {
-	    dtcm_buffer[i]   = i;
-	    sysram_buffer[i] = 0xa5a5a5a5;
-	    sdram_buffer[i]  = 0x5a5a5a5a;
-	}
+        test_DMA = TRUE;
+        // initialize sections of DTCM, system RAM and SDRAM
+        for (uint i = 0; i < BUFFER_SIZE; i++) {
+            dtcm_buffer[i]   = i;
+            sysram_buffer[i] = 0xa5a5a5a5;
+            sdram_buffer[i]  = 0x5a5a5a5a;
+        }
 
-	io_printf(IO_BUF, "[core %d] dtcm buffer @ 0x%08x\n", coreID,
-		(uint) dtcm_buffer);
+        io_printf(IO_BUF, "[core %d] dtcm buffer @ 0x%08x\n", coreID,
+                (uint) dtcm_buffer);
     }
 }
 /*
@@ -161,10 +161,10 @@ void app_done()
     io_printf(IO_BUF, "[core %d] failed %d DMA transfers\n", coreID, tfailed);
 
     if (tfailed) {
-	io_printf(IO_BUF, "\t%d : %d @ %d\n", tfvald, tfvals, tfaddr);
+        io_printf(IO_BUF, "\t%d : %d @ %d\n", tfvald, tfvals, tfaddr);
 
-	io_printf(IO_BUF, "\t%d : %d @ %d\n", dtcm_buffer[tfaddr],
-		sdram_buffer[tfaddr], tfaddr);
+        io_printf(IO_BUF, "\t%d : %d @ %d\n", dtcm_buffer[tfaddr],
+                sdram_buffer[tfaddr], tfaddr);
     }
 
     // say goodbye
@@ -193,9 +193,9 @@ void app_done()
 void send_packets(uint ticks, uint none)
 {
     for (uint i = 0; i < ITER_TIMES; i++) {
-	if (! spin1_send_mc_packet(coreID, ticks, 1)) {
-	    pfailed++;
-	}
+        if (! spin1_send_mc_packet(coreID, ticks, 1)) {
+            pfailed++;
+        }
     }
 }
 /*
@@ -223,19 +223,19 @@ void flip_led(uint ticks, uint null)
     // Only 1 core should flip leds!
 
     if (leadAp) {
-	spin1_led_control(LED_INV(1));
+        spin1_led_control(LED_INV(1));
     }
 
     // trigger user event to send packets
 
     if (spin1_trigger_user_event(ticks, NULL) == FAILURE) {
-	ufailed++;
+        ufailed++;
     }
 
     // stop if desired number of ticks reached
 
     if (ticks >= TOTAL_TICKS) {
-	spin1_exit(0);
+        spin1_exit(0);
     }
 }
 /*
@@ -260,11 +260,11 @@ void flip_led(uint ticks, uint null)
 void do_transfer(uint val, uint none)
 {
     if (val == 3) {
-	spin1_dma_transfer(DMA_WRITE, sysram_buffer, dtcm_buffer, DMA_WRITE,
-		BUFFER_SIZE*sizeof(uint));
+        spin1_dma_transfer(DMA_WRITE, sysram_buffer, dtcm_buffer, DMA_WRITE,
+                BUFFER_SIZE*sizeof(uint));
     } else if (val == 5) {
-	spin1_dma_transfer(DMA_WRITE, sdram_buffer, dtcm_buffer, DMA_WRITE,
-		BUFFER_SIZE*sizeof(uint));
+        spin1_dma_transfer(DMA_WRITE, sdram_buffer, dtcm_buffer, DMA_WRITE,
+                BUFFER_SIZE*sizeof(uint));
     }
 }
 /*
@@ -293,8 +293,8 @@ void count_packets(uint key, uint payload)
 
     // if testing DMA trigger transfer requests at the right time
     if (test_DMA) {
-	// schedule task (with priority 1) to trigger DMA
-	spin1_schedule_callback(do_transfer, payload, 0, 1);
+        // schedule task (with priority 1) to trigger DMA
+        spin1_schedule_callback(do_transfer, payload, 0, 1);
     }
 }
 /*
@@ -324,25 +324,25 @@ void check_memcopy(uint tid, uint ttag)
 
     // check if DMA transfer completed correctly
     if (tid <= ITER_TIMES) {
-	for (uint i = 0; i < BUFFER_SIZE; i++) {
-	    if (dtcm_buffer[i] != sysram_buffer[i]) {
-		tfailed++;
-		tfaddr = i;
-		break;
-	    }
-	}
+        for (uint i = 0; i < BUFFER_SIZE; i++) {
+            if (dtcm_buffer[i] != sysram_buffer[i]) {
+                tfailed++;
+                tfaddr = i;
+                break;
+            }
+        }
     }
 
     if (tid > ITER_TIMES) {
-	for (uint i = 0; i < BUFFER_SIZE; i++) {
-	    tfvald = dtcm_buffer[i];
-	    tfvals = sdram_buffer[i];
-	    if (tfvald != tfvals) {
-		tfailed++;
-		tfaddr = i;
-		break;
-	    }
-	}
+        for (uint i = 0; i < BUFFER_SIZE; i++) {
+            tfvald = dtcm_buffer[i];
+            tfvals = sdram_buffer[i];
+            if (tfvald != tfvals) {
+                tfailed++;
+                tfaddr = i;
+                break;
+            }
+        }
     }
 }
 /*
@@ -370,7 +370,7 @@ void c_main()
     // Say hello...
 
     io_printf(IO_BUF, ">> simple - chip (%d, %d) core %d\n",
-	    chipID >> 8, chipID & 255, coreID);
+            chipID >> 8, chipID & 255, coreID);
 
     // set timer tick value (in microseconds)
 

--- a/bmp/bmp.h
+++ b/bmp/bmp.h
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp.h	    Low-level hardware interface code for BMP LPC1768
+// bmp.h            Low-level hardware interface code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2016
 //
@@ -18,14 +18,14 @@
 
 //------------------------------------------------------------------------------
 
-#define BMP_VER_STR		SLLT_VER_STR
-#define BMP_VER_NUM		SLLT_VER_NUM
+#define BMP_VER_STR             SLLT_VER_STR
+#define BMP_VER_NUM             SLLT_VER_NUM
 
-#define BMP_ID_STR		"BC&MP/Spin5-BMP"
+#define BMP_ID_STR              "BC&MP/Spin5-BMP"
 
 //------------------------------------------------------------------------------
 
-#define CCLK			100000000	// CPU clock - 100 MHz
+#define CCLK                    100000000       // CPU clock - 100 MHz
 
 #ifndef NULL
 #define NULL 0
@@ -33,102 +33,102 @@
 
 //------------------------------------------------------------------------------
 
-#define LED_0 	    		(1 << 4)	// Green
-#define LED_1 	    		(1 << 5)	// Orange
-#define LED_2 	    		(1 << 19)	// Red
-#define LED_3 	    		(1 << 20)	// Green
-#define LED_4 	    		(1 << 21)	// Green
-#define LED_5 	    		(1 << 22)	// Green
-#define LED_6	    		(1 << 29)	// Green
-#define LED_7 	    		(1 << 30)	// Red
+#define LED_0                   (1 << 4)        // Green
+#define LED_1                   (1 << 5)        // Orange
+#define LED_2                   (1 << 19)       // Red
+#define LED_3                   (1 << 20)       // Green
+#define LED_4                   (1 << 21)       // Green
+#define LED_5                   (1 << 22)       // Green
+#define LED_6                   (1 << 29)       // Green
+#define LED_7                   (1 << 30)       // Red
 
-#define LED_MASK    		(LED_0 + LED_1 + LED_2 + LED_3 + \
+#define LED_MASK                (LED_0 + LED_1 + LED_2 + LED_3 + \
                                  LED_4 + LED_5 + LED_6 + LED_7)
 
-#define SF_NCS      		(1 << 16)
+#define SF_NCS                  (1 << 16)
 
-#define XFSEL_0     		(1 << 25)	// Port 3
-#define XFSEL_1     		(1 << 26)	// Port 3
-#define XFSEL_2     		(1 << 29)	// Port 4
-
-//------------------------------------------------------------------------------
-
-#define NUM_FPGAS		3
-
-#define FPGA_READ		0
-#define FPGA_WRITE		1
+#define XFSEL_0                 (1 << 25)       // Port 3
+#define XFSEL_1                 (1 << 26)       // Port 3
+#define XFSEL_2                 (1 << 29)       // Port 4
 
 //------------------------------------------------------------------------------
 
-#define CMD_VER			0
-#define CMD_RUN			1
-#define CMD_READ		2
-#define CMD_WRITE		3
-#define CMD_FILL		5
+#define NUM_FPGAS               3
 
-#define CMD_FPGA_READ  		17	// SPI interface to FPGAs
-#define CMD_FPGA_WRITE 		18	//
+#define FPGA_READ               0
+#define FPGA_WRITE              1
 
-#define CMD_LED 		25
-#define CMD_IPTAG 		26
+//------------------------------------------------------------------------------
 
-#define CMD_BMP_INFO		48
-#define CMD_FLASH_COPY		49
-#define CMD_FLASH_ERASE		50
-#define CMD_FLASH_WRITE		51
-#define CMD_XXX_52		52
-#define CMD_BMP_SF		53
-#define CMD_BMP_EE		54
-#define CMD_RESET		55
-#define CMD_XILINX		56
-#define CMD_POWER		57
+#define CMD_VER                 0
+#define CMD_RUN                 1
+#define CMD_READ                2
+#define CMD_WRITE               3
+#define CMD_FILL                5
 
-#define CMD_BMP_TEST	        63
+#define CMD_FPGA_READ           17      // SPI interface to FPGAs
+#define CMD_FPGA_WRITE          18      //
 
-#define CMD_TUBE  		64
+#define CMD_LED                 25
+#define CMD_IPTAG               26
+
+#define CMD_BMP_INFO            48
+#define CMD_FLASH_COPY          49
+#define CMD_FLASH_ERASE         50
+#define CMD_FLASH_WRITE         51
+#define CMD_XXX_52              52
+#define CMD_BMP_SF              53
+#define CMD_BMP_EE              54
+#define CMD_RESET               55
+#define CMD_XILINX              56
+#define CMD_POWER               57
+
+#define CMD_BMP_TEST            63
+
+#define CMD_TUBE                64
 
 
-#define TYPE_BYTE 		0
-#define TYPE_HALF 		1
-#define TYPE_WORD 		2
+#define TYPE_BYTE               0
+#define TYPE_HALF               1
+#define TYPE_WORD               2
 
-#define RC_OK 			0x80	// Command completed OK
-#define RC_LEN 			0x81	// Bad packet length
-#define RC_SUM 			0x82	// Bad checksum
-#define RC_CMD 			0x83	// Bad/invalid command
-#define RC_ARG     		0x84	// Invalid arguments
+#define RC_OK                   0x80    // Command completed OK
+#define RC_LEN                  0x81    // Bad packet length
+#define RC_SUM                  0x82    // Bad checksum
+#define RC_CMD                  0x83    // Bad/invalid command
+#define RC_ARG                  0x84    // Invalid arguments
 
-#define RC_OK 			0x80	// Command completed OK
-#define RC_LEN 			0x81	// Bad packet length
-#define RC_SUM 			0x82	// Bad checksum
-#define RC_CMD 			0x83	// Bad/invalid command
-#define RC_ARG     		0x84	// Invalid arguments
-#define RC_PORT	 		0x85	// Bad port number
-#define RC_TIMEOUT 		0x86	// Timeout
-#define RC_ROUTE 		0x87	// No P2P route
-#define RC_CPU	 		0x88	// Bad CPU number
+#define RC_OK                   0x80    // Command completed OK
+#define RC_LEN                  0x81    // Bad packet length
+#define RC_SUM                  0x82    // Bad checksum
+#define RC_CMD                  0x83    // Bad/invalid command
+#define RC_ARG                  0x84    // Invalid arguments
+#define RC_PORT                 0x85    // Bad port number
+#define RC_TIMEOUT              0x86    // Timeout
+#define RC_ROUTE                0x87    // No P2P route
+#define RC_CPU                  0x88    // Bad CPU number
 
-#define BOARD_MASK		31
+#define BOARD_MASK              31
 
-#define FLASH_BYTES		4096	// Size of flash buffer
-#define FLASH_WORDS		1024
+#define FLASH_BYTES             4096    // Size of flash buffer
+#define FLASH_WORDS             1024
 
 // IPTAG definitions
 
-#define IPTAG_NEW		0
-#define IPTAG_SET		1
-#define IPTAG_GET		2
-#define IPTAG_CLR		3
-#define IPTAG_TTO		4
+#define IPTAG_NEW               0
+#define IPTAG_SET               1
+#define IPTAG_GET               2
+#define IPTAG_CLR               3
+#define IPTAG_TTO               4
 
-#define IPTAG_MAX		4
+#define IPTAG_MAX               4
 
-#define IPTAG_VALID		0x8000	// Entry is valid
-#define IPTAG_TRANS		0x4000	// Entry is transient
-#define IPTAG_ARP		0x2000	// Awaiting ARP resolution
+#define IPTAG_VALID             0x8000  // Entry is valid
+#define IPTAG_TRANS             0x4000  // Entry is transient
+#define IPTAG_ARP               0x2000  // Awaiting ARP resolution
 
-#define TAG_NONE  		255	// Invalid tag/transient request
-#define TAG_HOST 		0	// Reserved for host
+#define TAG_NONE                255     // Invalid tag/transient request
+#define TAG_HOST                0       // Reserved for host
 
 
 #define TAG_FIXED_SIZE          8       // At bottom of table
@@ -138,10 +138,10 @@
 #define LAST_POOL_TAG           (TAG_FIXED_SIZE + TAG_POOL_SIZE - 1)
 
 #define TAG_TABLE_SIZE          (TAG_FIXED_SIZE + TAG_POOL_SIZE)
-#define SDPF_REPLY		0x80
+#define SDPF_REPLY              0x80
 
 
-typedef struct {		// IPTAG entry (24 bytes)
+typedef struct {                // IPTAG entry (24 bytes)
     uint8_t ip[4];
     uint8_t mac[6];
     uint16_t port;
@@ -153,13 +153,13 @@ typedef struct {		// IPTAG entry (24 bytes)
 
 //------------------------------------------------------------------------------
 
-#define PORT_SHIFT		5
-#define PORT_MASK		7
-#define BOARD_MASK		31
+#define PORT_SHIFT              5
+#define PORT_MASK               7
+#define BOARD_MASK              31
 
-#define PORT_ETH 		(7 << PORT_SHIFT)	// Port 7
+#define PORT_ETH                (7 << PORT_SHIFT)       // Port 7
 
-#define SDP_BUF_SIZE 		256
+#define SDP_BUF_SIZE            256
 
 // ------------------------------------------------------------------------
 // SDP type definitions
@@ -168,56 +168,56 @@ typedef struct {		// IPTAG entry (24 bytes)
 // the checksum. It will be a minimum of 8 as the SDP header
 // should always be present.
 
-typedef struct sdp_msg {	// SDP message (=292 bytes)
-    struct sdp_msg *next;	// Next in free list
-    uint16_t length;		// length
-    uint16_t checksum;		// checksum (if used)
+typedef struct sdp_msg {        // SDP message (=292 bytes)
+    struct sdp_msg *next;       // Next in free list
+    uint16_t length;            // length
+    uint16_t checksum;          // checksum (if used)
 
     // sdp_hdr_t
 
-    uint8_t flags;		// SDP flag byte
-    uint8_t tag;		// SDP IPtag
-    uint8_t dest_port;		// SDP destination port/CPU
-    uint8_t srce_port;		// SDP source port/CPU
-    uint16_t dest_addr;		// SDP destination address
-    uint16_t srce_addr;		// SDP source address
+    uint8_t flags;              // SDP flag byte
+    uint8_t tag;                // SDP IPtag
+    uint8_t dest_port;          // SDP destination port/CPU
+    uint8_t srce_port;          // SDP source port/CPU
+    uint16_t dest_addr;         // SDP destination address
+    uint16_t srce_addr;         // SDP source address
 
     // cmd_hdr_t (optional)
 
-    uint16_t cmd_rc;		// Command/Return Code
-    uint16_t seq;		// Sequence number
-    uint32_t arg1;		// Arg 1
-    uint32_t arg2;		// Arg 2
-    uint32_t arg3;		// Arg 3
+    uint16_t cmd_rc;            // Command/Return Code
+    uint16_t seq;               // Sequence number
+    uint32_t arg1;              // Arg 1
+    uint32_t arg2;              // Arg 2
+    uint32_t arg3;              // Arg 3
 
     // user data (optional)
 
-    uint8_t data[SDP_BUF_SIZE];	// User data (256 bytes)
+    uint8_t data[SDP_BUF_SIZE]; // User data (256 bytes)
 
-    uint32_t _PAD;		// Private padding
+    uint32_t _PAD;              // Private padding
 } sdp_msg_t;
 
 //------------------------------------------------------------------------------
 
-#define IO_STD 		((char *) 0)		// Stream numbers
-#define IO_DBG   	((char *) 1)
-#define IO_LCD   	((char *) 2)
-#define IO_NULL    	((char *) 3)
+#define IO_STD          ((char *) 0)            // Stream numbers
+#define IO_DBG          ((char *) 1)
+#define IO_LCD          ((char *) 2)
+#define IO_NULL         ((char *) 3)
 
-#define LCD_POS(x, y)	(0x80 + (y) * 64 + (x))
+#define LCD_POS(x, y)   (0x80 + (y) * 64 + (x))
 
 //------------------------------------------------------------------------------
 
-#define FL_DIR_SIZE 	16		// Number of fl_dir entries
+#define FL_DIR_SIZE     16              // Number of fl_dir entries
 
 // Values in fl_dir->type
 
-#define FL_BMP_IP	1
-#define FL_SPIN_IP 	2
-#define FL_FPGA      	3
-#define FL_XREG      	4
+#define FL_BMP_IP       1
+#define FL_SPIN_IP      2
+#define FL_FPGA         3
+#define FL_XREG         4
 
-typedef struct {	// 128 bytes
+typedef struct {        // 128 bytes
     uint8_t type;
     uint8_t size;
     uint16_t flags;
@@ -231,41 +231,41 @@ typedef struct {	// 128 bytes
     uint8_t data[96];
 } fl_dir_t;
 
-typedef struct {	// 256 bytes
-    uint8_t marker;		// 0 0x96
-    uint8_t sw_ver;		// 1 EE Data format version
-    uint8_t hw_ver;		// 2 Backplane HW version (0..7)
-    uint8_t frame_ID;		// 3 Frame Identifier
+typedef struct {        // 256 bytes
+    uint8_t marker;             // 0 0x96
+    uint8_t sw_ver;             // 1 EE Data format version
+    uint8_t hw_ver;             // 2 Backplane HW version (0..7)
+    uint8_t frame_ID;           // 3 Frame Identifier
 
-    uint32_t mod_date;		// 4 Date written
-    uint8_t gw_addr[4];		// 8 Gateway address (& IP base)
-    uint8_t flags;		// 12 8 flag bits
-    uint8_t mask_bits;		// 13 IP mask bits (0..31)
-    uint8_t mac_byte;		// 14 Byte 1 of MAC address
-    uint8_t LCD_time;		// 15 Time (secs) for initial display
+    uint32_t mod_date;          // 4 Date written
+    uint8_t gw_addr[4];         // 8 Gateway address (& IP base)
+    uint8_t flags;              // 12 8 flag bits
+    uint8_t mask_bits;          // 13 IP mask bits (0..31)
+    uint8_t mac_byte;           // 14 Byte 1 of MAC address
+    uint8_t LCD_time;           // 15 Time (secs) for initial display
 
     uint8_t __PAD1[16];
 
-    int8_t warn_int[4];		// 32 Int Temp Warning settings
-    int8_t shut_int[4];		// 36 Int Temp Shutdown settings
+    int8_t warn_int[4];         // 32 Int Temp Warning settings
+    int8_t shut_int[4];         // 36 Int Temp Shutdown settings
 
-    int8_t warn_ext[4];		// 40 Ext Temp Warning settings
-    int8_t shut_ext[4];		// 44 Ext Temp Shutdown settings
+    int8_t warn_ext[4];         // 40 Ext Temp Warning settings
+    int8_t shut_ext[4];         // 44 Ext Temp Shutdown settings
 
-    uint8_t warn_fan[4];	// 48 Fan Speed Warning settings
-    uint8_t shut_fan[4];	// 52 Fan Speed Shutdown settings
+    uint8_t warn_fan[4];        // 48 Fan Speed Warning settings
+    uint8_t shut_fan[4];        // 52 Fan Speed Shutdown settings
 
-    uint8_t warn_vlow[8];	// 56 Under-voltage Warning settings
-    uint8_t shut_vlow[8];	// 64 Under-voltage Shutdown settings
+    uint8_t warn_vlow[8];       // 56 Under-voltage Warning settings
+    uint8_t shut_vlow[8];       // 64 Under-voltage Shutdown settings
 
-    uint8_t warn_vhigh[8];	// 72 Over-voltage Warning settings
-    uint8_t shut_vhigh[8];	// 80 Over-voltage Shutdown settings
+    uint8_t warn_vhigh[8];      // 72 Over-voltage Warning settings
+    uint8_t shut_vhigh[8];      // 80 Over-voltage Shutdown settings
 
-    uint8_t __PAD2[164];	// 88
-    uint32_t CRC32;		// 252
+    uint8_t __PAD2[164];        // 88
+    uint32_t CRC32;             // 252
 } ee_data_t;
 
-typedef struct {	// 48 bytes
+typedef struct {        // 48 bytes
     uint16_t adc[8];
     int16_t t_int[4];
     int16_t t_ext[4];
@@ -274,7 +274,7 @@ typedef struct {	// 48 bytes
     uint32_t shutdown;
 } board_stat_t;
 
-typedef struct {	// 32 bytes
+typedef struct {        // 32 bytes
     uint16_t flags;
     uint8_t mac_addr[6];
     uint8_t ip_addr[4];
@@ -295,10 +295,10 @@ typedef void (*proc4) (uint32_t, uint32_t, uint32_t, uint32_t);
 typedef void (*main_proc) (void *, uint32_t, uint32_t, uint32_t);
 
 typedef struct {
-    uint32_t *stack_top;	// 0
+    uint32_t *stack_top;        // 0
     main_proc main;
 
-    handler NMI;		// 2
+    handler NMI;                // 2
     handler HardFault;
     handler MemManage;
     handler BusFault;
@@ -313,7 +313,7 @@ typedef struct {
     handler PendSV;
     handler SysTickH;
 
-    handler WDT;		// 16
+    handler WDT;                // 16
     handler TIMER0;
     handler TIMER1;
     handler TIMER2;
@@ -330,7 +330,7 @@ typedef struct {
     handler SSP0;
     handler SSP1;
 
-    handler PLL0;		// 32
+    handler PLL0;               // 32
     handler RTC;
     handler EINT0;
     handler EINT1;
@@ -347,17 +347,17 @@ typedef struct {
     handler MCPWM;
     handler QEI;
 
-    handler PLL1;		// 48
+    handler PLL1;               // 48
     handler USBActivity;
     handler CANActivity;
 
-    handler Rsvd_51;		// 51
+    handler Rsvd_51;            // 51
     handler Rsvd_52;
 
-    uint32_t build_date;	// 53
+    uint32_t build_date;        // 53
     uint32_t sw_ver;
 
-    uint32_t RO_length;		// 55
+    uint32_t RO_length;         // 55
     uint32_t RW_length;
     uint32_t *RO_limit;
     uint32_t *RW_base;
@@ -365,18 +365,18 @@ typedef struct {
     uint32_t *ZI_base;
     uint32_t *ZI_limit;
     uint32_t *stack_base;
-    uint32_t *stack_limit;	// 63
+    uint32_t *stack_limit;      // 63
 } cortex_vec_t;
 
 typedef struct {
-    uint32_t *stack_top;	// 0
-    handler boot_proc;		// 1
-    proc4 flash_copy;		// 2
-    proc4 Rsvd_3;		// 3
-    proc4 Rsvd_4;		// 4
-    uint32_t build_date;	// 5
-    uint32_t sw_ver;		// 6
-    uint32_t checksum;		// 7
+    uint32_t *stack_top;        // 0
+    handler boot_proc;          // 1
+    proc4 flash_copy;           // 2
+    proc4 Rsvd_3;               // 3
+    proc4 Rsvd_4;               // 4
+    uint32_t build_date;        // 5
+    uint32_t sw_ver;            // 6
+    uint32_t checksum;          // 7
 } boot_vec_t;
 
 static boot_vec_t * const boot_vec = (boot_vec_t *) 0;
@@ -414,12 +414,12 @@ static uint32_t * const uni_vec = (uint32_t *) 0x10001000;
 typedef void (*event_proc) (uint32_t, uint32_t);
 
 typedef struct event {
-    event_proc proc;	// Proc to be called or NULL
-    uint32_t arg1;	// First arg to proc
-    uint32_t arg2;	// Second arg to proc
-    uint32_t time;	// Time (CPU ticks) until event due (0 if at head of Q)
-    uint32_t ID;	// Unique ID for active event (0 if inactive)
-    struct event *next;	// Next in Q or NULL
+    event_proc proc;    // Proc to be called or NULL
+    uint32_t arg1;      // First arg to proc
+    uint32_t arg2;      // Second arg to proc
+    uint32_t time;      // Time (CPU ticks) until event due (0 if at head of Q)
+    uint32_t ID;        // Unique ID for active event (0 if inactive)
+    struct event *next; // Next in Q or NULL
 } event_t;
 
 void event_init (uint32_t priority);
@@ -446,10 +446,10 @@ void configure_i2c (void);
 uint32_t i2c_poll (LPC_I2C_TypeDef *i2c, uint32_t ctrl);
 
 uint32_t i2c_receive (LPC_I2C_TypeDef *i2c, uint32_t ctrl, uint32_t addr,
-		      uint32_t length, void *buf);
+                      uint32_t length, void *buf);
 
 uint32_t i2c_send (LPC_I2C_TypeDef *i2c, uint32_t ctrl, uint32_t addr,
-		   uint32_t length, void *buf);
+                   uint32_t length, void *buf);
 
 int16_t read_ts (LPC_I2C_TypeDef *i2c, uint32_t addr);
 

--- a/bmp/bmp_boot.c
+++ b/bmp/bmp_boot.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_boot.c	    System bootstrap code for BMP LPC1768
+// bmp_boot.c       System bootstrap code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2014-2015
 //
@@ -26,11 +26,11 @@
 
 // Linker generated symbols
 
-#define RO_LENGTH 	Image$$BOOT$$RO$$Length
-#define STACK_LIMIT 	Image$$STACK$$ZI$$Limit
+#define RO_LENGTH       Image$$BOOT$$RO$$Length
+#define STACK_LIMIT     Image$$STACK$$ZI$$Limit
 
-extern uint32_t RO_LENGTH;	// Size of this boot image
-extern uint32_t STACK_LIMIT;	// Stack top
+extern uint32_t RO_LENGTH;      // Size of this boot image
+extern uint32_t STACK_LIMIT;    // Stack top
 
 // Fudge to force 4 byte alignment
 
@@ -60,16 +60,16 @@ static void __attribute__((noreturn)) die(uint32_t code)
     uint32_t bits = LED_7;
 
     for (uint32_t i = 0; i < 4; i++) {
-	if (code & (1 << i)) {
-	    bits |= led_bit[i];
-	}
+        if (code & (1 << i)) {
+            bits |= led_bit[i];
+        }
     }
 
     LPC_GPIO0->FIOCLR = LED_MASK;
     LPC_GPIO0->FIOSET = bits;
 
     while (1) {
-	continue;
+        continue;
     }
 }
 
@@ -93,28 +93,28 @@ void __attribute__((noreturn)) boot_proc(void)
     uint32_t boot_size = (uint32_t) &RO_LENGTH;
 
     if (crc32_chk(boot_vec, boot_size + 4) != 0) {
-	die(14);
+        die(14);
     }
 
     // Check CRC of Code/Data section of Flash. Four 64KB blocks are
     // used, starting at 0x10000. They are checked in sequence until
     // one with a valid CRC is found.
 
-    uint32_t boot_sec = 1;		// Boot block number
-    cortex_vec_t *cortex_vec;		// Cortex boot vector
+    uint32_t boot_sec = 1;              // Boot block number
+    cortex_vec_t *cortex_vec;           // Cortex boot vector
 
     while (1) {
-	cortex_vec = (cortex_vec_t *) (boot_sec * 0x10000);
+        cortex_vec = (cortex_vec_t *) (boot_sec * 0x10000);
 
-	uint32_t length = cortex_vec->RO_length + cortex_vec->RW_length + 4;
+        uint32_t length = cortex_vec->RO_length + cortex_vec->RW_length + 4;
 
-	// Check length < 256KB
-	if (length < 0x40000 && crc32_chk(cortex_vec, length) == 0) {
-	    break;
-	}
-	if (boot_sec++ == 4) {
-	    die(13);
-	}
+        // Check length < 256KB
+        if (length < 0x40000 && crc32_chk(cortex_vec, length) == 0) {
+            break;
+        }
+        if (boot_sec++ == 4) {
+            die(13);
+        }
     }
 
     // Check CRC of Data sector unless blank. If CRC is bad we leave
@@ -124,9 +124,9 @@ void __attribute__((noreturn)) boot_proc(void)
     LPC_GPIO0->FIOCLR = LED_6 + LED_5 + LED_4 + LED_3;
 
     if (is_blank((void *) 0x1000, 4096) ||
-	    crc32_chk((void *) 0x1000, 4096) == 0) {
-	data_ok = true;
-	LPC_GPIO0->FIOCLR = LED_7;
+            crc32_chk((void *) 0x1000, 4096) == 0) {
+        data_ok = true;
+        LPC_GPIO0->FIOCLR = LED_7;
     }
 
     // Copy RW/DATA section from flash to RAM
@@ -134,21 +134,21 @@ void __attribute__((noreturn)) boot_proc(void)
     uint32_t *base = cortex_vec->RW_base;
     uint32_t *limit = cortex_vec->RW_limit;
     while (base < limit) {
-	*base++ = *from++;
+        *base++ = *from++;
     }
 
     // Clear ZI/BSS section
     base = cortex_vec->ZI_base;
     limit = cortex_vec->ZI_limit;
     while (base < limit) {
-	*base++ = 0;
+        *base++ = 0;
     }
 
     // Fill stack with 0xdeaddead
     base = cortex_vec->stack_base;
     limit = cortex_vec->stack_limit;
     while (base < limit) {
-	*base++ = 0xdeaddead;
+        *base++ = 0xdeaddead;
     }
 
     // Initialise heap if needed
@@ -174,7 +174,7 @@ void __attribute__((noreturn)) boot_proc(void)
 static void mem_copy(uint32_t *to, uint32_t *from, uint32_t n)
 {
     while (n--) {
-	*to++ = *from++;
+        *to++ = *from++;
     }
 }
 
@@ -199,18 +199,18 @@ flash_copy(uint32_t to, uint32_t from, int32_t size, int32_t arg4)
     flash_erase(flash_dest, flash_dest + size - 1);
 
     while (size > 0) {
-	refresh_wdt();
+        refresh_wdt();
 
-	mem_copy(flash_buf, flash_srce, FLASH_WORDS);
+        mem_copy(flash_buf, flash_srce, FLASH_WORDS);
 
-	flash_write(flash_dest, FLASH_BYTES, flash_buf);
+        flash_write(flash_dest, FLASH_BYTES, flash_buf);
 
-	flash_srce += FLASH_WORDS;
-	flash_dest += FLASH_BYTES;
-	size -= FLASH_BYTES;
+        flash_srce += FLASH_WORDS;
+        flash_dest += FLASH_BYTES;
+        size -= FLASH_BYTES;
     }
 
-    die(15);	// WDT should reset now...
+    die(15);    // WDT should reset now...
 }
 
 
@@ -224,14 +224,14 @@ flash_copy(uint32_t to, uint32_t from, int32_t size, int32_t arg4)
 // someone. The "openocd" JTAG application can do this as can "sum.pl"
 
 static const boot_vec_t boot_data __attribute__ ((section (".boot_vec"))) = {
-    &STACK_LIMIT,   		// 0: Boot stack pointer
-    boot_proc,			// 1; Boot routine
-    (proc4) flash_copy,		// 2: Flash copy routine
-    (proc4) 0,   		// 3:
-    (proc4) 0,         		// 4:
-    BUILD_DATE,  		// 5: Build date
-    BMP_VER_NUM,        	// 6: Version
-    0				// 7: Checksum
+    &STACK_LIMIT,               // 0: Boot stack pointer
+    boot_proc,                  // 1; Boot routine
+    (proc4) flash_copy,         // 2: Flash copy routine
+    (proc4) 0,                  // 3:
+    (proc4) 0,                  // 4:
+    BUILD_DATE,                 // 5: Build date
+    BMP_VER_NUM,                // 6: Version
+    0                           // 7: Checksum
 };
 
 

--- a/bmp/bmp_clock.c
+++ b/bmp/bmp_clock.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_clock.c	    Clock configuration code for BMP LPC1768
+// bmp_clock.c      Clock configuration code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -14,7 +14,7 @@
 
 //------------------------------------------------------------------------------
 
-#define XTAL_CLK 25000000	// Xtal clock (25 MHz)
+#define XTAL_CLK 25000000       // Xtal clock (25 MHz)
 
 /*
   Crystal on main osc is 25 MHz and we want 100 MHz CCLK. Use a 300 MHz
@@ -30,62 +30,62 @@
 #define PDIV2 2
 #define PDIV8 3
 
-#define	PCLKSEL_WDT  		0
-#define	PCLKSEL_TIMER0  	2
-#define	PCLKSEL_TIMER1  	4
-#define	PCLKSEL_UART0  		6
-#define	PCLKSEL_UART1  		8
-#define	PCLKSEL_PWM1  		12
-#define	PCLKSEL_I2C0  		14
-#define	PCLKSEL_SPI  		16
-#define	PCLKSEL_SSP1  		20
-#define	PCLKSEL_DAC  		22
-#define	PCLKSEL_ADC  		24
-#define	PCLKSEL_CAN1 		26
-#define	PCLKSEL_CAN2 		28
-#define	PCLKSEL_ACF  		30
+#define PCLKSEL_WDT             0
+#define PCLKSEL_TIMER0          2
+#define PCLKSEL_TIMER1          4
+#define PCLKSEL_UART0           6
+#define PCLKSEL_UART1           8
+#define PCLKSEL_PWM1            12
+#define PCLKSEL_I2C0            14
+#define PCLKSEL_SPI             16
+#define PCLKSEL_SSP1            20
+#define PCLKSEL_DAC             22
+#define PCLKSEL_ADC             24
+#define PCLKSEL_CAN1            26
+#define PCLKSEL_CAN2            28
+#define PCLKSEL_ACF             30
 
-#define	PCLKSEL_QEI  		0
-#define	PCLKSEL_PCB  		4
-#define	PCLKSEL_I2C1  		6
-#define	PCLKSEL_SSP0  		10
-#define	PCLKSEL_TIMER2  	12
-#define	PCLKSEL_TIMER3  	14
-#define	PCLKSEL_UART2  		16
-#define	PCLKSEL_UART3  		18
-#define	PCLKSEL_I2C2  		20
-#define	PCLKSEL_I2S  		22
-#define	PCLKSEL_RIT  		26
-#define	PCLKSEL_SYSCON  	28
-#define	PCLKSEL_MC  		30
+#define PCLKSEL_QEI             0
+#define PCLKSEL_PCB             4
+#define PCLKSEL_I2C1            6
+#define PCLKSEL_SSP0            10
+#define PCLKSEL_TIMER2          12
+#define PCLKSEL_TIMER3          14
+#define PCLKSEL_UART2           16
+#define PCLKSEL_UART3           18
+#define PCLKSEL_I2C2            20
+#define PCLKSEL_I2S             22
+#define PCLKSEL_RIT             26
+#define PCLKSEL_SYSCON          28
+#define PCLKSEL_MC              30
 
-#define	PCONP_PCTIM0	        (1<<1)
-#define	PCONP_PCTIM1	        (1<<2)
-#define	PCONP_PCUART0  	        (1<<3)
-#define	PCONP_PCUART1  	        (1<<4)
-#define	PCONP_PCPWM1	        (1<<6)
-#define	PCONP_PCI2C0	        (1<<7)
-#define	PCONP_PCSPI  	        (1<<8)
-#define	PCONP_PCRTC  	        (1<<9)
-#define	PCONP_PCSSP1	        (1<<10)
-#define	PCONP_PCAD  	        (1<<12)
-#define	PCONP_PCAN1  	        (1<<13)
-#define	PCONP_PCAN2 	        (1<<14)
-#define	PCONP_PCGPIO 	        (1<<15)
-#define	PCONP_PCRIT 	        (1<<16)
-#define PCONP_PCMC 	        (1<<17)
-#define PCONP_PCQEI	        (1<<18)
-#define	PCONP_PCI2C1  	        (1<<19)
-#define	PCONP_PCSSP0	        (1<<21)
-#define	PCONP_PCTIM2	        (1<<22)
-#define	PCONP_PCTIM3	        (1<<23)
-#define	PCONP_PCUART2  	        (1<<24)
-#define	PCONP_PCUART3  	        (1<<25)
-#define	PCONP_PCI2C2	        (1<<26)
-#define	PCONP_PCI2S  	        (1<<27)
-#define	PCONP_PCGPDMA  	        (1<<29)
-#define	PCONP_PCENET	        (1<<30)
-#define	PCONP_PCUSB  	        (1<<31)
+#define PCONP_PCTIM0            (1<<1)
+#define PCONP_PCTIM1            (1<<2)
+#define PCONP_PCUART0           (1<<3)
+#define PCONP_PCUART1           (1<<4)
+#define PCONP_PCPWM1            (1<<6)
+#define PCONP_PCI2C0            (1<<7)
+#define PCONP_PCSPI             (1<<8)
+#define PCONP_PCRTC             (1<<9)
+#define PCONP_PCSSP1            (1<<10)
+#define PCONP_PCAD              (1<<12)
+#define PCONP_PCAN1             (1<<13)
+#define PCONP_PCAN2             (1<<14)
+#define PCONP_PCGPIO            (1<<15)
+#define PCONP_PCRIT             (1<<16)
+#define PCONP_PCMC              (1<<17)
+#define PCONP_PCQEI             (1<<18)
+#define PCONP_PCI2C1            (1<<19)
+#define PCONP_PCSSP0            (1<<21)
+#define PCONP_PCTIM2            (1<<22)
+#define PCONP_PCTIM3            (1<<23)
+#define PCONP_PCUART2           (1<<24)
+#define PCONP_PCUART3           (1<<25)
+#define PCONP_PCI2C2            (1<<26)
+#define PCONP_PCI2S             (1<<27)
+#define PCONP_PCGPDMA           (1<<29)
+#define PCONP_PCENET            (1<<30)
+#define PCONP_PCUSB             (1<<31)
 
 // Timer 0 - 100MHz
 // Timer 1 - 100MHz
@@ -131,11 +131,11 @@
 
 //------------------------------------------------------------------------------
 
-#define SCS_V                 	0x00000030	// Range 15-25MHz, main osc on
-#define CCLKCFG_V             	0x00000002	// Divide PLL0 by 3 for CCLK
-#define CLKSRCSEL_V           	0x00000001	// Main clock -> PLL0
-#define PLL0CFG_V             	0x0001000b	// N = 2, M = 12
-#define FLASHCFG_V            	0x0000403a	// Flash uses 5 clks / access
+#define SCS_V                   0x00000030      // Range 15-25MHz, main osc on
+#define CCLKCFG_V               0x00000002      // Divide PLL0 by 3 for CCLK
+#define CLKSRCSEL_V             0x00000001      // Main clock -> PLL0
+#define PLL0CFG_V               0x0001000b      // N = 2, M = 12
+#define FLASHCFG_V              0x0000403a      // Flash uses 5 clks / access
 
 #define PLL_UP     ((1 << 25) + (1 << 24))
 #define PLL_LOCK   (1 << 26)
@@ -163,48 +163,48 @@
 
 void configure_clocks()
 {
-    LPC_SC->SCS = SCS_V;		// Configure main osc.
+    LPC_SC->SCS = SCS_V;                // Configure main osc.
 
     // Wait for Osc ready
     while ((LPC_SC->SCS & OSC_UP) == 0) {
-	continue;
+        continue;
     }
-    LPC_SC->CCLKCFG   = CCLKCFG_V; 	// Set PLL0->CCLK divider
+    LPC_SC->CCLKCFG   = CCLKCFG_V;      // Set PLL0->CCLK divider
 
     // Peripheral Clock Selection doesn't seem to work here!
 
     // LPC_SC->PCLKSEL0  = PCLKSEL0_V;
     // LPC_SC->PCLKSEL1  = PCLKSEL1_V;
 
-    LPC_SC->CLKSRCSEL = CLKSRCSEL_V;	// Select Clock Source for PLL0
+    LPC_SC->CLKSRCSEL = CLKSRCSEL_V;    // Select Clock Source for PLL0
 
-    LPC_SC->PLL0CFG   = PLL0CFG_V;	// Configure PLL0
+    LPC_SC->PLL0CFG   = PLL0CFG_V;      // Configure PLL0
     LPC_SC->PLL0FEED  = 0xaa;
     LPC_SC->PLL0FEED  = 0x55;
 
-    LPC_SC->PLL0CON   = 0x01;		// Enable PLL0
+    LPC_SC->PLL0CON   = 0x01;           // Enable PLL0
     LPC_SC->PLL0FEED  = 0xaa;
     LPC_SC->PLL0FEED  = 0x55;
 
     // Wait for PLL to lock
     while ((LPC_SC->PLL0STAT & PLL_LOCK) == 0) {
-	continue;
+        continue;
     }
-    LPC_SC->PLL0CON   = 0x03;		// PLL0 Enable & Connect
+    LPC_SC->PLL0CON   = 0x03;           // PLL0 Enable & Connect
     LPC_SC->PLL0FEED  = 0xaa;
     LPC_SC->PLL0FEED  = 0x55;
 
     // Wait for PLLC0_STAT & PLLE0_STAT
     while ((LPC_SC->PLL0STAT & PLL_UP) != PLL_UP) {
-	continue;
+        continue;
     }
-    LPC_SC->FLASHCFG  = FLASHCFG_V;	// Configure flash accelerator
+    LPC_SC->FLASHCFG  = FLASHCFG_V;     // Configure flash accelerator
 
-    LPC_SC->PCONP     = PCONP_V;	// Power Control for Peripherals
+    LPC_SC->PCONP     = PCONP_V;        // Power Control for Peripherals
 
-    uint32_t n = 32 * 1024;		// Wait about 1ms
+    uint32_t n = 32 * 1024;             // Wait about 1ms
     while (n--) {
-	continue;
+        continue;
     }
 }
 

--- a/bmp/bmp_cmd.c
+++ b/bmp/bmp_cmd.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_cmd.c	    Command handling for BC&MP
+// bmp_cmd.c        Command handling for BC&MP
 //
 // Copyright (C)    The University of Manchester - 2012-2016
 //
@@ -39,17 +39,17 @@ static void fpga_xreg(uint32_t count, uint8_t *data)
     uint32_t *words = (uint32_t *) data;
 
     for (uint32_t i = 0; i < count; i++) {
-	uint32_t addr = words[2 * i];
-	uint32_t *data = words + 2 * i + 1;
-	uint32_t fpga = addr & 3;
+        uint32_t addr = words[2 * i];
+        uint32_t *data = words + 2 * i + 1;
+        uint32_t fpga = addr & 3;
 
-	fpga = (fpga == 3) ? 7 : 1 << fpga;
+        fpga = (fpga == 3) ? 7 : 1 << fpga;
 
-	for (uint32_t f = 0; f < 3; f++) {
-	    if (fpga & (1 << f)) {
-		fpga_word(addr, f, data, FPGA_WRITE);
-	    }
-	}
+        for (uint32_t f = 0; f < 3; f++) {
+            if (fpga & (1 << f)) {
+                fpga_word(addr, f, data, FPGA_WRITE);
+            }
+        }
     }
 }
 
@@ -60,16 +60,16 @@ static void fpga_xreg(uint32_t count, uint8_t *data)
 static void sf_scan(void)
 {
     if (! data_ok) {
-	return;
+        return;
     }
     ssp1_fast();
 
     for (uint32_t i = 0; i < FL_DIR_SIZE; i++) {
-	fl_dir_t *e = fl_dir + i;
+        fl_dir_t *e = fl_dir + i;
 
-	if (e->type == FL_FPGA && e->length != 0 && (e->flags & 0x8000) != 0) {
-	    fpga_boot(e->base, e->length, e->flags);
-	}
+        if (e->type == FL_FPGA && e->length != 0 && (e->flags & 0x8000) != 0) {
+            fpga_boot(e->base, e->length, e->flags);
+        }
     }
 
     // Reset line high, wait a while then process "xreg" blocks
@@ -78,11 +78,11 @@ static void sf_scan(void)
     delay_ms(5);
 
     for (uint32_t i = 0; i < FL_DIR_SIZE; i++) {
-	fl_dir_t *e = fl_dir + i;
+        fl_dir_t *e = fl_dir + i;
 
-	if (e->type == FL_XREG && e->size > 0) {
-	    fpga_xreg(e->size, e->data);
-	}
+        if (e->type == FL_XREG && e->size > 0) {
+            fpga_xreg(e->size, e->data);
+        }
     }
 }
 
@@ -93,7 +93,7 @@ static void sf_scan(void)
 void flash_buf_init(void)
 {
     for (uint32_t i = 0; i < FLASH_WORDS; i++) {
-	flash_buf[i] = 0xffffffff;
+        flash_buf[i] = 0xffffffff;
     }
 }
 
@@ -107,9 +107,9 @@ static uint32_t cmd_flash_erase (sdp_msg_t *msg)
     flash_buf_init();
 
     if (msg->arg1 == 0) {
-	msg->arg1 = (uint32_t) flash_buf;
+        msg->arg1 = (uint32_t) flash_buf;
     } else {
-	msg->cmd_rc = RC_ARG;
+        msg->cmd_rc = RC_ARG;
     }
     return 4;
 }
@@ -126,18 +126,18 @@ static uint32_t cmd_flash_write(sdp_msg_t *msg)
     uint32_t erase = msg->arg3;
 
     if (erase) {
-	msg->arg1 = flash_erase(start, start + length - 1);
-	if (msg->arg1 != 0) {
-	    msg->cmd_rc = RC_ARG;
-	    return 4;
-	}
+        msg->arg1 = flash_erase(start, start + length - 1);
+        if (msg->arg1 != 0) {
+            msg->cmd_rc = RC_ARG;
+            return 4;
+        }
     }
 
     msg->arg1 = flash_write(start, length, flash_buf);
     flash_buf_init();
 
     if (msg->arg1 == 0) {
-	return 0;
+        return 0;
     }
     msg->cmd_rc = RC_ARG;
     return 4;
@@ -155,21 +155,21 @@ static uint32_t cmd_xilinx(sdp_msg_t *msg)
 {
     uint32_t op = msg->arg1;
 
-    if (op == 0) {		// Send config bitfile
-	ssp1_fast();
-	ssp1_copy(msg->arg2, msg->data);
-    } else if (op == 1) {	// Initialise FPGA
-	if (! fpga_init(msg->arg2)) {
-	    msg->cmd_rc = RC_TIMEOUT;
-	}
-    } else if (op == 2) {	// Reset FPGA
-	if (msg->arg2 <= 2) {
-	    fpga_reset(msg->arg2);
-	} else {
-	    msg->cmd_rc = RC_ARG;
-	}
+    if (op == 0) {              // Send config bitfile
+        ssp1_fast();
+        ssp1_copy(msg->arg2, msg->data);
+    } else if (op == 1) {       // Initialise FPGA
+        if (! fpga_init(msg->arg2)) {
+            msg->cmd_rc = RC_TIMEOUT;
+        }
+    } else if (op == 2) {       // Reset FPGA
+        if (msg->arg2 <= 2) {
+            fpga_reset(msg->arg2);
+        } else {
+            msg->cmd_rc = RC_ARG;
+        }
     } else {
-	msg->cmd_rc = RC_ARG;
+        msg->cmd_rc = RC_ARG;
     }
 
     return 0;
@@ -188,8 +188,8 @@ uint32_t cmd_fpga_read(sdp_msg_t *msg)
     uint32_t link = msg->arg3;
 
     if (len > SDP_BUF_SIZE || link > NUM_FPGAS - 1) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t addr = msg->arg1;
@@ -198,9 +198,9 @@ uint32_t cmd_fpga_read(sdp_msg_t *msg)
     ssp1_slow();
 
     for (uint32_t i = 0; i < len / 4; i++) {
-	fpga_word(addr, link, buf, FPGA_READ);
-	addr += 4;
-	buf += 1;
+        fpga_word(addr, link, buf, FPGA_READ);
+        addr += 4;
+        buf += 1;
     }
 
     return len;
@@ -218,8 +218,8 @@ uint32_t cmd_fpga_write(sdp_msg_t *msg)
     uint32_t link = msg->arg3;
 
     if (len > SDP_BUF_SIZE || link > NUM_FPGAS - 1) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t addr = msg->arg1;
@@ -228,9 +228,9 @@ uint32_t cmd_fpga_write(sdp_msg_t *msg)
     ssp1_slow();
 
     for (uint32_t i = 0; i < len / 4; i++) {
-	fpga_word(addr, link, buf, FPGA_WRITE);
-	addr += 4;
-	buf += 1;
+        fpga_word(addr, link, buf, FPGA_WRITE);
+        addr += 4;
+        buf += 1;
     }
 
     return 0;
@@ -246,22 +246,22 @@ static uint32_t cmd_sf(sdp_msg_t *msg)
     uint32_t op = msg->arg3;
 
     if ((op < 2 && len > SDP_BUF_SIZE) || op > 2) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t r;
 
     ssp0_pins(1);
     if (op == 0) {
-	sf_read(addr, len, (uint8_t *) &msg->arg1);
-	r = len;
+        sf_read(addr, len, (uint8_t *) &msg->arg1);
+        r = len;
     } else if (op == 1) {
-	sf_write(addr, len, msg->data);
-	r = 0
+        sf_write(addr, len, msg->data);
+        r = 0
     } else {
-	msg->arg1 = sf_crc32(addr, len);
-	r = 4;
+        msg->arg1 = sf_crc32(addr, len);
+        r = 4;
     }
     ssp0_pins(0);
 
@@ -279,32 +279,32 @@ static uint32_t cmd_ee(sdp_msg_t *msg)
     uint32_t op = msg->arg3;
 
     if (len > SDP_BUF_SIZE || op > 1 || ! bp_ctrl) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     if (op == 0) {
-	if (read_ee(addr, len, &msg->arg1)) {
-	    return len;
-	}
-	msg->cmd_rc = RC_TIMEOUT;
+        if (read_ee(addr, len, &msg->arg1)) {
+            return len;
+        }
+        msg->cmd_rc = RC_TIMEOUT;
     } else {
-	uint8_t *buf = msg->data;
+        uint8_t *buf = msg->data;
 
-	if (!read_ee(addr, 0, NULL)) {
-	    msg->cmd_rc = RC_TIMEOUT;
-	    return 0;
-	}
+        if (!read_ee(addr, 0, NULL)) {
+            msg->cmd_rc = RC_TIMEOUT;
+            return 0;
+        }
 
-	while (len > 0) {
-	    uint32_t count = (len > 16) ? 16 : len;
+        while (len > 0) {
+            uint32_t count = (len > 16) ? 16 : len;
 
-	    write_ee(addr, count, buf);
+            write_ee(addr, count, buf);
 
-	    addr += 16;
-	    buf += 16;
-	    len -= 16;
-	}
+            addr += 16;
+            buf += 16;
+            len -= 16;
+        }
     }
 
     return 0;
@@ -317,7 +317,7 @@ static uint32_t cmd_ee(sdp_msg_t *msg)
 void proc_led(uint32_t arg, uint32_t mask)
 {
     if (mask & (1 << board_ID)) {
-	led_set(arg);
+        led_set(arg);
     }
 }
 
@@ -327,7 +327,7 @@ static uint32_t cmd_led(sdp_msg_t *msg)
     uint32_t mask = msg->arg2 & ~(1 << board_ID);
 
     if (mask) {
-	can_proc_cmd(31, PROC_LED, msg->arg1, mask);
+        can_proc_cmd(31, PROC_LED, msg->arg1, mask);
     }
     proc_led(msg->arg1, msg->arg2);
 
@@ -343,10 +343,10 @@ void proc_reset(uint32_t arg, uint32_t mask)
     uint32_t delay = (arg >> 16) * board_ID;
 
     if (mask & (1 << board_ID)) {
-	if (delay) {
-	    delay_ms(delay);
-	}
-	reset_spin(reset);
+        if (delay) {
+            delay_ms(delay);
+        }
+        reset_spin(reset);
     }
 }
 
@@ -354,13 +354,13 @@ void proc_reset(uint32_t arg, uint32_t mask)
 static uint32_t cmd_reset(sdp_msg_t *msg)
 {
     if ((msg->arg1 & 0xfb) > 2) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t mask = msg->arg2 & ~(1 << board_ID);
     if (mask) {
-	can_proc_cmd(31, PROC_RESET, msg->arg1, mask);
+        can_proc_cmd(31, PROC_RESET, msg->arg1, mask);
     }
     proc_reset(msg->arg1, msg->arg2);
 
@@ -380,17 +380,17 @@ void proc_power(uint32_t arg, uint32_t mask)
     uint32_t delay = (arg >> 16) * board_ID;
 
     if (mask & (1 << board_ID)) {
-	if (delay) {
-	    delay_ms(delay);
-	}
-	if (on) {
-	    set_power(POWER_ON);	// Sets POR
-	    delay_ms(25);
-	    sf_scan();			// Boot FPGAs
-	    reset_spin(0);		// Clear POR
-	} else {
-	    set_power(POWER_OFF);
-	}
+        if (delay) {
+            delay_ms(delay);
+        }
+        if (on) {
+            set_power(POWER_ON);        // Sets POR
+            delay_ms(25);
+            sf_scan();                  // Boot FPGAs
+            reset_spin(0);              // Clear POR
+        } else {
+            set_power(POWER_OFF);
+        }
     }
 }
 
@@ -398,14 +398,14 @@ void proc_power(uint32_t arg, uint32_t mask)
 static uint32_t cmd_power(sdp_msg_t *msg)
 {
     if ((msg->arg1 & 255) > 1) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t mask = msg->arg2 & ~(1 << board_ID);
 
     if (mask) {
-	can_proc_cmd(31, PROC_POWER, msg->arg1, mask);
+        can_proc_cmd(31, PROC_POWER, msg->arg1, mask);
     }
     proc_power(msg->arg1, msg->arg2);
 
@@ -421,7 +421,7 @@ static uint32_t cmd_ver(sdp_msg_t *msg)
     uint32_t cv = (uint32_t) cortex_vec / 0x10000;
 
     msg->arg1 = (cv << 24) + (ee_data.frame_ID << 16) +
-	    (can_ID << 8) + board_ID;
+            (can_ID << 8) + board_ID;
     msg->arg2 = 0xffff0000 + SDP_BUF_SIZE;
     msg->arg3 = cortex_vec->build_date;
 
@@ -440,9 +440,9 @@ static uint32_t cmd_ver(sdp_msg_t *msg)
 // Return various useful bits of information about the BMP
 
 // arg1 = 0 returns
-//	    0   - hw_ver
-//	    1-4 - LPC1768 serial number
-//	    5   - flash buffer address
+//          0   - hw_ver
+//          1-4 - LPC1768 serial number
+//          5   - flash buffer address
 //          6   - board_stat address (this board)
 //          7   - Cortex boot vector address
 // arg1 = 1 returns EE data buffer
@@ -458,39 +458,39 @@ static uint32_t cmd_bmp_info(sdp_msg_t *msg)
 
     switch (msg->arg1) {
     case 0:
-	buf[0] = 58;
-	lpc_iap(buf, buf);
-	buf[0] = hw_ver;
-	buf[5] = (uint32_t) flash_buf;
-	buf[6] = (uint32_t) &board_stat[can_ID];
-	buf[7] = (uint32_t) cortex_vec;
-	return 32;
+        buf[0] = 58;
+        lpc_iap(buf, buf);
+        buf[0] = hw_ver;
+        buf[5] = (uint32_t) flash_buf;
+        buf[6] = (uint32_t) &board_stat[can_ID];
+        buf[7] = (uint32_t) cortex_vec;
+        return 32;
 
     case 1:
-	memcpy(buf, &ee_data, sizeof(ee_data_t));
-	return sizeof(ee_data_t);
+        memcpy(buf, &ee_data, sizeof(ee_data_t));
+        return sizeof(ee_data_t);
 
     case 2:
-	memcpy(buf, can_status, sizeof(can_status));
-	return sizeof(can_status);
+        memcpy(buf, can_status, sizeof(can_status));
+        return sizeof(can_status);
 
     case 3:
-	memcpy(buf, &board_stat[can_ID], sizeof(board_stat_t));
-	return sizeof(board_stat_t);
+        memcpy(buf, &board_stat[can_ID], sizeof(board_stat_t));
+        return sizeof(board_stat_t);
 
     case 4:
-	memcpy(buf, &bmp_ip, sizeof(ip_data_t));
-	buf += sizeof(ip_data_t) / sizeof(uint32_t);
-	memcpy(buf, &spin_ip, sizeof(ip_data_t));
-	return 2 * sizeof(ip_data_t);
+        memcpy(buf, &bmp_ip, sizeof(ip_data_t));
+        buf += sizeof(ip_data_t) / sizeof(uint32_t);
+        memcpy(buf, &spin_ip, sizeof(ip_data_t));
+        return 2 * sizeof(ip_data_t);
 
     case 5:
-	memcpy(buf, uni_vec, 32);
-	return 32;
+        memcpy(buf, uni_vec, 32);
+        return 32;
 
     default:
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 }
 
@@ -505,8 +505,8 @@ static uint32_t cmd_fill(sdp_msg_t *msg)
     int32_t n = msg->arg3;
 
     while (n > 0) {
-	*to++ = data;
-	n -= 4;
+        *to++ = data;
+        n -= 4;
     }
 
     return 0;
@@ -518,38 +518,38 @@ static uint32_t cmd_fill(sdp_msg_t *msg)
 
 static uint32_t cmd_read(sdp_msg_t *msg)
 {
-    uint32_t addr = msg->arg1;	// Address
-    uint32_t len = msg->arg2;	// Length
-    uint32_t type = msg->arg3;	// Type
+    uint32_t addr = msg->arg1;  // Address
+    uint32_t len = msg->arg2;   // Length
+    uint32_t type = msg->arg3;  // Type
 
     if (len > SDP_BUF_SIZE || type > TYPE_WORD) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint8_t *buffer = (uint8_t *) &msg->arg1;
 
     if (type == TYPE_BYTE) {
-	uint8_t *mem = (uint8_t *) addr;
-	uint8_t *buf = (uint8_t *) buffer;
+        uint8_t *mem = (uint8_t *) addr;
+        uint8_t *buf = (uint8_t *) buffer;
 
-	for (uint32_t i = 0; i < len; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint32_t i = 0; i < len; i++) {
+            buf[i] = mem[i];
+        }
     } else if (type == TYPE_HALF) {
-	uint16_t *mem = (uint16_t *) addr;
-	uint16_t *buf = (uint16_t *) buffer;
+        uint16_t *mem = (uint16_t *) addr;
+        uint16_t *buf = (uint16_t *) buffer;
 
-	for (uint32_t i = 0; i < len / 2; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint32_t i = 0; i < len / 2; i++) {
+            buf[i] = mem[i];
+        }
     } else {
-	uint32_t *mem = (uint32_t *) addr;
-	uint32_t *buf = (uint32_t *) buffer;
+        uint32_t *mem = (uint32_t *) addr;
+        uint32_t *buf = (uint32_t *) buffer;
 
-	for (uint32_t i = 0; i < len / 4; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint32_t i = 0; i < len / 4; i++) {
+            buf[i] = mem[i];
+        }
     }
 
     return len;
@@ -560,38 +560,38 @@ static uint32_t cmd_read(sdp_msg_t *msg)
 
 static uint32_t cmd_write(sdp_msg_t *msg)
 {
-    uint32_t addr = msg->arg1;	// Address
-    uint32_t len = msg->arg2;	// Length
-    uint32_t type = msg->arg3;	// Type
+    uint32_t addr = msg->arg1;  // Address
+    uint32_t len = msg->arg2;   // Length
+    uint32_t type = msg->arg3;  // Type
 
     if (len > SDP_BUF_SIZE || type > TYPE_WORD) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint8_t *buffer = msg->data;
 
     if (type == TYPE_BYTE) {
-	uint8_t *mem = (uint8_t *) addr;
-	uint8_t *buf = (uint8_t *) buffer;
+        uint8_t *mem = (uint8_t *) addr;
+        uint8_t *buf = (uint8_t *) buffer;
 
-	for (uint32_t i = 0; i < len; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint32_t i = 0; i < len; i++) {
+            mem[i] = buf[i];
+        }
     } else if (type == TYPE_HALF) {
-	uint16_t *mem = (uint16_t *) addr;
-	uint16_t *buf = (uint16_t *) buffer;
+        uint16_t *mem = (uint16_t *) addr;
+        uint16_t *buf = (uint16_t *) buffer;
 
-	for (uint32_t i = 0; i < len / 2; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint32_t i = 0; i < len / 2; i++) {
+            mem[i] = buf[i];
+        }
     } else {
-	uint32_t *mem = (uint32_t *) addr;
-	uint32_t *buf = (uint32_t *) buffer;
+        uint32_t *mem = (uint32_t *) addr;
+        uint32_t *buf = (uint32_t *) buffer;
 
-	for (uint32_t i = 0; i < len / 4; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint32_t i = 0; i < len / 4; i++) {
+            mem[i] = buf[i];
+        }
     }
 
     return 0;
@@ -610,54 +610,54 @@ static uint32_t cmd_iptag(sdp_msg_t *msg)
     uint32_t tag = msg->arg1 & 255;
 
     if (op > IPTAG_MAX || tag >= TAG_TABLE_SIZE) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     if (op == IPTAG_NEW || op == IPTAG_SET) {
-	if (op == IPTAG_NEW) {
-	    tag = iptag_new();
-	}
-	if (tag != TAG_NONE) {
-	    iptag_t *tt = tag_table + tag;
-	    uint32_t timeout = (msg->arg2 >> 16) & 15;
+        if (op == IPTAG_NEW) {
+            tag = iptag_new();
+        }
+        if (tag != TAG_NONE) {
+            iptag_t *tt = tag_table + tag;
+            uint32_t timeout = (msg->arg2 >> 16) & 15;
 
-	    if (timeout != 0) {
-		timeout = 1 << (timeout - 1);
-	    }
-	    tt->timeout = timeout;
+            if (timeout != 0) {
+                timeout = 1 << (timeout - 1);
+            }
+            tt->timeout = timeout;
 
-	    tt->port = msg->arg2 & 0xffff;
+            tt->port = msg->arg2 & 0xffff;
 
-	    uint8_t *ip_addr = (uint8_t *) &msg->arg3;
-	    copy_ip(ip_addr, tt->ip);
+            uint8_t *ip_addr = (uint8_t *) &msg->arg3;
+            copy_ip(ip_addr, tt->ip);
 
-	    tt->flags = IPTAG_ARP | timeout; // waiting for ARP
-	    arp_lookup(tt);
-	}
+            tt->flags = IPTAG_ARP | timeout; // waiting for ARP
+            arp_lookup(tt);
+        }
 
-	msg->arg1 = tag;
-	return 4;
+        msg->arg1 = tag;
+        return 4;
     } else if (op == IPTAG_GET) {
-	iptag_t *tt = tag_table + tag;
-	uint32_t size = msg->arg2 * sizeof(iptag_t);
+        iptag_t *tt = tag_table + tag;
+        uint32_t size = msg->arg2 * sizeof(iptag_t);
 
-	if (size > SDP_BUF_SIZE) {
-	    msg->cmd_rc = RC_ARG;
-	    return 0;
-	}
+        if (size > SDP_BUF_SIZE) {
+            msg->cmd_rc = RC_ARG;
+            return 0;
+        }
 
-	memcpy(&msg->arg1, tt, size);
-	return size;
+        memcpy(&msg->arg1, tt, size);
+        return size;
     } else if (op == IPTAG_TTO) {
-	msg->arg1 = (TAG_FIXED_SIZE << 24) + (TAG_POOL_SIZE << 16) + tag_tto;
+        msg->arg1 = (TAG_FIXED_SIZE << 24) + (TAG_POOL_SIZE << 16) + tag_tto;
 
-	if (msg->arg2 < 16) {
-	    tag_tto = msg->arg2;
-	}
-	return 4;
-    } else {				// IPTAG_CLR
-	tag_table[tag].flags = 0;
+        if (msg->arg2 < 16) {
+            tag_tto = msg->arg2;
+        }
+        return 4;
+    } else {                            // IPTAG_CLR
+        tag_table[tag].flags = 0;
     }
 
     return 0;
@@ -676,22 +676,22 @@ static uint32_t cmd_i2c(sdp_msg_t *msg)
     uint32_t count = msg->arg3;
 
     if (count > SDP_BUF_SIZE || !bp_ctrl) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint32_t ctrl = msg->arg1;
     uint32_t addr = msg->arg2;
 
-    if (ctrl > 256) {		// Poll
-	msg->arg1 = i2c_poll (LPC_I2C0, ctrl & 255);
-	return 4;
-    } else if (ctrl & 1) {	// Read
-	i2c_receive(LPC_I2C0, ctrl, addr, count, (void *) &msg->arg1);
-	return count;
-    } else {			// Write
-	i2c_send(LPC_I2C0, ctrl, addr, count, msg->data);
-	return 0;
+    if (ctrl > 256) {           // Poll
+        msg->arg1 = i2c_poll (LPC_I2C0, ctrl & 255);
+        return 4;
+    } else if (ctrl & 1) {      // Read
+        i2c_receive(LPC_I2C0, ctrl, addr, count, (void *) &msg->arg1);
+        return count;
+    } else {                    // Write
+        i2c_send(LPC_I2C0, ctrl, addr, count, msg->data);
+        return 0;
     }
 }
 
@@ -705,79 +705,79 @@ uint32_t debug(sdp_msg_t *msg)
     uint32_t len = msg->length;
 
     if (len < 24) {
-	msg->cmd_rc = RC_LEN;
-	return 0;
+        msg->cmd_rc = RC_LEN;
+        return 0;
     }
 
     uint32_t t = msg->cmd_rc;
     msg->cmd_rc = RC_OK;
 
 //    io_printf(IO_DBG, "-- BMP debug %u %x %x %x (%u)\n",
-//	    t, msg->arg1, msg->arg2, msg->arg3, msg->length);
+//          t, msg->arg1, msg->arg2, msg->arg3, msg->length);
 
     switch (t) {
     case CMD_VER:
-	return cmd_ver(msg);
+        return cmd_ver(msg);
 
     case CMD_READ:
-	return cmd_read(msg);
+        return cmd_read(msg);
 
     case CMD_WRITE:
-	return cmd_write(msg);
+        return cmd_write(msg);
 
     case CMD_FILL:
-	return cmd_fill(msg);
+        return cmd_fill(msg);
 
     case CMD_LED:
-	return cmd_led(msg);
+        return cmd_led(msg);
 
     case CMD_FLASH_ERASE:
-	return cmd_flash_erase(msg);
+        return cmd_flash_erase(msg);
 
     case CMD_FLASH_WRITE:
-	return cmd_flash_write(msg);
+        return cmd_flash_write(msg);
 
     case CMD_FLASH_COPY:
-	boot_vec->flash_copy(msg->arg1, msg->arg2, msg->arg3, 0);
-	return 0;
+        boot_vec->flash_copy(msg->arg1, msg->arg2, msg->arg3, 0);
+        return 0;
 
     case CMD_FPGA_READ:
-	return cmd_fpga_read(msg);
+        return cmd_fpga_read(msg);
 
     case CMD_FPGA_WRITE:
-	return cmd_fpga_write(msg);
+        return cmd_fpga_write(msg);
 
     case CMD_XILINX:
-	return cmd_xilinx(msg);
+        return cmd_xilinx(msg);
 
     case CMD_RESET:
-	return cmd_reset(msg);
+        return cmd_reset(msg);
 
     case CMD_POWER:
-	return cmd_power(msg);
+        return cmd_power(msg);
 
     case CMD_IPTAG:
-	return cmd_iptag(msg);
+        return cmd_iptag(msg);
 
     case CMD_BMP_SF:
-	return cmd_sf(msg);
+        return cmd_sf(msg);
 
     case CMD_BMP_EE:
-	return cmd_ee(msg);
+        return cmd_ee(msg);
 
     case CMD_BMP_INFO:
-	return cmd_bmp_info(msg);
+        return cmd_bmp_info(msg);
 
     case 61:
-	return cmd_i2c(msg);
+        return cmd_i2c(msg);
 
     case 62:
-	configure_pwm(msg->arg1, msg->arg2);
-	return 0;
+        configure_pwm(msg->arg1, msg->arg2);
+        return 0;
 
     default:
-	msg->cmd_rc = RC_CMD;
-	return 0;
+        msg->cmd_rc = RC_CMD;
+        return 0;
     }
 }
 

--- a/bmp/bmp_crc.c
+++ b/bmp/bmp_crc.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_crc.c	    CRC32 routines for BMP LPC1768
+// bmp_crc.c        CRC32 routines for BMP LPC1768
 //
 // Author           Steve Temple, APT Group, School of Computer Science
 // Email            steven.temple@manchester.ac.uk
@@ -70,7 +70,7 @@ uint32_t crc32(void *buf, uint32_t len, uint32_t crc)
     uint8_t *buffer = (uint8_t *) buf;
 
     for (int32_t i = 0; i < len; i++) {
-	crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
+        crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
     }
     return crc;
 }
@@ -82,7 +82,7 @@ uint32_t crc32_chk(void *buf, uint32_t len)
     uint32_t crc = 0xffffffff;
 
     while (len--) {
-	crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
+        crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
     }
     return crc;
 }
@@ -97,13 +97,13 @@ void crc32_buf(void *buf, uint32_t len)
     uint32_t crc = 0xffffffff;
 
     while (len > 4) {
-	crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
-	len--;
+        crc = crc_table[(crc ^ (*buffer++)) & 0xff] ^ (crc >> 8);
+        len--;
     }
 
     while (len--) {
-	*buffer++ = crc;
-	crc = crc >> 8;
+        *buffer++ = crc;
+        crc = crc >> 8;
     }
 }
 
@@ -118,18 +118,18 @@ int main()
     uint32_t count = 0;
 
     for (int i = 0; i < 4096; i++) {
-	buf[i] = 0xff;
+        buf[i] = 0xff;
     }
     crc32_insert(buf, 4096);
     fwrite(buf, 1, 4096, stdout);
 
     while (1) {
-	uint32_t r = fread(buf, 1, 4096, stdin);
-	if (r == 0) {
-	    break;
-	}
-	count++;
-	crc = crc32(buf, r, crc);
+        uint32_t r = fread(buf, 1, 4096, stdin);
+        if (r == 0) {
+            break;
+        }
+        count++;
+        crc = crc32(buf, r, crc);
     }
 
     fprintf(stderr, "CRC32 %08x (%d)\n", crc, count);

--- a/bmp/bmp_eth.c
+++ b/bmp/bmp_eth.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_eth.c	    Ethernet hardware interface code for BMP LPC1768
+// bmp_eth.c        Ethernet hardware interface code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -21,23 +21,23 @@
 
 
 typedef struct {
-    uint32_t Packet;	// Receive Packet Descriptor
-    uint32_t Ctrl;	// Receive Control Descriptor
+    uint32_t Packet;    // Receive Packet Descriptor
+    uint32_t Ctrl;      // Receive Control Descriptor
 } rx_desc_t;
 
 
 typedef struct {
-    uint32_t Info;	// Receive Information Status
-    uint32_t HashCRC;	// Receive Hash CRC Status
+    uint32_t Info;      // Receive Information Status
+    uint32_t HashCRC;   // Receive Hash CRC Status
 } rx_stat_t;
 
 typedef struct {
-    uint32_t Packet;	// Transmit Packet Descriptor
-    uint32_t Ctrl;	// Transmit Control Descriptor
+    uint32_t Packet;    // Transmit Packet Descriptor
+    uint32_t Ctrl;      // Transmit Control Descriptor
 } tx_desc_t;
 
 typedef struct {
-    uint32_t Info;	// Transmit Information Status
+    uint32_t Info;      // Transmit Information Status
 } tx_stat_t;
 
 
@@ -67,7 +67,7 @@ void eth_update_tx(void)
     uint32_t idx = LPC_EMAC->TxProduceIndex + 1;
 
     if (idx == ETH_TX_BUFS) {
-	idx = 0;
+        idx = 0;
     }
     LPC_EMAC->TxProduceIndex = idx;
 }
@@ -77,7 +77,7 @@ void eth_rx_discard(void)
     uint32_t idx = LPC_EMAC->RxConsumeIndex + 1;
 
     if (idx == ETH_RX_BUFS) {
-	idx = 0;
+        idx = 0;
     }
     LPC_EMAC->RxConsumeIndex = idx;
 }
@@ -117,11 +117,11 @@ static void rx_desc_init(void)
 {
     // Initialise receive descriptors
     for (uint32_t i = 0; i < ETH_RX_BUFS; i++) {
-	rx_desc[i].Packet  = (uint32_t) &rx_buf[i];
-	rx_desc[i].Ctrl    = EMAC_RCTRL_INT | (EMAC_ETH_MAX_FLEN - 1);
+        rx_desc[i].Packet  = (uint32_t) &rx_buf[i];
+        rx_desc[i].Ctrl    = EMAC_RCTRL_INT | (EMAC_ETH_MAX_FLEN - 1);
 
-	rx_stat[i].Info    = 0;
-	rx_stat[i].HashCRC = 0;
+        rx_stat[i].Info    = 0;
+        rx_stat[i].HashCRC = 0;
     }
 
     // Set EMAC Receive Descriptor Registers.
@@ -137,9 +137,9 @@ static void tx_desc_init(void)
 {
     // Initialise transmit descriptors
     for (uint32_t i = 0; i < ETH_TX_BUFS; i++) {
-	tx_desc[i].Packet = (uint32_t) &tx_buf[i];
-	tx_desc[i].Ctrl   = 0;
-	tx_stat[i].Info   = 0;
+        tx_desc[i].Packet = (uint32_t) &tx_buf[i];
+        tx_desc[i].Ctrl   = 0;
+        tx_stat[i].Info   = 0;
     }
 
     // Set EMAC Transmit Descriptor Registers
@@ -156,10 +156,10 @@ void configure_eth(uint8_t *mac_addr)
 {
     // Reset all EMAC internal modules
     LPC_EMAC->MAC1 = EMAC_MAC1_RES_TX | EMAC_MAC1_RES_MCS_TX
-	    | EMAC_MAC1_RES_RX | EMAC_MAC1_RES_MCS_RX | EMAC_MAC1_SIM_RES
-	    | EMAC_MAC1_SOFT_RES;
+            | EMAC_MAC1_RES_RX | EMAC_MAC1_RES_MCS_RX | EMAC_MAC1_SIM_RES
+            | EMAC_MAC1_SOFT_RES;
     LPC_EMAC->Command = EMAC_CR_REG_RES | EMAC_CR_TX_RES | EMAC_CR_RX_RES
-	    | EMAC_CR_PASS_RUNT_FRM;
+            | EMAC_CR_PASS_RUNT_FRM;
 
     delay_us(5);
 
@@ -188,7 +188,7 @@ void configure_eth(uint8_t *mac_addr)
     LPC_EMAC->SUPP = 0;
     */
 
-    LPC_EMAC->SUPP = EMAC_SUPP_SPEED;	//!! Bodge - assume 100 MHz for now
+    LPC_EMAC->SUPP = EMAC_SUPP_SPEED;   //!! Bodge - assume 100 MHz for now
 
     // Set EMAC address
     LPC_EMAC->SA0 = (mac_addr[5] << 8) | mac_addr[4];
@@ -201,7 +201,7 @@ void configure_eth(uint8_t *mac_addr)
 
     // Set Receive Filter register: enable broadcast and multicast
     LPC_EMAC->RxFilterCtrl = EMAC_RFC_MCAST_EN | EMAC_RFC_BCAST_EN
-	    | EMAC_RFC_PERFECT_EN;
+            | EMAC_RFC_PERFECT_EN;
 
     // Enable Rx Done and Tx Done interrupt for EMAC
     //!!  LPC_EMAC->IntEnable = EMAC_INT_RX_DONE | EMAC_INT_TX_DONE;

--- a/bmp/bmp_event.c
+++ b/bmp/bmp_event.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_event.c	    Event handling routines for BMP LPC1768
+// bmp_event.c      Event handling routines for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -14,15 +14,15 @@
 
 //------------------------------------------------------------------------------
 
-static event_t *event_list;	// List of free events
-static event_t *event_queue;	// List of active events
+static event_t *event_list;     // List of free events
+static event_t *event_queue;    // List of active events
 
-static event_t *proc_head;	// List of queued "proc" events
-static event_t *proc_tail;	// and tail of that list
+static event_t *proc_head;      // List of queued "proc" events
+static event_t *proc_tail;      // and tail of that list
 
-static uint32_t event_id;	// Makes unique ID for active events
-static uint32_t event_count;	// Number of events currently in use
-static uint32_t event_max;	// Maximum number ever used
+static uint32_t event_id;       // Makes unique ID for active events
+static uint32_t event_count;    // Number of events currently in use
+static uint32_t event_max;      // Maximum number ever used
 
 #define NUM_EVENTS 16
 
@@ -42,8 +42,8 @@ void event_init(uint32_t priority)
     event_t *e = event_list = events;
 
     for (uint32_t i = 0; i < NUM_EVENTS - 1; i++) {
-	e->next = e + 1;
-	e = e + 1;
+        e->next = e + 1;
+        e = e + 1;
     }
 
     e->next = NULL;
@@ -62,10 +62,10 @@ void proc_queue_add(event_t *e)
     uint32_t cpsr = cpu_int_off();
 
     if (proc_head == NULL) {
-	proc_head = proc_tail = e;
+        proc_head = proc_tail = e;
     } else {
-	proc_tail->next = e;
-	proc_tail = e;
+        proc_tail->next = e;
+        proc_tail = e;
     }
     
     cpu_int_restore(cpsr);
@@ -79,26 +79,26 @@ void proc_queue_run()
 {
     uint32_t cpsr = cpu_int_off();
 
-    event_t *e = proc_head;	// Get list of events and
-    proc_head = NULL;		// update list head
+    event_t *e = proc_head;     // Get list of events and
+    proc_head = NULL;           // update list head
 
     cpu_int_restore(cpsr);
 
     while (e != NULL) {
-	e->proc(e->arg1, e->arg2);// No need to check for NULL here
+        e->proc(e->arg1, e->arg2);// No need to check for NULL here
 
-	event_t *next = e->next;
+        event_t *next = e->next;
 
-	uint32_t cpsr = cpu_int_off();
+        uint32_t cpsr = cpu_int_off();
 
-	e->next = event_list;	// Return to free queue
-	event_list = e;
-	e->ID = 0;
-	event_count--;
+        e->next = event_list;   // Return to free queue
+        event_list = e;
+        e->ID = 0;
+        event_count--;
 
-	cpu_int_restore(cpsr);
+        cpu_int_restore(cpsr);
 
-	e = next;
+        e = next;
     }
 }
 
@@ -107,42 +107,42 @@ void proc_queue_run()
 
 void TIMER3_IRQHandler(void)
 {
-    LPC_TIM3->IR = 1;			// Clear MR0 interrupt
+    LPC_TIM3->IR = 1;                   // Clear MR0 interrupt
 
-    event_t *e = event_queue;		// Pointer to event queue
-    event_t *eq = NULL;			// Accumulates list of events to execute
+    event_t *e = event_queue;           // Pointer to event queue
+    event_t *eq = NULL;                 // Accumulates list of events to execute
 
-    while (e != NULL && e->time == 0) {	// Process all in queue with time=0
-	event_t *next = e->next;	// Remove head of event queue
-	event_queue = next;
+    while (e != NULL && e->time == 0) { // Process all in queue with time=0
+        event_t *next = e->next;        // Remove head of event queue
+        event_queue = next;
 
-	e->next = eq;			// Move to exec queue
-	eq = e;
+        e->next = eq;                   // Move to exec queue
+        eq = e;
 
-	e = next;			// Move to next entry
+        e = next;                       // Move to next entry
     }
 
-    if (e != NULL) {			// If entries remain in queue
-	LPC_TIM3->MR0 = e->time;	// Put first one into timer
-	e->time = 0;			// Set head of queue time to zero
+    if (e != NULL) {                    // If entries remain in queue
+        LPC_TIM3->MR0 = e->time;        // Put first one into timer
+        e->time = 0;                    // Set head of queue time to zero
 
-	LPC_TIM3->TC = 0;		// Set timer back to zero
-	LPC_TIM3->MCR = 5;		// Interrupt and stop on match
-	LPC_TIM3->TCR = 1;		// Enable counting
+        LPC_TIM3->TC = 0;               // Set timer back to zero
+        LPC_TIM3->MCR = 5;              // Interrupt and stop on match
+        LPC_TIM3->TCR = 1;              // Enable counting
     }
 
-    while (eq != NULL) {		// Run the execute queue
-	if (eq->proc != NULL) {		// Execute proc if non-NULL
-	    eq->proc(eq->arg1, eq->arg2);
-	}
-	event_t *next = eq->next;
+    while (eq != NULL) {                // Run the execute queue
+        if (eq->proc != NULL) {         // Execute proc if non-NULL
+            eq->proc(eq->arg1, eq->arg2);
+        }
+        event_t *next = eq->next;
 
-	eq->next = event_list;		// Return to free queue
-	event_list = eq;
-	eq->ID = 0;
-	event_count--;
+        eq->next = event_list;          // Return to free queue
+        event_list = eq;
+        eq->ID = 0;
+        event_count--;
 
-	eq = next;
+        eq = next;
     }
 }
 
@@ -159,34 +159,34 @@ void event_cancel(event_t *e, uint32_t ID)
 {
     uint32_t cpsr = cpu_int_off();
 
-    if (e->ID == ID) { 			// Still active (return if not)
-	event_t *q = event_queue;
+    if (e->ID == ID) {                  // Still active (return if not)
+        event_t *q = event_queue;
 
-	if (q == e) { 			// At head of queue - nullify proc
-	    e->proc = NULL;
-	} else { 			// Further down queue - remove
-	    event_t *pq = q;
-	    q = q->next;
+        if (q == e) {                   // At head of queue - nullify proc
+            e->proc = NULL;
+        } else {                        // Further down queue - remove
+            event_t *pq = q;
+            q = q->next;
 
-	    while (q != NULL) {
-		if (q == e) {
-		    pq->next = e->next;
+            while (q != NULL) {
+                if (q == e) {
+                    pq->next = e->next;
 
-		    if (e->next != NULL) { // Add our time to next in queue
-			e->next->time += e->time;
-		    }
-		    e->next = event_list;  // Return to free queue
-		    event_list = e;
-		    e->ID = 0;
-		    event_count--;
+                    if (e->next != NULL) { // Add our time to next in queue
+                        e->next->time += e->time;
+                    }
+                    e->next = event_list;  // Return to free queue
+                    event_list = e;
+                    e->ID = 0;
+                    event_count--;
 
-		    break;
-		}
+                    break;
+                }
 
-		pq = q;
-		q = q->next;
-	    }
-	}
+                pq = q;
+                q = q->next;
+            }
+        }
     }
 
     cpu_int_restore(cpsr);
@@ -204,25 +204,25 @@ event_t* event_new(event_proc proc, uint32_t arg1, uint32_t arg2)
     event_t *e = event_list;
 
     if (e != NULL) {
-	uint32_t next_id = event_id + 1;
+        uint32_t next_id = event_id + 1;
 
-	if (next_id == 0) {
-	    next_id = 1;
-	}
-	event_list = e->next;
-	e->next = NULL;
+        if (next_id == 0) {
+            next_id = 1;
+        }
+        event_list = e->next;
+        e->next = NULL;
 
-	e->ID = event_id = next_id;
+        e->ID = event_id = next_id;
 
-	e->proc = proc;
-	e->arg1 = arg1;
-	e->arg2 = arg2;
-	e->time = 0;
+        e->proc = proc;
+        e->arg1 = arg1;
+        e->arg2 = arg2;
+        e->time = 0;
 
-	event_count++;
-	if (event_count > event_max) {
-	    event_max = event_count;
-	}
+        event_count++;
+        if (event_count > event_max) {
+            event_max = event_count;
+        }
     }
 
     cpu_int_restore(cpsr);
@@ -233,40 +233,40 @@ event_t* event_new(event_proc proc, uint32_t arg1, uint32_t arg2)
 
 void event_schedule(event_t *e, uint32_t time)
 {
-    time *= CCLK / 1000000;	// Convert us to timer ticks
+    time *= CCLK / 1000000;     // Convert us to timer ticks
 
     uint32_t cpsr = cpu_int_off();
 
-    if (event_queue == NULL) {	// Queue empty - just insert
-	event_queue = e;
+    if (event_queue == NULL) {  // Queue empty - just insert
+        event_queue = e;
 
-	LPC_TIM3->MR0 = time;	// Set match register
-	LPC_TIM3->TC = 0;	// Set timer back to zero
-	LPC_TIM3->MCR = 5;	// Interrupt and stop on match
-	LPC_TIM3->TCR = 1;	// Enable counting
+        LPC_TIM3->MR0 = time;   // Set match register
+        LPC_TIM3->TC = 0;       // Set timer back to zero
+        LPC_TIM3->MCR = 5;      // Interrupt and stop on match
+        LPC_TIM3->TCR = 1;      // Enable counting
 
-	cpu_int_restore(cpsr);
-	return;
+        cpu_int_restore(cpsr);
+        return;
     }
 
-    LPC_TIM3->TCR = 0;		//## Stop counting
+    LPC_TIM3->TCR = 0;          //## Stop counting
 
     uint32_t t2c = LPC_TIM3->MR0 - LPC_TIM3->TC;
 
-    if (time < t2c) {		// Earlier than current head - replace
-	LPC_TIM3->MR0 = LPC_TIM3->TC + time;	// Set counter to new time
-	LPC_TIM3->TCR = 1;	//## Start counting
+    if (time < t2c) {           // Earlier than current head - replace
+        LPC_TIM3->MR0 = LPC_TIM3->TC + time;    // Set counter to new time
+        LPC_TIM3->TCR = 1;      //## Start counting
 
-	event_queue->time = t2c - time;	// Adjust old head time
+        event_queue->time = t2c - time; // Adjust old head time
 
-	e->next = event_queue;		// and insert new event at head
-	event_queue = e;
+        e->next = event_queue;          // and insert new event at head
+        event_queue = e;
 
-	cpu_int_restore(cpsr);
-	return;
+        cpu_int_restore(cpsr);
+        return;
     }
 
-    LPC_TIM3->TCR = 1;		//## Start counting
+    LPC_TIM3->TCR = 1;          //## Start counting
 
     // (time >= t2c) - Insert in correct place in queue (tricky!)
 
@@ -279,16 +279,16 @@ void event_schedule(event_t *e, uint32_t time)
     time -= t2c;
 
     while (q != NULL) {
-	total += q->time;
+        total += q->time;
 
-	if (total > time) {
-	    q->time = total - time;
-	    break;
-	}
+        if (total > time) {
+            q->time = total - time;
+            break;
+        }
 
-	pq = q;
-	ptotal += q->time;
-	q = q->next;
+        pq = q;
+        ptotal += q->time;
+        q = q->next;
     }
 
     e->time = time - ptotal;

--- a/bmp/bmp_flash.c
+++ b/bmp/bmp_flash.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_flash.c	    Flash routines for BMP LPC1768
+// bmp_flash.c      Flash routines for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2013-2015
 //
@@ -23,9 +23,9 @@ uint32_t is_blank(void *buf, uint32_t len)
     uint8_t *buffer = (uint8_t *) buf;
 
     for (uint32_t i = 0; i < len; i++) {
-	if (buffer[i] != 0xff) {
-	    return 0;
-	}
+        if (buffer[i] != 0xff) {
+            return 0;
+        }
     }
     return 1;
 }
@@ -40,9 +40,9 @@ uint32_t is_blank(void *buf, uint32_t len)
 uint32_t flash_sector(uint32_t addr)
 {
     if (addr < 0x10000) {
-	return addr / 4096;
+        return addr / 4096;
     } else {
-	return 16 + (addr - 0x10000) / 32768;
+        return 16 + (addr - 0x10000) / 32768;
     }
 }
 
@@ -59,16 +59,16 @@ uint32_t flash_erase(uint32_t start, uint32_t end)
     uint32_t iap_cmd[5];
     uint32_t iap_res[4];
 
-    iap_cmd[0] = 50;			// Flash prepare
+    iap_cmd[0] = 50;                    // Flash prepare
     iap_cmd[1] = ss;
     iap_cmd[2] = es;
 
     lpc_iap(iap_cmd, iap_res);
 
     if (iap_res[0] == 0) {
-	iap_cmd[0] = 52;		// Flash erase
-	iap_cmd[3] = CCLK / 1000;
-	lpc_iap(iap_cmd, iap_res);
+        iap_cmd[0] = 52;                // Flash erase
+        iap_cmd[3] = CCLK / 1000;
+        lpc_iap(iap_cmd, iap_res);
     }
 
     return iap_res[0];
@@ -88,20 +88,20 @@ uint32_t flash_write(uint32_t addr, uint32_t length, uint32_t *buffer)
     uint32_t iap_cmd[5];
     uint32_t iap_res[4];
 
-    iap_cmd[0] = 50;			// Flash prepare
+    iap_cmd[0] = 50;                    // Flash prepare
     iap_cmd[1] = ss;
     iap_cmd[2] = ss;
 
     lpc_iap(iap_cmd, iap_res);
 
     if (iap_res[0] == 0) {
-	iap_cmd[0] = 51;		// Flash copy
-	iap_cmd[1] = addr;
-	iap_cmd[2] = (uint32_t) buffer;
-	iap_cmd[3] = length;
-	iap_cmd[4] = CCLK / 1000;
+        iap_cmd[0] = 51;                // Flash copy
+        iap_cmd[1] = addr;
+        iap_cmd[2] = (uint32_t) buffer;
+        iap_cmd[3] = length;
+        iap_cmd[4] = CCLK / 1000;
 
-	lpc_iap(iap_cmd, iap_res);
+        lpc_iap(iap_cmd, iap_res);
     }
 
     return iap_res[0];

--- a/bmp/bmp_hw.c
+++ b/bmp/bmp_hw.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_hw.c	    Low-level hardware interface code for BMP LPC1768
+// bmp_hw.c         Low-level hardware interface code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -21,81 +21,81 @@
 
 // Port 0
 
-#define FAN_ED2		(1 << 6)
+#define FAN_ED2         (1 << 6)
 
-#define IO_EN1      	(1 << 23)
+#define IO_EN1          (1 << 23)
 
-#define I2C_SDA		(1 << 27)
-#define I2C_SCL		(1 << 28)
+#define I2C_SDA         (1 << 27)
+#define I2C_SCL         (1 << 28)
 
-#define P0_EN       	(SF_NCS + IO_EN1 + LED_MASK)
+#define P0_EN           (SF_NCS + IO_EN1 + LED_MASK)
 
-#define P0_INIT     	(SF_NCS + IO_EN1 + LED_0)
+#define P0_INIT         (SF_NCS + IO_EN1 + LED_0)
 
 
 //------------------------------------------------------------------------------
 // Port 1
 
-#define XIL_RST		(1 << 14)
+#define XIL_RST         (1 << 14)
 
-#define EN_V12	    	(1 << 18)
-#define EN_V18	    	(1 << 19)
-#define EN_VFPGA      	(1 << 20)
+#define EN_V12          (1 << 18)
+#define EN_V18          (1 << 19)
+#define EN_VFPGA        (1 << 20)
 
-#define XPROGB_0    	(1 << 21)
-#define XPROGB_1    	(1 << 23)
-#define XPROGB_2    	(1 << 24)
+#define XPROGB_0        (1 << 21)
+#define XPROGB_1        (1 << 23)
+#define XPROGB_2        (1 << 24)
 
-#define XDONE       	(1 << 31)
+#define XDONE           (1 << 31)
 
-#define P1_EN       	(EN_V12 + EN_V18 + EN_VFPGA + XPROGB_0 + XPROGB_1 + \
-			 XPROGB_2 + XIL_RST)
+#define P1_EN           (EN_V12 + EN_V18 + EN_VFPGA + XPROGB_0 + XPROGB_1 + \
+                         XPROGB_2 + XIL_RST)
 
-#define P1_INIT     	(EN_V12 + EN_V18 + XPROGB_0 + XPROGB_1 + XPROGB_2)
+#define P1_INIT         (EN_V12 + EN_V18 + XPROGB_0 + XPROGB_1 + XPROGB_2)
 
 //------------------------------------------------------------------------------
 // Port 2
 
-#define BOOT_1      	(1 << 0)	// GPIO[1]
-#define IO_6      	(1 << 1)	// GPIO[6]
-#define IO_7        	(1 << 2)	// GPIO[7]
-#define IO_8       	(1 << 3)
-#define IO_9       	(1 << 4)
-#define FAN_PWM		(1 << 5)
-#define POR         	(1 << 6)
-#define RST         	(1 << 7)
+#define BOOT_1          (1 << 0)        // GPIO[1]
+#define IO_6            (1 << 1)        // GPIO[6]
+#define IO_7            (1 << 2)        // GPIO[7]
+#define IO_8            (1 << 3)
+#define IO_9            (1 << 4)
+#define FAN_PWM         (1 << 5)
+#define POR             (1 << 6)
+#define RST             (1 << 7)
 
-#define FAN_ED0		(1 << 8)
-#define FAN_ED1		(1 << 9)
-#define IO_EN2      	(1 << 10)
-#define XINITB_0     	(1 << 11)
-#define XINITB_1     	(1 << 12)
-#define XINITB_2     	(1 << 13)
+#define FAN_ED0         (1 << 8)
+#define FAN_ED1         (1 << 9)
+#define IO_EN2          (1 << 10)
+#define XINITB_0        (1 << 11)
+#define XINITB_1        (1 << 12)
+#define XINITB_2        (1 << 13)
 
-#define XINIT_B		(XINITB_0 + XINITB_1 + XINITB_2)
+#define XINIT_B         (XINITB_0 + XINITB_1 + XINITB_2)
 
-#define P2_EN       	(BOOT_1 + POR + RST + IO_EN2 + IO_6 + \
-                     	IO_7 + IO_8 + IO_9)
+#define P2_EN           (BOOT_1 + POR + RST + IO_EN2 + IO_6 + \
+                        IO_7 + IO_8 + IO_9)
 
-#define P2_INIT     	(IO_6 + IO_EN2)	// BootROM + serial + POST
+#define P2_INIT         (IO_6 + IO_EN2) // BootROM + serial + POST
 
 //------------------------------------------------------------------------------
 // Port 3
 
 
-#define P3_EN 	    	(XFSEL_0 + XFSEL_1)
-#define P3_INIT     	(XFSEL_0 + XFSEL_1)
+#define P3_EN           (XFSEL_0 + XFSEL_1)
+#define P3_INIT         (XFSEL_0 + XFSEL_1)
 
 //------------------------------------------------------------------------------
 // Port 4
 
 
-#define P4_EN 	    	(XFSEL_2)
-#define P4_INIT     	(XFSEL_2)
+#define P4_EN           (XFSEL_2)
+#define P4_INIT         (XFSEL_2)
 
 //------------------------------------------------------------------------------
 
-#define XTAL_CLK 25000000	// Xtal clock (25 MHz)
+#define XTAL_CLK 25000000       // Xtal clock (25 MHz)
 
 /*
   Crystal on main osc is 25 MHz and we want 100 MHz CCLK. Use a 300 MHz
@@ -111,62 +111,62 @@
 #define PDIV2 2
 #define PDIV8 3
 
-#define	PCLKSEL_WDT  		0
-#define	PCLKSEL_TIMER0  	2
-#define	PCLKSEL_TIMER1  	4
-#define	PCLKSEL_UART0  		6
-#define	PCLKSEL_UART1  		8
-#define	PCLKSEL_PWM1  		12
-#define	PCLKSEL_I2C0  		14
-#define	PCLKSEL_SPI  		16
-#define	PCLKSEL_SSP1  		20
-#define	PCLKSEL_DAC  		22
-#define	PCLKSEL_ADC  		24
-#define	PCLKSEL_CAN1 		26
-#define	PCLKSEL_CAN2 		28
-#define	PCLKSEL_ACF  		30
+#define PCLKSEL_WDT             0
+#define PCLKSEL_TIMER0          2
+#define PCLKSEL_TIMER1          4
+#define PCLKSEL_UART0           6
+#define PCLKSEL_UART1           8
+#define PCLKSEL_PWM1            12
+#define PCLKSEL_I2C0            14
+#define PCLKSEL_SPI             16
+#define PCLKSEL_SSP1            20
+#define PCLKSEL_DAC             22
+#define PCLKSEL_ADC             24
+#define PCLKSEL_CAN1            26
+#define PCLKSEL_CAN2            28
+#define PCLKSEL_ACF             30
 
-#define	PCLKSEL_QEI  		0
-#define	PCLKSEL_PCB  		4
-#define	PCLKSEL_I2C1  		6
-#define	PCLKSEL_SSP0  		10
-#define	PCLKSEL_TIMER2  	12
-#define	PCLKSEL_TIMER3  	14
-#define	PCLKSEL_UART2  		16
-#define	PCLKSEL_UART3  		18
-#define	PCLKSEL_I2C2  		20
-#define	PCLKSEL_I2S  		22
-#define	PCLKSEL_RIT  		26
-#define	PCLKSEL_SYSCON  	28
-#define	PCLKSEL_MC  		30
+#define PCLKSEL_QEI             0
+#define PCLKSEL_PCB             4
+#define PCLKSEL_I2C1            6
+#define PCLKSEL_SSP0            10
+#define PCLKSEL_TIMER2          12
+#define PCLKSEL_TIMER3          14
+#define PCLKSEL_UART2           16
+#define PCLKSEL_UART3           18
+#define PCLKSEL_I2C2            20
+#define PCLKSEL_I2S             22
+#define PCLKSEL_RIT             26
+#define PCLKSEL_SYSCON          28
+#define PCLKSEL_MC              30
 
-#define	PCONP_PCTIM0	        (1<<1)
-#define	PCONP_PCTIM1	        (1<<2)
-#define	PCONP_PCUART0  	        (1<<3)
-#define	PCONP_PCUART1  	        (1<<4)
-#define	PCONP_PCPWM1	        (1<<6)
-#define	PCONP_PCI2C0	        (1<<7)
-#define	PCONP_PCSPI  	        (1<<8)
-#define	PCONP_PCRTC  	        (1<<9)
-#define	PCONP_PCSSP1	        (1<<10)
-#define	PCONP_PCAD  	        (1<<12)
-#define	PCONP_PCAN1  	        (1<<13)
-#define	PCONP_PCAN2 	        (1<<14)
-#define	PCONP_PCGPIO 	        (1<<15)
-#define	PCONP_PCRIT 	        (1<<16)
-#define PCONP_PCMC 	        (1<<17)
-#define PCONP_PCQEI	        (1<<18)
-#define	PCONP_PCI2C1  	        (1<<19)
-#define	PCONP_PCSSP0	        (1<<21)
-#define	PCONP_PCTIM2	        (1<<22)
-#define	PCONP_PCTIM3	        (1<<23)
-#define	PCONP_PCUART2  	        (1<<24)
-#define	PCONP_PCUART3  	        (1<<25)
-#define	PCONP_PCI2C2	        (1<<26)
-#define	PCONP_PCI2S  	        (1<<27)
-#define	PCONP_PCGPDMA  	        (1<<29)
-#define	PCONP_PCENET	        (1<<30)
-#define	PCONP_PCUSB  	        (1<<31)
+#define PCONP_PCTIM0            (1<<1)
+#define PCONP_PCTIM1            (1<<2)
+#define PCONP_PCUART0           (1<<3)
+#define PCONP_PCUART1           (1<<4)
+#define PCONP_PCPWM1            (1<<6)
+#define PCONP_PCI2C0            (1<<7)
+#define PCONP_PCSPI             (1<<8)
+#define PCONP_PCRTC             (1<<9)
+#define PCONP_PCSSP1            (1<<10)
+#define PCONP_PCAD              (1<<12)
+#define PCONP_PCAN1             (1<<13)
+#define PCONP_PCAN2             (1<<14)
+#define PCONP_PCGPIO            (1<<15)
+#define PCONP_PCRIT             (1<<16)
+#define PCONP_PCMC              (1<<17)
+#define PCONP_PCQEI             (1<<18)
+#define PCONP_PCI2C1            (1<<19)
+#define PCONP_PCSSP0            (1<<21)
+#define PCONP_PCTIM2            (1<<22)
+#define PCONP_PCTIM3            (1<<23)
+#define PCONP_PCUART2           (1<<24)
+#define PCONP_PCUART3           (1<<25)
+#define PCONP_PCI2C2            (1<<26)
+#define PCONP_PCI2S             (1<<27)
+#define PCONP_PCGPDMA           (1<<29)
+#define PCONP_PCENET            (1<<30)
+#define PCONP_PCUSB             (1<<31)
 
 // Timer 0 - 100MHz
 // Timer 1 - 100MHz
@@ -217,14 +217,14 @@ board_stat_t board_stat[CAN_SIZE];
 
 static uint32_t adc_chan;
 
-uint8_t can_ID;		// CAN ID (from backplane)
-uint8_t board_ID;	// Board ID (devived from can_ID)
-bool bp_ctrl;		// Backplane controller
-bool fan_sense;		// Compute fan speed
+uint8_t can_ID;         // CAN ID (from backplane)
+uint8_t board_ID;       // Board ID (devived from can_ID)
+bool bp_ctrl;           // Backplane controller
+bool fan_sense;         // Compute fan speed
 
-uint8_t power_state;	// Power supply state
+uint8_t power_state;    // Power supply state
 
-ee_data_t ee_data;	// Copy of EEPROM data
+ee_data_t ee_data;      // Copy of EEPROM data
 
 extern uint32_t config1, config2;
 
@@ -257,12 +257,12 @@ __asm void cpu_int_restore(uint32_t cpsr)
 void clock_div (uint32_t bit_pos, uint32_t value)
 {
     if (bit_pos < 32) {
-	LPC_SC->PCLKSEL0 &= (~(CLKPWR_PCLKSEL_BITMASK (bit_pos)));
-	LPC_SC->PCLKSEL0 |= (CLKPWR_PCLKSEL_SET (bit_pos, value));
+        LPC_SC->PCLKSEL0 &= (~(CLKPWR_PCLKSEL_BITMASK (bit_pos)));
+        LPC_SC->PCLKSEL0 |= (CLKPWR_PCLKSEL_SET (bit_pos, value));
     } else {
-	bit_pos -= 32;
-	LPC_SC->PCLKSEL1 &= ~(CLKPWR_PCLKSEL_BITMASK (bit_pos));
-	LPC_SC->PCLKSEL1 |= (CLKPWR_PCLKSEL_SET (bit_pos, value));
+        bit_pos -= 32;
+        LPC_SC->PCLKSEL1 &= ~(CLKPWR_PCLKSEL_BITMASK (bit_pos));
+        LPC_SC->PCLKSEL1 |= (CLKPWR_PCLKSEL_SET (bit_pos, value));
     }
 }
 
@@ -272,21 +272,21 @@ void clock_div (uint32_t bit_pos, uint32_t value)
 void set_power(uint32_t state)
 {
     if (state == POWER_ON) {
-	LPC_GPIO0->FIOSET = LED_1;
-	LPC_GPIO2->FIOSET = POR;	// Set POR
+        LPC_GPIO0->FIOSET = LED_1;
+        LPC_GPIO2->FIOSET = POR;        // Set POR
 
-	LPC_GPIO0->FIOCLR = IO_EN1;
-	LPC_GPIO1->FIOCLR = EN_V12 + EN_V18;
-	LPC_GPIO1->FIOSET = EN_VFPGA;
+        LPC_GPIO0->FIOCLR = IO_EN1;
+        LPC_GPIO1->FIOCLR = EN_V12 + EN_V18;
+        LPC_GPIO1->FIOSET = EN_VFPGA;
 
-	board_stat_t *stat = &board_stat[can_ID];
-	stat->shutdown = 0;
+        board_stat_t *stat = &board_stat[can_ID];
+        stat->shutdown = 0;
     } else {
-	LPC_GPIO0->FIOCLR = LED_1;
+        LPC_GPIO0->FIOCLR = LED_1;
 
-	LPC_GPIO0->FIOSET = IO_EN1;
-	LPC_GPIO1->FIOSET = EN_V12 + EN_V18;
-	LPC_GPIO1->FIOCLR = EN_VFPGA;
+        LPC_GPIO0->FIOSET = IO_EN1;
+        LPC_GPIO1->FIOSET = EN_V12 + EN_V18;
+        LPC_GPIO1->FIOCLR = EN_VFPGA;
     }
 
     power_state = state;
@@ -304,22 +304,22 @@ static const uint32_t led_bit[] = {
 void led_set(uint32_t leds)
 {
     for (uint32_t i = 0; i < 8; i++) {
-	uint32_t led = led_bit[i];
-	uint32_t cmd = leds & 3;
+        uint32_t led = led_bit[i];
+        uint32_t cmd = leds & 3;
 
-	leds = leds >> 2;
+        leds = leds >> 2;
 
-	switch (cmd) {
-	case 1:
-	    LPC_GPIO0->FIOPIN ^= led;
-	    break;
-	case 2:
-	    LPC_GPIO0->FIOCLR = led;
-	    break;
-	case 3:
-	    LPC_GPIO0->FIOSET = led;
-	    break;
-	}
+        switch (cmd) {
+        case 1:
+            LPC_GPIO0->FIOPIN ^= led;
+            break;
+        case 2:
+            LPC_GPIO0->FIOCLR = led;
+            break;
+        case 3:
+            LPC_GPIO0->FIOSET = led;
+            break;
+        }
     }
 }
 
@@ -330,15 +330,15 @@ void led_set(uint32_t leds)
 void fpga_reset(uint32_t code)
 {
     if (code == 0) {
-	LPC_GPIO1->FIOCLR = XIL_RST;
+        LPC_GPIO1->FIOCLR = XIL_RST;
     } else if (code == 1) {
-	LPC_GPIO1->FIOSET = XIL_RST;
+        LPC_GPIO1->FIOSET = XIL_RST;
     } else {
-	LPC_GPIO1->FIOSET = XIL_RST;
-	delay_us(5);
-	LPC_GPIO1->FIOCLR = XIL_RST;
-	delay_us(5);
-	LPC_GPIO1->FIOSET = XIL_RST;
+        LPC_GPIO1->FIOSET = XIL_RST;
+        delay_us(5);
+        LPC_GPIO1->FIOCLR = XIL_RST;
+        delay_us(5);
+        LPC_GPIO1->FIOSET = XIL_RST;
     }
 }
 
@@ -349,46 +349,46 @@ uint32_t fpga_init(uint32_t mask)
     uint32_t xinitb = 0;
 
     if (mask & 1) {
-	xprogb |= XPROGB_0;
-	xinitb |= XINITB_0;
+        xprogb |= XPROGB_0;
+        xinitb |= XINITB_0;
     }
     if (mask & 2) {
-	xprogb |= XPROGB_1;
-	xinitb |= XINITB_1;
+        xprogb |= XPROGB_1;
+        xinitb |= XINITB_1;
     }
     if (mask & 4) {
-	xprogb |= XPROGB_2;
-	xinitb |= XINITB_2;
+        xprogb |= XPROGB_2;
+        xinitb |= XINITB_2;
     }
 
-    LPC_GPIO1->FIOCLR = XIL_RST;	// Reset line (HSWAPEN) low
+    LPC_GPIO1->FIOCLR = XIL_RST;        // Reset line (HSWAPEN) low
 
-    uint32_t led = LPC_GPIO0->FIOPIN & (LED_5 + LED_6);	// Save state of LEDs
-    LPC_GPIO0->FIOSET = LED_5 + LED_6;	// Set M0, M1 high
+    uint32_t led = LPC_GPIO0->FIOPIN & (LED_5 + LED_6); // Save state of LEDs
+    LPC_GPIO0->FIOSET = LED_5 + LED_6;  // Set M0, M1 high
 
-    LPC_GPIO1->FIOSET = xprogb;		// Set PROGB high
+    LPC_GPIO1->FIOSET = xprogb;         // Set PROGB high
     delay_us(5);
-    LPC_GPIO1->FIOCLR = xprogb;		// then low
+    LPC_GPIO1->FIOCLR = xprogb;         // then low
     delay_us(5);
-    LPC_GPIO1->FIOSET = xprogb;		// then high again
+    LPC_GPIO1->FIOSET = xprogb;         // then high again
 
     // M0, M1 have to be held for some time after PROGB rises otherwise
     // the FPGAs start up in the wrong configuration mode and drive CCLK
     // themselves (not good!)
 
-    delay_us(2000);		// Determined by guesswork! Should be checked
+    delay_us(2000);             // Determined by guesswork! Should be checked
 
-    LPC_GPIO0->FIOCLR = LED_5 + LED_6;	// Clear LEDs
-    LPC_GPIO0->FIOSET = led;		// and restore
+    LPC_GPIO0->FIOCLR = LED_5 + LED_6;  // Clear LEDs
+    LPC_GPIO0->FIOSET = led;            // and restore
 
     uint32_t t = 1024;
 
     // Spin4 has all InitB signals commoned - Spin5 has 3 separate lines
 
     while ((LPC_GPIO2->FIOPIN & xinitb) != xinitb) { // Wait for INITB high
-	delay_us(10);
-	if (--t == 0) {
-	    return 0;
+        delay_us(10);
+        if (--t == 0) {
+            return 0;
         }
     }
 
@@ -398,11 +398,11 @@ uint32_t fpga_init(uint32_t mask)
 //------------------------------------------------------------------------------
 
 
-#define ADC_PCLK	25000000	// 25 MHz
-#define ADC_CLK		13000000	// 13 MHz
-#define ADC_PDN		(1 << 21)
+#define ADC_PCLK        25000000        // 25 MHz
+#define ADC_CLK         13000000        // 13 MHz
+#define ADC_PDN         (1 << 21)
 
-#define ADC_VALID	0xde		// Channels 0, 5 not used on Spin5
+#define ADC_VALID       0xde            // Channels 0, 5 not used on Spin5
 
 // Channels 0-7 - V12d, V12c, V12b, V12a, V18, V25, V33, Vpwr
 
@@ -413,7 +413,7 @@ static void configure_adc(void)
     LPC_ADC->ADCR = ADC_PDN + ((div - 1) << 8);
 
     for (uint32_t i = 0; i < 8; i++) {
-	board_stat[can_ID].adc[i] = UINT16_MAX;
+        board_stat[can_ID].adc[i] = UINT16_MAX;
     }
 }
 
@@ -423,15 +423,15 @@ void read_adc(void)
     uint32_t *adc = (uint32_t *) &LPC_ADC->ADDR0;
 
     if ((1 << adc_chan) & ADC_VALID) {
-	board_stat[can_ID].adc[adc_chan] = (adc[adc_chan] >> 4) & 0xfff;
+        board_stat[can_ID].adc[adc_chan] = (adc[adc_chan] >> 4) & 0xfff;
     }
 
-    if (++adc_chan == 8) {		// Move to next channel
-	adc_chan = 0;
+    if (++adc_chan == 8) {              // Move to next channel
+        adc_chan = 0;
     }
-    LPC_ADC->ADCR &= ~ 0x070000ff;	// Clear channels & start
-    LPC_ADC->ADCR |= 1 << adc_chan;	// Select channel
-    LPC_ADC->ADCR |= 0x01000000;	// Start conversion
+    LPC_ADC->ADCR &= ~ 0x070000ff;      // Clear channels & start
+    LPC_ADC->ADCR |= 1 << adc_chan;     // Select channel
+    LPC_ADC->ADCR |= 0x01000000;        // Start conversion
 }
 
 
@@ -442,8 +442,8 @@ void read_adc(void)
 static void configure_wdt(uint32_t period)
 {
     LPC_WDT->WDTC = period;
-    LPC_WDT->WDCLKSEL = 1;	// Use APB clock (25MHz)
-    LPC_WDT->WDMOD = 3;		// Enable WDT and reset
+    LPC_WDT->WDCLKSEL = 1;      // Use APB clock (25MHz)
+    LPC_WDT->WDMOD = 3;         // Enable WDT and reset
     LPC_WDT->WDFEED = 0xaa;
     LPC_WDT->WDFEED = 0x55;
 }
@@ -470,21 +470,21 @@ static void process_reset(void)
 
     // Clear uninitialised vector if POR or EXTR
     if ((rsid & 3) != 0) {
-	for (uint32_t i = 0; i < 8; i++) {
-	    uni_vec[i] = 0;
-	}
-	LPC_SC->RSID = 3;
+        for (uint32_t i = 0; i < 8; i++) {
+            uni_vec[i] = 0;
+        }
+        LPC_SC->RSID = 3;
     }
 
     // Process watchdog reset
     if (rsid & 4) {
-	LPC_GPIO0->FIOSET = LED_7;
+        LPC_GPIO0->FIOSET = LED_7;
 
-	uni_vec[1]++;			// Bump WDT count
-	uni_vec[3] = uni_vec[2];	// Copy uptime;
-	uni_vec[2] += 10;		// Try to keep uptime correct
+        uni_vec[1]++;                   // Bump WDT count
+        uni_vec[3] = uni_vec[2];        // Copy uptime;
+        uni_vec[2] += 10;               // Try to keep uptime correct
 
-	LPC_SC->RSID = 4;
+        LPC_SC->RSID = 4;
     }
 
     // Save RSID register
@@ -497,15 +497,15 @@ static void process_reset(void)
 
 void configure_pwm(uint32_t period, uint32_t width)
 {
-    LPC_PWM1->TCR = 0;			// Disable...
+    LPC_PWM1->TCR = 0;                  // Disable...
 
-    LPC_PWM1->PCR = 1 << 14;		// Enable PWM6 output
-    LPC_PWM1->MR0 = period;		// Period
-    LPC_PWM1->MR6 = width;		// Pulse width
-    LPC_PWM1->MCR = 2;			// Reset TC on MR0
+    LPC_PWM1->PCR = 1 << 14;            // Enable PWM6 output
+    LPC_PWM1->MR0 = period;             // Period
+    LPC_PWM1->MR6 = width;              // Pulse width
+    LPC_PWM1->MCR = 2;                  // Reset TC on MR0
     LPC_PWM1->LER = (1 << 0) + (1 << 6); // Enable match copy
 
-    LPC_PWM1->TCR = 9;			// Enable everything...
+    LPC_PWM1->TCR = 9;                  // Enable everything...
 }
 
 
@@ -513,16 +513,16 @@ void configure_pwm(uint32_t period, uint32_t width)
 
 
 static void timer_init(LPC_TIM_TypeDef *timer, uint32_t channel,
-	uint32_t value)
+        uint32_t value)
 {
     volatile uint32_t *match = &timer->MR0;
 
-    match[channel] = value - 1;		// Set match value
+    match[channel] = value - 1;         // Set match value
 
     timer->MCR = 1 << (channel * 3 + 1); // Reset on match
     timer->EMR = 3 << (channel * 2 + 4); // Toggle on match
 
-    timer->TCR = 1;			// Enable timer
+    timer->TCR = 1;                     // Enable timer
 }
 
 
@@ -549,8 +549,8 @@ static void configure_timers(void)
 
     // CLKOUT produces 50 MHz on P1.27
     LPC_SC->CLKOUTCFG = CLKPWR_CLKOUTCFG_CLKOUTSEL_CPU +
-	    CLKPWR_CLKOUTCFG_CLKOUTDIV(1) +
-	    CLKPWR_CLKOUTCFG_CLKOUT_EN;
+            CLKPWR_CLKOUTCFG_CLKOUTDIV(1) +
+            CLKPWR_CLKOUTCFG_CLKOUT_EN;
 }
 
 
@@ -558,16 +558,16 @@ static void configure_timers(void)
 
 
 static void set_pin_mf(uint32_t port, uint32_t pin, uint32_t mode,
-	uint32_t function)
+        uint32_t function)
 {
     uint32_t *func_reg = (uint32_t *) &LPC_PINCON->PINSEL0 + 2 * port;
     uint32_t *mode_reg = (uint32_t *) &LPC_PINCON->PINMODE0 + 2 * port;
 
     pin *= 2;
     if (pin >= 32) {
-	pin -= 32;
-	func_reg++;
-	mode_reg++;
+        pin -= 32;
+        func_reg++;
+        mode_reg++;
     }
 
     *func_reg &= ~(3 << pin);
@@ -583,9 +583,9 @@ static void set_pin_od(uint32_t port, uint32_t pin, uint32_t mode)
     uint32_t *od_reg = (uint32_t *) &LPC_PINCON->PINMODE_OD0 + port;
 
     if (mode == PINSEL_PINMODE_OPENDRAIN) {
-	*od_reg |= 1 << pin;
+        *od_reg |= 1 << pin;
     } else {
-	*od_reg &= ~(1 << pin);
+        *od_reg &= ~(1 << pin);
     }
 }
 
@@ -602,21 +602,21 @@ static void config_pin(uint32_t port, uint32_t pin, uint32_t func)
 void ssp0_pins(uint32_t on)
 {
     if (on) {
-	LPC_GPIO2->FIOSET = IO_EN2;	// Disable Spin from Flash
+        LPC_GPIO2->FIOSET = IO_EN2;     // Disable Spin from Flash
 
-	LPC_GPIO0->FIODIR |= SF_NCS;	// Enable output (high)
+        LPC_GPIO0->FIODIR |= SF_NCS;    // Enable output (high)
 
-	config_pin(PINSEL_PORT_0, 15, PINSEL_FUNC_2); // Flash SCK
-	config_pin(PINSEL_PORT_0, 17, PINSEL_FUNC_2); // Flash SO
-	config_pin(PINSEL_PORT_0, 18, PINSEL_FUNC_2); // Flash SI
+        config_pin(PINSEL_PORT_0, 15, PINSEL_FUNC_2); // Flash SCK
+        config_pin(PINSEL_PORT_0, 17, PINSEL_FUNC_2); // Flash SO
+        config_pin(PINSEL_PORT_0, 18, PINSEL_FUNC_2); // Flash SI
     } else {
-	LPC_GPIO0->FIODIR &= ~SF_NCS;	// Disable output
+        LPC_GPIO0->FIODIR &= ~SF_NCS;   // Disable output
 
-	config_pin(PINSEL_PORT_0, 15, PINSEL_FUNC_0); // Flash SCK
-	config_pin(PINSEL_PORT_0, 17, PINSEL_FUNC_0); // Flash SO
-	config_pin(PINSEL_PORT_0, 18, PINSEL_FUNC_0); // Flash SI
+        config_pin(PINSEL_PORT_0, 15, PINSEL_FUNC_0); // Flash SCK
+        config_pin(PINSEL_PORT_0, 17, PINSEL_FUNC_0); // Flash SO
+        config_pin(PINSEL_PORT_0, 18, PINSEL_FUNC_0); // Flash SI
 
-	LPC_GPIO2->FIOCLR = IO_EN2;	// Enable Spin onto Flash
+        LPC_GPIO2->FIOCLR = IO_EN2;     // Enable Spin onto Flash
     }
 
     delay_ms(1);
@@ -633,8 +633,8 @@ static uint32_t configure_pins(void)
     //-----------------
     // Configure Port 0
 
-    LPC_GPIO0->FIOSET = P0_INIT;	// Initialise outputs
-    LPC_GPIO0->FIODIR = P0_EN;		// Enable outputs
+    LPC_GPIO0->FIOSET = P0_INIT;        // Initialise outputs
+    LPC_GPIO0->FIODIR = P0_EN;          // Enable outputs
 
     config_pin(PINSEL_PORT_0,  0, PINSEL_FUNC_1); // CAN RX
     config_pin(PINSEL_PORT_0,  1, PINSEL_FUNC_1); // CAN TX
@@ -665,8 +665,8 @@ static uint32_t configure_pins(void)
     //-----------------
     // Configure Port 1
 
-    LPC_GPIO1->FIOSET = P1_INIT;	// Initialise outputs
-    LPC_GPIO1->FIODIR = P1_EN;		// Enable outputs
+    LPC_GPIO1->FIOSET = P1_INIT;        // Initialise outputs
+    LPC_GPIO1->FIODIR = P1_EN;          // Enable outputs
 
     config_pin(PINSEL_PORT_1,  0, PINSEL_FUNC_1); // MII TXD0
     config_pin(PINSEL_PORT_1,  1, PINSEL_FUNC_1); // MII TXD1
@@ -693,16 +693,16 @@ static uint32_t configure_pins(void)
     //-----------------
     // Configure Port 2
 
-    LPC_GPIO2->FIOSET = P2_INIT;	// Initialise outputs
-    LPC_GPIO2->FIODIR = P2_EN;		// Enable outputs
+    LPC_GPIO2->FIOSET = P2_INIT;        // Initialise outputs
+    LPC_GPIO2->FIODIR = P2_EN;          // Enable outputs
 
     config_pin(PINSEL_PORT_2,  5, PINSEL_FUNC_1); // PWM 1.6 (Fan)
 
     //-----------------
     // Configure Port 3
 
-    LPC_GPIO3->FIOSET = P3_INIT;	// Initialise outputs
-    LPC_GPIO3->FIODIR = P3_EN;		// Enable outputs
+    LPC_GPIO3->FIOSET = P3_INIT;        // Initialise outputs
+    LPC_GPIO3->FIODIR = P3_EN;          // Enable outputs
 
     // 25    - output XIL_FSEL[0]
     // 26    - output XIL_FSEL[1]
@@ -710,8 +710,8 @@ static uint32_t configure_pins(void)
     //-----------------
     // Configure Port 4
 
-    LPC_GPIO4->FIOSET = P4_INIT;	// Initialise outputs
-    LPC_GPIO4->FIODIR = P4_EN;		// Enable outputs
+    LPC_GPIO4->FIOSET = P4_INIT;        // Initialise outputs
+    LPC_GPIO4->FIODIR = P4_EN;          // Enable outputs
 
     config_pin(PINSEL_PORT_4, 28, PINSEL_FUNC_2); // Timer2/M0
     // 29    - output XIL_FSEL[2]
@@ -742,21 +742,21 @@ void reset_spin(uint32_t code)
 
     code &= 3;
     if (code != 0) {
-	LPC_GPIO2->FIOSET = POR;
-	if (fpga) {
-	    LPC_GPIO1->FIOCLR = XIL_RST;
-	}
+        LPC_GPIO2->FIOSET = POR;
+        if (fpga) {
+            LPC_GPIO1->FIOCLR = XIL_RST;
+        }
     }
 
     if (code != 1) {
-	delay_ms(1);			// Wait a while
-	ssp0_pins(0);			// Enable Spin->Flash
+        delay_ms(1);                    // Wait a while
+        ssp0_pins(0);                   // Enable Spin->Flash
 
-	LPC_GPIO2->FIOCLR = POR;	// Clear POR
+        LPC_GPIO2->FIOCLR = POR;        // Clear POR
 
-	if (fpga) {			// Set XRST
-	    LPC_GPIO1->FIOSET = XIL_RST;
-	}
+        if (fpga) {                     // Set XRST
+            LPC_GPIO1->FIOSET = XIL_RST;
+        }
     }
 }
 
@@ -803,18 +803,18 @@ void read_fans(void)
     uint32_t fan2 = LPC_GPIO0->FIOPIN;
 
     if (((fan_last[0] ^ fan0) & FAN_ED0) != 0) {
-	fan_last[0] = fan0;
-	fan_count[0]++;
+        fan_last[0] = fan0;
+        fan_count[0]++;
     }
 
     if (((fan_last[1] ^ fan1) & FAN_ED1) != 0) {
-	fan_last[1] = fan1;
-	fan_count[1]++;
+        fan_last[1] = fan1;
+        fan_count[1]++;
     }
 
     if (((fan_last[2] ^ fan2) & FAN_ED2) != 0) {
-	fan_last[2] = fan2;
-	fan_count[2]++;
+        fan_last[2] = fan2;
+        fan_count[2]++;
     }
 }
 
@@ -827,24 +827,24 @@ void read_temp(void)
     board_stat_t *stat = &board_stat[can_ID];
 
     for (uint32_t i = 0; i < 4; i++) {
-	stat->t_int[i] = INT16_MIN;		// 0x8000
-	stat->t_ext[i] = INT16_MIN;
-	stat->fan[i] = UINT16_MAX;
+        stat->t_int[i] = INT16_MIN;             // 0x8000
+        stat->t_ext[i] = INT16_MIN;
+        stat->fan[i] = UINT16_MAX;
     }
 
-    stat->t_int[0] = read_ts(LPC_I2C2, 0x90);	// First on-board sensor
-    stat->t_int[1] = read_ts(LPC_I2C2, 0x98);	// Second on-board sensor
+    stat->t_int[0] = read_ts(LPC_I2C2, 0x90);   // First on-board sensor
+    stat->t_int[1] = read_ts(LPC_I2C2, 0x98);   // Second on-board sensor
 
-    if (bp_ctrl) {				// Backplane stuff
-	stat->t_ext[0] = read_ts(LPC_I2C0, 0x9c); // First off-board sensor
-	stat->t_ext[1] = read_ts(LPC_I2C0, 0x9e); // Second off-board sensor
+    if (bp_ctrl) {                              // Backplane stuff
+        stat->t_ext[0] = read_ts(LPC_I2C0, 0x9c); // First off-board sensor
+        stat->t_ext[1] = read_ts(LPC_I2C0, 0x9e); // Second off-board sensor
     }
 
     if (fan_sense) {
-	for (uint32_t i = 0; i < 4; i++) {	// Fans
-	    stat->fan[i] = fan_count[i] * 15;
-	    fan_count[i] = 0;
-	}
+        for (uint32_t i = 0; i < 4; i++) {      // Fans
+            stat->fan[i] = fan_count[i] * 15;
+            fan_count[i] = 0;
+        }
     }
 }
 
@@ -863,16 +863,16 @@ void die(uint32_t code)
     uint32_t bits = LED_7;
 
     for (uint32_t i = 0; i < 4; i++) {
-	if (code & (1 << i)) {
-	    bits |= led_bit[i+3];
-	}
+        if (code & (1 << i)) {
+            bits |= led_bit[i+3];
+        }
     }
 
     LPC_GPIO0->FIOCLR = LED_MASK;
     LPC_GPIO0->FIOSET = bits;
 
     while (1) {
-	refresh_wdt();
+        refresh_wdt();
     }
 }
 
@@ -881,7 +881,7 @@ void delay_us(uint32_t n)
 {
     n *= 34;
     while (n--) {
-	continue;
+        continue;
     }
 }
 
@@ -889,7 +889,7 @@ void delay_us(uint32_t n)
 void delay_ms(uint32_t n)
 {
     while (n--) {
-	delay_us(1000);
+        delay_us(1000);
     }
 }
 
@@ -909,18 +909,18 @@ void delay_ms(uint32_t n)
 // single entry in a dummy load block.
 
 
-#define SYSRAM_IP_DATA		0xf5007fe0
+#define SYSRAM_IP_DATA          0xf5007fe0
 
 
 static void configure_spin(void)
 {
-    uint32_t buf[128];	// 512 bytes
+    uint32_t buf[128];  // 512 bytes
     uint32_t *ip = (uint32_t *) &spin_ip;
 
     // Clear out temporary buffer used to assemble data
 
     for (uint32_t i = 0; i < 128; i++) {
-	buf[i] = 0xffffffff;
+        buf[i] = 0xffffffff;
     }
 
     // First thing in buffer is IP address info (11 words)
@@ -930,7 +930,7 @@ static void configure_spin(void)
     buf[1] = __rev(SYSRAM_IP_DATA);
 
     for (uint32_t i = 0; i < 8; i++) {
-	buf[i+2] = __rev(ip[i]);
+        buf[i+2] = __rev(ip[i]);
     }
     buf[10] = __rev(0xaaaaaaaa);
 
@@ -940,19 +940,19 @@ static void configure_spin(void)
     uint32_t *info = (uint32_t *) 0x1e00;
     uint32_t count = info[0];
 
-    if (count > 63) {	// !! Un-init. flash?
-	count = 0;
+    if (count > 63) {   // !! Un-init. flash?
+        count = 0;
     }
     buf[64] = count;
 
     for (uint32_t i = 1; i < count + 1; i++) {
-	buf[64 + i] = info[i];
+        buf[64 + i] = info[i];
     }
     sf_read(0, 512, (uint8_t *) flash_buf);
 
     if (memcmp(flash_buf, buf, 512) != 0) {
-	memcpy(flash_buf, buf, 512);
-	sf_write(0, 512, (uint8_t *) flash_buf);
+        memcpy(flash_buf, buf, 512);
+        sf_write(0, 512, (uint8_t *) flash_buf);
     }
 }
 
@@ -989,13 +989,13 @@ void proc_setup(uint32_t d1, uint32_t d2)
     uint32_t frame_ID = (d1 >> 8) & 255;
 
     if (hw_ver == 0) {
-	can2board = can2board_0;
-	board2can = board2can_0;
+        can2board = can2board_0;
+        board2can = board2can_0;
     } else if (hw_ver == 1) {
-	can2board = null_map;
-	board2can = null_map;
+        can2board = null_map;
+        board2can = null_map;
     } else {
-	die(9);
+        die(9);
     }
 
     board_ID = can2board[can_ID];
@@ -1004,51 +1004,51 @@ void proc_setup(uint32_t d1, uint32_t d2)
     mask = 0xffffffff << mask;
 
     if ((bmp_ip.flags & 0x4000) == 0) {
-	bmp_ip.ip_addr[0] = d2 >> 24;
-	bmp_ip.ip_addr[1] = d2 >> 16;
-	bmp_ip.ip_addr[2] = frame_ID;
-	bmp_ip.ip_addr[3] = 8 * board_ID;
+        bmp_ip.ip_addr[0] = d2 >> 24;
+        bmp_ip.ip_addr[1] = d2 >> 16;
+        bmp_ip.ip_addr[2] = frame_ID;
+        bmp_ip.ip_addr[3] = 8 * board_ID;
 
-	bmp_ip.gw_addr[0] = d2 >> 24;
-	bmp_ip.gw_addr[1] = d2 >> 16;
-	bmp_ip.gw_addr[2] = d2 >> 8;
-	bmp_ip.gw_addr[3] = d2 >> 0;
+        bmp_ip.gw_addr[0] = d2 >> 24;
+        bmp_ip.gw_addr[1] = d2 >> 16;
+        bmp_ip.gw_addr[2] = d2 >> 8;
+        bmp_ip.gw_addr[3] = d2 >> 0;
 
-	bmp_ip.net_mask[0] = mask >> 24;
-	bmp_ip.net_mask[1] = mask >> 16;
-	bmp_ip.net_mask[2] = mask >> 8;
-	bmp_ip.net_mask[3] = mask >> 0;
+        bmp_ip.net_mask[0] = mask >> 24;
+        bmp_ip.net_mask[1] = mask >> 16;
+        bmp_ip.net_mask[2] = mask >> 8;
+        bmp_ip.net_mask[3] = mask >> 0;
 
-	bmp_ip.mac_addr[0] = 0;
-	bmp_ip.mac_addr[1] = 0;
-	bmp_ip.mac_addr[2] = 0xa4;
-	bmp_ip.mac_addr[3] = frame_ID;
-	bmp_ip.mac_addr[4] = d1 >> 16;
-	bmp_ip.mac_addr[5] = 8 * board_ID;
+        bmp_ip.mac_addr[0] = 0;
+        bmp_ip.mac_addr[1] = 0;
+        bmp_ip.mac_addr[2] = 0xa4;
+        bmp_ip.mac_addr[3] = frame_ID;
+        bmp_ip.mac_addr[4] = d1 >> 16;
+        bmp_ip.mac_addr[5] = 8 * board_ID;
     }
 
     if ((spin_ip.flags & 0x4000) == 0) {
-	spin_ip.ip_addr[0] = d2 >> 24;
-	spin_ip.ip_addr[1] = d2 >> 16;
-	spin_ip.ip_addr[2] = frame_ID;
-	spin_ip.ip_addr[3] = 8 * board_ID + 1;
+        spin_ip.ip_addr[0] = d2 >> 24;
+        spin_ip.ip_addr[1] = d2 >> 16;
+        spin_ip.ip_addr[2] = frame_ID;
+        spin_ip.ip_addr[3] = 8 * board_ID + 1;
 
-	spin_ip.gw_addr[0] = d2 >> 24;
-	spin_ip.gw_addr[1] = d2 >> 16;
-	spin_ip.gw_addr[2] = d2 >> 8;
-	spin_ip.gw_addr[3] = d2 >> 0;
+        spin_ip.gw_addr[0] = d2 >> 24;
+        spin_ip.gw_addr[1] = d2 >> 16;
+        spin_ip.gw_addr[2] = d2 >> 8;
+        spin_ip.gw_addr[3] = d2 >> 0;
 
-	spin_ip.net_mask[0] = mask >> 24;
-	spin_ip.net_mask[1] = mask >> 16;
-	spin_ip.net_mask[2] = mask >> 8;
-	spin_ip.net_mask[3] = mask >> 0;
+        spin_ip.net_mask[0] = mask >> 24;
+        spin_ip.net_mask[1] = mask >> 16;
+        spin_ip.net_mask[2] = mask >> 8;
+        spin_ip.net_mask[3] = mask >> 0;
 
-	spin_ip.mac_addr[0] = 0;
-	spin_ip.mac_addr[1] = 0;
-	spin_ip.mac_addr[2] = 0xa4;
-	spin_ip.mac_addr[3] = frame_ID;
-	spin_ip.mac_addr[4] = d1 >> 16;
-	spin_ip.mac_addr[5] = 8 * board_ID + 1;
+        spin_ip.mac_addr[0] = 0;
+        spin_ip.mac_addr[1] = 0;
+        spin_ip.mac_addr[2] = 0xa4;
+        spin_ip.mac_addr[3] = frame_ID;
+        spin_ip.mac_addr[4] = d1 >> 16;
+        spin_ip.mac_addr[5] = 8 * board_ID + 1;
     }
 
     configure_eth(bmp_ip.mac_addr);
@@ -1057,7 +1057,7 @@ void proc_setup(uint32_t d1, uint32_t d2)
     uint32_t flags = d1 >> 24;
 
     if ((flags & 2) == 0) {
-	proc_power(((10 * board_ID) << 16) + 1, 1 << board_ID);
+        proc_power(((10 * board_ID) << 16) + 1, 1 << board_ID);
     }
 }
 
@@ -1066,27 +1066,27 @@ void proc_setup(uint32_t d1, uint32_t d2)
 
 
 static const ee_data_t ee_default = {
-    0x96,			// Marker
-    0,				// SW version
-    0,				// HW version
-    240,			// Frame ID
-    0,				// Mod date
-    {192, 168, 240, 254},	// GW address
-    0,				// Flags
-    16,				// IP mask bits
-    0,				// MAC byte 1
-    5,				// LCD time
-    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},	// Pad
-    {65, 65, 0, 0},		// T_int warn
-    {80, 80, 0, 0},		// T_int shut
-    {50, 50, 0, 0},		// T_ext warn
-    {65, 65, 0, 0},		// T_ext shut
-    {50, 50, 50, 0}, 		// Fan warn
-    {0, 0, 0, 0},		// Fan shut
-    {114, 114, 114, 114, 166, 184, 203, 184},	// V-under warn
-    {102, 102, 102, 102, 147, 164, 0,   0},	// V-under shut
-    {140, 140, 140, 140, 203, 225, 248, 225},	// V-over warn
-    {152, 152, 152, 152, 221, 246, 0, 0}	// V-over shut
+    0x96,                       // Marker
+    0,                          // SW version
+    0,                          // HW version
+    240,                        // Frame ID
+    0,                          // Mod date
+    {192, 168, 240, 254},       // GW address
+    0,                          // Flags
+    16,                         // IP mask bits
+    0,                          // MAC byte 1
+    5,                          // LCD time
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},   // Pad
+    {65, 65, 0, 0},             // T_int warn
+    {80, 80, 0, 0},             // T_int shut
+    {50, 50, 0, 0},             // T_ext warn
+    {65, 65, 0, 0},             // T_ext shut
+    {50, 50, 50, 0},            // Fan warn
+    {0, 0, 0, 0},               // Fan shut
+    {114, 114, 114, 114, 166, 184, 203, 184},   // V-under warn
+    {102, 102, 102, 102, 147, 164, 0,   0},     // V-under shut
+    {140, 140, 140, 140, 203, 225, 248, 225},   // V-over warn
+    {152, 152, 152, 152, 221, 246, 0, 0}        // V-over shut
 };
 
 
@@ -1104,46 +1104,46 @@ void configure_hw(void)
     memcpy(&ee_data, &ee_default, sizeof(ee_data));
 
     if (bp_ctrl) {
-	configure_lcd();
+        configure_lcd();
 
-	if (!read_ee(0, sizeof(ee_data), &ee_data) ||
-		is_blank(&ee_data, sizeof(ee_data)) ||
-		crc32_chk(&ee_data, sizeof(ee_data)) != 0) {
-	    LPC_GPIO0->FIOSET = LED_7;
-	    memcpy(&ee_data, &ee_default, sizeof(ee_data));
-	}
+        if (!read_ee(0, sizeof(ee_data), &ee_data) ||
+                is_blank(&ee_data, sizeof(ee_data)) ||
+                crc32_chk(&ee_data, sizeof(ee_data)) != 0) {
+            LPC_GPIO0->FIOSET = LED_7;
+            memcpy(&ee_data, &ee_default, sizeof(ee_data));
+        }
     }
 
     config2 = (ee_data.gw_addr[0] << 24) +
-	    (ee_data.gw_addr[1] << 16) +
-	    (ee_data.gw_addr[2] << 8) +
-	    (ee_data.gw_addr[3] << 0);
+            (ee_data.gw_addr[1] << 16) +
+            (ee_data.gw_addr[2] << 8) +
+            (ee_data.gw_addr[3] << 0);
 
     config1 = (ee_data.flags << 24) +
-	    (ee_data.mac_byte << 16) +
-	    (ee_data.frame_ID << 8) +
-	    (ee_data.mask_bits << 3) +
-	    ee_data.hw_ver;
+            (ee_data.mac_byte << 16) +
+            (ee_data.frame_ID << 8) +
+            (ee_data.mask_bits << 3) +
+            ee_data.hw_ver;
 
     if (can_ID == 0 || can_ID >= CAN_SIZE) { // >= probably not in a backplane
-	proc_setup(config1, config2);
+        proc_setup(config1, config2);
     }
     if (can_ID < CAN_SIZE) {
-	configure_can(can_ID);
+        configure_can(can_ID);
     }
-    if (can_ID == 31) {		// No backplane
-	can_ID = board_ID = 0;
-	can_status[0] = 1;
-	fan_sense = 1;
+    if (can_ID == 31) {         // No backplane
+        can_ID = board_ID = 0;
+        can_status[0] = 1;
+        fan_sense = 1;
     } else {
-	fan_sense = bp_ctrl;
+        fan_sense = bp_ctrl;
     }
     if (bp_ctrl && (ee_data.flags & 1)) {
-	configure_pwm(1024, 256);
+        configure_pwm(1024, 256);
     }
-    configure_adc();		// NB uses can_ID
+    configure_adc();            // NB uses can_ID
 
-    configure_wdt(62500000);	// 10 secs
+    configure_wdt(62500000);    // 10 secs
 }
 
 

--- a/bmp/bmp_i2c.c
+++ b/bmp/bmp_i2c.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_i2c.c	    I2C peripheral handling for BC&MP
+// bmp_i2c.c        I2C peripheral handling for BC&MP
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -17,11 +17,11 @@
 
 //------------------------------------------------------------------------------
 
-#define I2C_EE		0xa0	// 24LC08
-#define I2C_LCD		0x78	// ST7036
-#define I2C_TS		0x90	// LM75B
+#define I2C_EE          0xa0    // 24LC08
+#define I2C_LCD         0x78    // ST7036
+#define I2C_TS          0x90    // LM75B
 
-#define LCD_SIZE	32	// LCD character buffer
+#define LCD_SIZE        32      // LCD character buffer
 
 static uint8_t lcd_buf[LCD_SIZE];
 static uint32_t lcd_ptr;
@@ -41,9 +41,9 @@ void configure_i2c()
     clock_div(CLKPWR_PCLKSEL_I2C0, CLKPWR_PCLKSEL_CCLK_DIV_4);
     clock_div(CLKPWR_PCLKSEL_I2C2, CLKPWR_PCLKSEL_CCLK_DIV_4);
 
-    LPC_I2C0->I2SCLH = LPC_I2C0->I2SCLL = 62;	// 200 kHz
+    LPC_I2C0->I2SCLH = LPC_I2C0->I2SCLL = 62;   // 200 kHz
 
-    LPC_I2C2->I2SCLH = LPC_I2C2->I2SCLL = 31;	// 400 kHz
+    LPC_I2C2->I2SCLH = LPC_I2C2->I2SCLL = 31;   // 400 kHz
 
     LPC_I2C0->I2CONSET = 0x40;
     LPC_I2C2->I2CONSET = 0x40;
@@ -54,116 +54,116 @@ void configure_i2c()
 static void wait_i2c(LPC_I2C_TypeDef *i2c)
 {
     while ((i2c->I2CONSET & 0x08) == 0) {
-	continue;
+        continue;
     }
 }
 
 uint32_t i2c_poll(LPC_I2C_TypeDef *i2c, uint32_t ctrl)
 {
-    i2c->I2CONSET = 0x20;		// Send START
+    i2c->I2CONSET = 0x20;               // Send START
     wait_i2c(i2c);
 
-    i2c->I2DAT = ctrl;			// Send control byte
-    i2c->I2CONCLR = 0x28;		// Clear START, SI
+    i2c->I2DAT = ctrl;                  // Send control byte
+    i2c->I2CONCLR = 0x28;               // Clear START, SI
     wait_i2c(i2c);
 
     uint32_t status = i2c->I2STAT;
 
-    i2c->I2CONSET = 0x10;		// Set STOP
-    i2c->I2CONCLR = 0x08;		// Clear SI
+    i2c->I2CONSET = 0x10;               // Set STOP
+    i2c->I2CONCLR = 0x08;               // Clear SI
 
-    while (i2c->I2CONSET & 0x10) {	// Wait for STO to clear
-	continue;
+    while (i2c->I2CONSET & 0x10) {      // Wait for STO to clear
+        continue;
     }
-    return status == 0x18;		// Return 1 if ACK received
+    return status == 0x18;              // Return 1 if ACK received
 }
 
 uint32_t i2c_send(LPC_I2C_TypeDef *i2c, uint32_t ctrl, uint32_t addr,
-	uint32_t length, void *buf)
+        uint32_t length, void *buf)
 {
     uint8_t *data = (uint8_t *) buf;
 
-    i2c->I2CONSET = 0x20;		// Send START
+    i2c->I2CONSET = 0x20;               // Send START
     wait_i2c(i2c);
 
-    i2c->I2DAT = ctrl;			// Send control byte
-    i2c->I2CONCLR = 0x28;		// Clear START, SI
+    i2c->I2DAT = ctrl;                  // Send control byte
+    i2c->I2CONCLR = 0x28;               // Clear START, SI
     wait_i2c(i2c);
 
     uint32_t status = i2c->I2STAT;
 
     if (status != 0x18) {
-	i2c->I2CONSET = 0x10;		// Set STOP
-	i2c->I2CONCLR = 0x08;		// Clear SI
+        i2c->I2CONSET = 0x10;           // Set STOP
+        i2c->I2CONCLR = 0x08;           // Clear SI
 
-	while (i2c->I2CONSET & 0x10) {	// Wait for STO to clear
-	    continue;
+        while (i2c->I2CONSET & 0x10) {  // Wait for STO to clear
+            continue;
         }
-	return 0;
+        return 0;
     }
 
-    i2c->I2DAT = addr;			// Send address byte
-    i2c->I2CONCLR = 0x08;		// Clear SI
+    i2c->I2DAT = addr;                  // Send address byte
+    i2c->I2CONCLR = 0x08;               // Clear SI
     wait_i2c(i2c);
 
-    for (uint32_t i = 0; i < length; i++) {	// Send data...
-	i2c->I2DAT = data[i];
-	i2c->I2CONCLR = 0x08;	// Clear SI
-	(void) wait_i2c(i2c);
+    for (uint32_t i = 0; i < length; i++) {     // Send data...
+        i2c->I2DAT = data[i];
+        i2c->I2CONCLR = 0x08;   // Clear SI
+        (void) wait_i2c(i2c);
     }
 
-    i2c->I2CONSET = 0x10;		// Set STOP
-    i2c->I2CONCLR = 0x08;		// Clear SI
+    i2c->I2CONSET = 0x10;               // Set STOP
+    i2c->I2CONCLR = 0x08;               // Clear SI
 
-    while (i2c->I2CONSET & 0x10) {	// Wait for STO to clear
-	continue;
+    while (i2c->I2CONSET & 0x10) {      // Wait for STO to clear
+        continue;
     }
     return 1;
 }
 
 uint32_t i2c_receive(LPC_I2C_TypeDef *i2c, uint32_t ctrl, uint32_t addr,
-	uint32_t length, void *buf)
+        uint32_t length, void *buf)
 {
     uint8_t *data = (uint8_t *) buf;
 
-    i2c->I2CONSET = 0x20;		// Send START
+    i2c->I2CONSET = 0x20;               // Send START
     wait_i2c(i2c);
 
-    i2c->I2DAT = ctrl;			// Send control byte
-    i2c->I2CONCLR = 0x28;		// Clear START, SI
+    i2c->I2DAT = ctrl;                  // Send control byte
+    i2c->I2CONCLR = 0x28;               // Clear START, SI
     wait_i2c(i2c);
 
     uint32_t status = i2c->I2STAT;
 
     if (status != 0x40) {
-	i2c->I2CONSET = 0x10;		// Set STOP
-	i2c->I2CONCLR = 0x08;		// Clear SI
+        i2c->I2CONSET = 0x10;           // Set STOP
+        i2c->I2CONCLR = 0x08;           // Clear SI
 
-	while (i2c->I2CONSET & 0x10) {	// Wait for STO to clear
-	    continue;
-	}
-	return 0;
+        while (i2c->I2CONSET & 0x10) {  // Wait for STO to clear
+            continue;
+        }
+        return 0;
     }
 
     if (length > 1) {
-	i2c->I2CONSET = 0x04;		// Set AA
+        i2c->I2CONSET = 0x04;           // Set AA
     }
 
     for (uint32_t i = 0; i < length; i++) {
-	if (i == length - 1) {
-	    i2c->I2CONCLR = 0x04;	// Clear AA
+        if (i == length - 1) {
+            i2c->I2CONCLR = 0x04;       // Clear AA
         }
-	i2c->I2CONCLR = 0x08;		// Clear SI
-	wait_i2c(i2c);
+        i2c->I2CONCLR = 0x08;           // Clear SI
+        wait_i2c(i2c);
 
-	data[i] = i2c->I2DAT;
+        data[i] = i2c->I2DAT;
     }
 
-    i2c->I2CONSET = 0x10;		// Set STO
-    i2c->I2CONCLR = 0x0c;		// Clear SI, AA
+    i2c->I2CONSET = 0x10;               // Set STO
+    i2c->I2CONCLR = 0x0c;               // Clear SI, AA
 
-    while (i2c->I2CONSET & 0x10) {	// Wait for STO to clear
-	continue;
+    while (i2c->I2CONSET & 0x10) {      // Wait for STO to clear
+        continue;
     }
     return 1;
 }
@@ -174,36 +174,36 @@ int16_t read_ts(LPC_I2C_TypeDef *i2c, uint32_t addr)
 {
     uint8_t buf[4];
 
-    if (! i2c_send(i2c, addr, 0, 0, NULL)) {	// Send ctrl & ptr=0
-	return INT16_MIN;
+    if (! i2c_send(i2c, addr, 0, 0, NULL)) {    // Send ctrl & ptr=0
+        return INT16_MIN;
     }
-    i2c_receive(i2c, addr | 1, 0, 2, &buf);	// then read data
+    i2c_receive(i2c, addr | 1, 0, 2, &buf);     // then read data
 
     return (buf[0] << 8) + buf[1];
 }
 
 uint32_t read_ee(uint32_t addr, uint32_t count, void *buf)
 {
-    uint32_t ctrl = I2C_EE + ((addr >> 7) & 6);		// 24lc08 code
+    uint32_t ctrl = I2C_EE + ((addr >> 7) & 6);         // 24lc08 code
 
     if (!i2c_send(LPC_I2C0, ctrl, addr & 255, 0, NULL)) { // Send address
-	return 0;
+        return 0;
     }
     if (count != 0) {
-	i2c_receive(LPC_I2C0, ctrl + 1, 0, count, buf);	// then read data
+        i2c_receive(LPC_I2C0, ctrl + 1, 0, count, buf); // then read data
     }
     return 1;
 }
 
 uint32_t write_ee(uint32_t addr, uint32_t count, void *buf)
 {
-    uint32_t ctrl = I2C_EE + ((addr >> 7) & 6);		// 24lc08 code
+    uint32_t ctrl = I2C_EE + ((addr >> 7) & 6);         // 24lc08 code
 
     if (!i2c_send(LPC_I2C0, ctrl, addr & 255, count, buf)) { // Send addr & data
-	return 0;
+        return 0;
     }
-    while (!i2c_poll(LPC_I2C0, ctrl)) {			// Wait until done
-	continue;
+    while (!i2c_poll(LPC_I2C0, ctrl)) {                 // Wait until done
+        continue;
     }
     return 1;
 }
@@ -211,29 +211,29 @@ uint32_t write_ee(uint32_t addr, uint32_t count, void *buf)
 //------------------------------------------------------------------------------
 
 static const uint8_t lcd_init[] = {
-    0x38,	// 8 bit, 2 lines, not dbl ht, IS=00
-    0x00,	// Data follows (RS=0)
-    0x39,	// 8 bit, 2 lines, not dbl ht, IS=01
-    0x14,	// Bias = 1/4, not 3-line
-    0x70,	// Contrast[3:0] = 0000
-    0x6c,	// Follower on, Rab[2:0] = 100
-    0x56,	// Boost on, Contrast[5:4] = 10
-    0x0c,	// Display on, no cursor
-    0x01	// Clear and home
+    0x38,       // 8 bit, 2 lines, not dbl ht, IS=00
+    0x00,       // Data follows (RS=0)
+    0x39,       // 8 bit, 2 lines, not dbl ht, IS=01
+    0x14,       // Bias = 1/4, not 3-line
+    0x70,       // Contrast[3:0] = 0000
+    0x6c,       // Follower on, Rab[2:0] = 100
+    0x56,       // Boost on, Contrast[5:4] = 10
+    0x0c,       // Display on, no cursor
+    0x01        // Clear and home
 };
 
 void configure_lcd(void)
 {
     lcd_active = i2c_send(LPC_I2C0, I2C_LCD, 0x80,
-	    sizeof(lcd_init), (void *) lcd_init);
+            sizeof(lcd_init), (void *) lcd_init);
     delay_us(1000);
 }
 
 static void lcd_flush(void)
 {
     if (lcd_ptr) {
-	i2c_send(LPC_I2C0, I2C_LCD, 0x40, lcd_ptr, lcd_buf);
-	lcd_ptr = 0;
+        i2c_send(LPC_I2C0, I2C_LCD, 0x40, lcd_ptr, lcd_buf);
+        lcd_ptr = 0;
     }
 }
 
@@ -250,10 +250,10 @@ void lcd_ctrl(uint32_t c)
 void lcd_putc(uint32_t c)
 {
     if (c != '\n') {
-	lcd_buf[lcd_ptr++] = c;
+        lcd_buf[lcd_ptr++] = c;
     }
     if (c == '\n' || lcd_ptr == LCD_SIZE) {
-	lcd_flush();
+        lcd_flush();
     }
 }
 

--- a/bmp/bmp_init.c
+++ b/bmp/bmp_init.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_init.c	    System initialisation code for BMP LPC1768
+// bmp_init.c       System initialisation code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -18,19 +18,19 @@
 
 // Linker generated symbols
 
-#define RO_BASE    	Image$$PROGRAM$$RO$$Base
-#define RO_LIMIT   	Image$$PROGRAM$$RO$$Limit
-#define RO_LENGTH  	Image$$PROGRAM$$RO$$Length
+#define RO_BASE         Image$$PROGRAM$$RO$$Base
+#define RO_LIMIT        Image$$PROGRAM$$RO$$Limit
+#define RO_LENGTH       Image$$PROGRAM$$RO$$Length
 
-#define RW_BASE    	Image$$SRAM$$RW$$Base
-#define RW_LIMIT     	Image$$SRAM$$RW$$Limit
-#define RW_LENGTH  	Image$$SRAM$$RW$$Length
+#define RW_BASE         Image$$SRAM$$RW$$Base
+#define RW_LIMIT        Image$$SRAM$$RW$$Limit
+#define RW_LENGTH       Image$$SRAM$$RW$$Length
 
-#define ZI_BASE    	Image$$SRAM$$ZI$$Base
-#define ZI_LIMIT     	Image$$SRAM$$ZI$$Limit
+#define ZI_BASE         Image$$SRAM$$ZI$$Base
+#define ZI_LIMIT        Image$$SRAM$$ZI$$Limit
 
-#define STACK_LIMIT  	Image$$STACK$$ZI$$Limit
-#define STACK_BASE 	Image$$STACK$$ZI$$Base
+#define STACK_LIMIT     Image$$STACK$$ZI$$Limit
+#define STACK_BASE      Image$$STACK$$ZI$$Base
 
 
 extern uint32_t RO_BASE, RO_LIMIT, RO_LENGTH;
@@ -53,7 +53,7 @@ extern void c_main(void);
 void  __attribute__((noreturn)) error_han(void)
 {
     while (1) {
-	die(12);
+        die(12);
     }
 }
 
@@ -66,7 +66,7 @@ void BusFault_Handler       (void) __attribute__ ((weak, alias ("error_han")));
 void UsageFault_Handler     (void) __attribute__ ((weak, alias ("error_han")));
 void SVC_Handler            (void) __attribute__ ((weak, alias ("error_han")));
 void DebugMon_Handler       (void) __attribute__ ((weak, alias ("error_han")));
-void PendSV_Handler	    (void) __attribute__ ((weak, alias ("error_han")));
+void PendSV_Handler         (void) __attribute__ ((weak, alias ("error_han")));
 void SysTick_Handler        (void) __attribute__ ((weak, alias ("error_han")));
 
 // LPC17xx specific interrupt handlers
@@ -109,7 +109,7 @@ void CANActivity_IRQHandler (void) __attribute__ ((weak, alias ("error_han")));
 
 
 const cortex_vec_t main_vec __attribute__ ((section (".vectors"))) = {
-    (uint32_t *) &STACK_LIMIT,	   // 0:  Stack top
+    (uint32_t *) &STACK_LIMIT,     // 0:  Stack top
     (main_proc) c_main,            // 1:  Entry point
 
     NMI_Handler,                   // 2:  NMI Handler
@@ -127,58 +127,58 @@ const cortex_vec_t main_vec __attribute__ ((section (".vectors"))) = {
     PendSV_Handler,                // 14: Pending SV Handler
     SysTick_Handler,               // 15: SysTick Handler
 
-    WDT_IRQHandler,            	   // 16: Watchdog Timer
-    TIMER0_IRQHandler,         	   // 17: Timer0
-    TIMER1_IRQHandler,         	   // 18: Timer1
-    TIMER2_IRQHandler,         	   // 19: Timer2
-    TIMER3_IRQHandler,         	   // 20: Timer3
-    UART0_IRQHandler,          	   // 21: UART0
-    UART1_IRQHandler,          	   // 22: UART1
-    UART2_IRQHandler,          	   // 23: UART2
-    UART3_IRQHandler,          	   // 24: UART3
-    PWM1_IRQHandler,           	   // 25: PWM1
-    I2C0_IRQHandler,           	   // 26: I2C0
-    I2C1_IRQHandler,           	   // 27: I2C1
-    I2C2_IRQHandler,           	   // 28: I2C2
-    SPI_IRQHandler,            	   // 29: SPI
-    SSP0_IRQHandler,           	   // 30: SSP0
-    SSP1_IRQHandler,           	   // 31: SSP1
+    WDT_IRQHandler,                // 16: Watchdog Timer
+    TIMER0_IRQHandler,             // 17: Timer0
+    TIMER1_IRQHandler,             // 18: Timer1
+    TIMER2_IRQHandler,             // 19: Timer2
+    TIMER3_IRQHandler,             // 20: Timer3
+    UART0_IRQHandler,              // 21: UART0
+    UART1_IRQHandler,              // 22: UART1
+    UART2_IRQHandler,              // 23: UART2
+    UART3_IRQHandler,              // 24: UART3
+    PWM1_IRQHandler,               // 25: PWM1
+    I2C0_IRQHandler,               // 26: I2C0
+    I2C1_IRQHandler,               // 27: I2C1
+    I2C2_IRQHandler,               // 28: I2C2
+    SPI_IRQHandler,                // 29: SPI
+    SSP0_IRQHandler,               // 30: SSP0
+    SSP1_IRQHandler,               // 31: SSP1
 
-    PLL0_IRQHandler,           	   // 32: PLL0 Lock (Main PLL)
-    RTC_IRQHandler,            	   // 33: Real Time Clock
-    EINT0_IRQHandler,          	   // 34: External Interrupt 0
-    EINT1_IRQHandler,          	   // 35: External Interrupt 1
-    EINT2_IRQHandler,          	   // 36: External Interrupt 2
-    EINT3_IRQHandler,          	   // 37: External Interrupt 3
-    ADC_IRQHandler,            	   // 38: A/D Converter
-    BOD_IRQHandler,            	   // 39: Brown-Out Detect
-    USB_IRQHandler,            	   // 40: USB
-    CAN_IRQHandler,            	   // 41: CAN
-    DMA_IRQHandler,            	   // 42: General Purpose DMA
-    I2S_IRQHandler,            	   // 43: I2S
-    ENET_IRQHandler,           	   // 44: Ethernet
-    RIT_IRQHandler,            	   // 45: Repetitive Interrupt Timer
-    MCPWM_IRQHandler,          	   // 46: Motor Control PWM
-    QEI_IRQHandler,            	   // 47: Quadrature Encoder Interface
-    PLL1_IRQHandler,           	   // 48: PLL1 Lock (USB PLL)
+    PLL0_IRQHandler,               // 32: PLL0 Lock (Main PLL)
+    RTC_IRQHandler,                // 33: Real Time Clock
+    EINT0_IRQHandler,              // 34: External Interrupt 0
+    EINT1_IRQHandler,              // 35: External Interrupt 1
+    EINT2_IRQHandler,              // 36: External Interrupt 2
+    EINT3_IRQHandler,              // 37: External Interrupt 3
+    ADC_IRQHandler,                // 38: A/D Converter
+    BOD_IRQHandler,                // 39: Brown-Out Detect
+    USB_IRQHandler,                // 40: USB
+    CAN_IRQHandler,                // 41: CAN
+    DMA_IRQHandler,                // 42: General Purpose DMA
+    I2S_IRQHandler,                // 43: I2S
+    ENET_IRQHandler,               // 44: Ethernet
+    RIT_IRQHandler,                // 45: Repetitive Interrupt Timer
+    MCPWM_IRQHandler,              // 46: Motor Control PWM
+    QEI_IRQHandler,                // 47: Quadrature Encoder Interface
+    PLL1_IRQHandler,               // 48: PLL1 Lock (USB PLL)
 
-    USBActivity_IRQHandler,    	   // 49: USB Activity
+    USBActivity_IRQHandler,        // 49: USB Activity
     CANActivity_IRQHandler,        // 50: CAN Activity
 
-    (handler) 0,		   // 51:
-    (handler) 0,		   // 52:
-    BUILD_DATE,			   // 53: Build date
-    BMP_VER_NUM,		   // 54: Version number
+    (handler) 0,                   // 51:
+    (handler) 0,                   // 52:
+    BUILD_DATE,                    // 53: Build date
+    BMP_VER_NUM,                   // 54: Version number
 
     (uint32_t) &RO_LENGTH,         // 55: RO_length
     (uint32_t) &RW_LENGTH,         // 56: RW_length
-    &RO_LIMIT,   		   // 57: RO_limit
-    &RW_BASE,	 		   // 58: RW_base
-    &RW_LIMIT,	 		   // 59: RW_limit
-    &ZI_BASE,	 		   // 60: ZI_base
-    &ZI_LIMIT,	 		   // 61: ZI_limit
-    &STACK_BASE, 		   // 62: stack_base
-    &STACK_LIMIT 		   // 63: stack_limit
+    &RO_LIMIT,                     // 57: RO_limit
+    &RW_BASE,                      // 58: RW_base
+    &RW_LIMIT,                     // 59: RW_limit
+    &ZI_BASE,                      // 60: ZI_base
+    &ZI_LIMIT,                     // 61: ZI_limit
+    &STACK_BASE,                   // 62: stack_base
+    &STACK_LIMIT                   // 63: stack_limit
 };
 
 

--- a/bmp/bmp_io.c
+++ b/bmp/bmp_io.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_io.c	    Simple character I/O library for BMP
+// bmp_io.c         Simple character I/O library for BMP
 //
 // Copyright (C)    The University of Manchester - 2009-2015
 //
@@ -24,7 +24,7 @@ extern void eth_putc (uint32_t c);
 
 static const char hex[] = "0123456789abcdef";
 
-static uint32_t sp_ptr; 		// for 'sprintf'
+static uint32_t sp_ptr;                 // for 'sprintf'
 static uint32_t tube_ptr;
 static uint8_t tube_buf[256];
 
@@ -35,26 +35,26 @@ static void std_putc(uint32_t c)
     tube_buf[tube_ptr++] = c;
 
     if (c != 0 && c != '\n' && tube_ptr != 256) {
-	return;
+        return;
     }
 
     sdp_msg_t *msg = msg_get();
 
     if (msg != NULL) {
-	memcpy(&msg->arg1, tube_buf, tube_ptr);
+        memcpy(&msg->arg1, tube_buf, tube_ptr);
 
-	msg->cmd_rc = CMD_TUBE;
-	msg->seq = 0;
-	msg->flags = 0x07;
-	msg->tag = TAG_HOST;
-	// msg->dest_port = PORT_ETH;		// Sent via board 0
-	msg->dest_port = PORT_ETH + board_ID;	// Sent from this board
-	msg->srce_port = board_ID;
-	msg->dest_addr = 0;
-	msg->srce_addr = ee_data.frame_ID;
-	msg->length = 12 + tube_ptr;
+        msg->cmd_rc = CMD_TUBE;
+        msg->seq = 0;
+        msg->flags = 0x07;
+        msg->tag = TAG_HOST;
+        // msg->dest_port = PORT_ETH;           // Sent via board 0
+        msg->dest_port = PORT_ETH + board_ID;   // Sent from this board
+        msg->srce_port = board_ID;
+        msg->dest_addr = 0;
+        msg->srce_addr = ee_data.frame_ID;
+        msg->length = 12 + tube_ptr;
 
-	msg_queue_insert(msg);
+        msg_queue_insert(msg);
     }
 
     tube_ptr = 0;
@@ -65,14 +65,14 @@ static void std_putc(uint32_t c)
 static void io_put_char(char *stream, uint32_t c)
 {
     if (stream == IO_STD) {
-	std_putc(c);
+        std_putc(c);
     } else if (stream == IO_DBG) {
-	eth_putc(c);
+        eth_putc(c);
     } else if (stream == IO_LCD) {
-	lcd_putc(c);
+        lcd_putc(c);
     } else if (stream > IO_NULL) {
-	stream[sp_ptr++] = c;
-	stream[sp_ptr] = 0;
+        stream[sp_ptr++] = c;
+        stream[sp_ptr] = 0;
     }
 }
 
@@ -82,13 +82,13 @@ static void io_put_str(char *stream, char *s, int d)
     int n = 0;
 
     while (*t++) {
-	n++;
+        n++;
     }
     while (d-- > n) {
-	io_put_char(stream, ' ');
+        io_put_char(stream, ' ');
     }
     while (*s) {
-	io_put_char(stream, *s++);
+        io_put_char(stream, *s++);
     }
 }
 
@@ -100,29 +100,29 @@ static void io_put_int(char *stream, int n, uint32_t d, uint32_t pad)
     uint32_t neg = 0;
 
     if (n < 0) {
-	n = -n;
-	neg = '-';
+        n = -n;
+        neg = '-';
     }
 
     while (1) {
-	s[i++] = n % 10 + '0';
-	n = n / 10;
-	if (n == 0) {
-	    break;
-	}
+        s[i++] = n % 10 + '0';
+        n = n / 10;
+        if (n == 0) {
+            break;
+        }
     }
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
     if (neg) {
-	s[++i] = neg;
+        s[++i] = neg;
     }
     while (d-- > i + 1) {
-	io_put_char(stream, ' ');
+        io_put_char(stream, ' ');
     }
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
@@ -132,28 +132,28 @@ static void io_put_uint(char *stream, uint32_t n, uint32_t d, uint32_t pad)
     int i = 0;
 
     while (1) {
-	s[i++] = n % 10 + '0';
-	n = n / 10;
-	if (n == 0) {
-	    break;
-	}
+        s[i++] = n % 10 + '0';
+        n = n / 10;
+        if (n == 0) {
+            break;
+        }
     }
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
     while (d-- > i + 1) {
-	io_put_char(stream, pad);
+        io_put_char(stream, pad);
     }
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
 static void io_put_zhex(char *stream, uint32_t n, uint32_t d)
 {
     for (int i = d - 1; i >= 0; i--) {
-	io_put_char(stream, hex[(n >> (4 * i)) & 15]);
+        io_put_char(stream, hex[(n >> (4 * i)) & 15]);
     }
 }
 
@@ -163,23 +163,23 @@ static void io_put_hex(char *stream, uint32_t n, uint32_t d, uint32_t pad)
     int i = 0;
 
     while (1) {
-	s[i++] = hex[n & 15];
-	n = n >> 4;
-	if (n == 0) {
-	    break;
-	}
+        s[i++] = hex[n & 15];
+        n = n >> 4;
+        if (n == 0) {
+            break;
+        }
     }
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
 
     while (d-- > i + 1) {
-	io_put_char(stream, pad);
+        io_put_char(stream, pad);
     }
 
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
@@ -187,10 +187,10 @@ static void io_put_hex(char *stream, uint32_t n, uint32_t d, uint32_t pad)
 static void io_put_mac(char *stream, uint8_t *s)
 {
     for (uint32_t i = 0; i < 6; i++) {
-	io_put_zhex(stream, s[i], 2);
-	if (i != 5) {
-	    io_put_char(stream, ':');
-	}
+        io_put_zhex(stream, s[i], 2);
+        if (i != 5) {
+            io_put_char(stream, ':');
+        }
     }
 }
 
@@ -198,10 +198,10 @@ static void io_put_mac(char *stream, uint8_t *s)
 static void io_put_ip(char *stream, uint8_t *s)
 {
     for (uint32_t i = 0; i < 4; i++) {
-	io_put_int(stream, s[i], 0, 0);
-	if (i != 3) {
-	    io_put_char(stream, '.');
-	}
+        io_put_int(stream, s[i], 0, 0);
+        if (i != 3) {
+            io_put_char(stream, '.');
+        }
     }
 }
 
@@ -211,91 +211,91 @@ void io_printf(char *stream, char *f, ...)
     va_list ap;
 
     if (stream == IO_NULL || (stream == IO_LCD && ! lcd_active)) {
-	return;
+        return;
     }
 
-    if (stream > IO_NULL) {	// Initialise string (sprintf)
-	sp_ptr = stream[0] = 0;
+    if (stream > IO_NULL) {     // Initialise string (sprintf)
+        sp_ptr = stream[0] = 0;
     }
 
     va_start(ap, f);
 
     while (1) {
-	char c = *f++;
+        char c = *f++;
 
-	if (c == 0) {
-	    break;
-	}
+        if (c == 0) {
+            break;
+        }
 
-	if (c != '%') {
-	    io_put_char(stream, c);
-	    continue;
-	}
+        if (c != '%') {
+            io_put_char(stream, c);
+            continue;
+        }
 
-	c = *f++;
+        c = *f++;
 
-	if (c == 0) {
-	    break;
-	}
+        if (c == 0) {
+            break;
+        }
 
-	char pad = ' ';
-	if (c == '0') {
-	    pad = c;
-	}
+        char pad = ' ';
+        if (c == '0') {
+            pad = c;
+        }
 
-	uint32_t size = 0;
+        uint32_t size = 0;
 
-	while (c >= '0' && c <= '9') {
-	    size = 10 * size + c - '0';
-	    c = *f++;
-	}
+        while (c >= '0' && c <= '9') {
+            size = 10 * size + c - '0';
+            c = *f++;
+        }
 
-	if (c == 0) {
-	    break;
-	}
+        if (c == 0) {
+            break;
+        }
 
-	switch (c) {
-	case 'c': // character
-	    io_put_char(stream, va_arg(ap, uint32_t));
-	    break;
+        switch (c) {
+        case 'c': // character
+            io_put_char(stream, va_arg(ap, uint32_t));
+            break;
 
-	case 's': // string
-	    io_put_str(stream, va_arg(ap, char *), size);
-	    break;
+        case 's': // string
+            io_put_str(stream, va_arg(ap, char *), size);
+            break;
 
-	case 'd': //signed integer
-	    io_put_int(stream, va_arg(ap, int), size, pad);
-	    break;
+        case 'd': //signed integer
+            io_put_int(stream, va_arg(ap, int), size, pad);
+            break;
 
-	case 'u': // unsigned integer
-	    io_put_uint(stream, va_arg(ap, uint32_t), size, pad);
-	    break;
+        case 'u': // unsigned integer
+            io_put_uint(stream, va_arg(ap, uint32_t), size, pad);
+            break;
 
-	case 'x': // hex, digits as needed
-	    io_put_hex(stream, va_arg(ap, uint32_t), size, pad);
-	    break;
+        case 'x': // hex, digits as needed
+            io_put_hex(stream, va_arg(ap, uint32_t), size, pad);
+            break;
 
-	case 'z': // zero prefixed hex, exactly "size" digits
-	    io_put_zhex(stream, va_arg(ap, uint32_t), size);
-	    break;
+        case 'z': // zero prefixed hex, exactly "size" digits
+            io_put_zhex(stream, va_arg(ap, uint32_t), size);
+            break;
 
-	case 'p': // pointer to IP address
-	    io_put_ip(stream, va_arg(ap, uint8_t *));
-	    break;
+        case 'p': // pointer to IP address
+            io_put_ip(stream, va_arg(ap, uint8_t *));
+            break;
 
-	case 'm': // pointer to MAC address
-	    io_put_mac(stream, va_arg(ap, uint8_t *));
-	    break;
+        case 'm': // pointer to MAC address
+            io_put_mac(stream, va_arg(ap, uint8_t *));
+            break;
 
-	case 'q': // LCD control code
-	    if (stream == IO_LCD) {
-		lcd_ctrl(va_arg(ap, uint32_t));
-	    }
-	    break;
+        case 'q': // LCD control code
+            if (stream == IO_LCD) {
+                lcd_ctrl(va_arg(ap, uint32_t));
+            }
+            break;
 
-	default:
-	    io_put_char(stream, c);
-	}
+        default:
+            io_put_char(stream, c);
+        }
     }
 
     va_end(ap);

--- a/bmp/bmp_main.c
+++ b/bmp/bmp_main.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_main.c	    Control program for Spin4/Spin5 BMP
+// bmp_main.c       Control program for Spin4/Spin5 BMP
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -19,7 +19,7 @@
 // 1.34 - 18aug14 - add reset code to "cmd_xilinx"
 // 1.35 - 19aug14 - add code to control LEDs
 // 1.36 - 09sep14 - add SPI code to talk to FPGAs
-//		  - make can_ID=31 look like can_ID=0
+//                - make can_ID=31 look like can_ID=0
 //
 //------------------------------------------------------------------------------
 
@@ -30,12 +30,12 @@
 
 //------------------------------------------------------------------------------
 
-static uint32_t ms_tens;	// counts 1ms ticks 0..9
-static uint32_t ticks;		// counts 10ms ticks 0..99
+static uint32_t ms_tens;        // counts 1ms ticks 0..9
+static uint32_t ticks;          // counts 10ms ticks 0..99
 
-bool data_ok;			// Data sector CRC OK
-uint32_t boot_sec;		// Boot block number
-cortex_vec_t *cortex_vec;	// Cortex boot vector
+bool data_ok;                   // Data sector CRC OK
+uint32_t boot_sec;              // Boot block number
+cortex_vec_t *cortex_vec;       // Cortex boot vector
 
 //------------------------------------------------------------------------------
 
@@ -53,17 +53,17 @@ static void set_text(const char *s, uint32_t mask)
 {
     strcpy(text, s);
 
-    if ((mask & 0x000ff) == 0) {	// Volts
-	text[5] = ' ';
+    if ((mask & 0x000ff) == 0) {        // Volts
+        text[5] = ' ';
     }
-    if ((mask & 0x00f00) == 0) {	// T_int
-	text[6] = ' ';
+    if ((mask & 0x00f00) == 0) {        // T_int
+        text[6] = ' ';
     }
-    if ((mask & 0x0f000) == 0) {	// T_ext
-	text[7] = ' ';
+    if ((mask & 0x0f000) == 0) {        // T_ext
+        text[7] = ' ';
     }
-    if ((mask & 0xf0000) == 0) {	// Fan
-	text[8] = ' ';
+    if ((mask & 0xf0000) == 0) {        // Fan
+        text[8] = ' ';
     }
 }
 
@@ -78,69 +78,69 @@ static void update_lcd(void)
     uint32_t mins = up_time / 60;
 
     io_printf(IO_LCD, "%qFrame %u%qUp", LCD_POS(0, 0), ee_data.frame_ID,
-	    LCD_POS(10, 0));
+            LCD_POS(10, 0));
 
     if (hours < 10) {
-	io_printf(IO_LCD, "%2u:%02u:%02u\n", hours, mins % 60, up_time % 60);
+        io_printf(IO_LCD, "%2u:%02u:%02u\n", hours, mins % 60, up_time % 60);
     } else if (hours < 100) {
-	io_printf(IO_LCD, "%4uh%02um\n", hours, mins % 60);
+        io_printf(IO_LCD, "%4uh%02um\n", hours, mins % 60);
     } else {
-	io_printf(IO_LCD, "%4ud%02uh\n", days, hours % 24);
+        io_printf(IO_LCD, "%4ud%02uh\n", days, hours % 24);
     }
 
     // Print status on second line
 
     if (up_time < ee_data.LCD_time) {
-	io_printf(IO_LCD, "%q%p%q%5u\n",
-		LCD_POS(0, 1), &bmp_ip.ip_addr,
-		LCD_POS(15, 1), board_ID);
-	return;
+        io_printf(IO_LCD, "%q%p%q%5u\n",
+                LCD_POS(0, 1), &bmp_ip.ip_addr,
+                LCD_POS(15, 1), board_ID);
+        return;
     }
 
     while (1) {
-	scan_next++;
+        scan_next++;
 
-	if (scan_next == CAN_SIZE) {
-	    uint32_t count = 0;
+        if (scan_next == CAN_SIZE) {
+            uint32_t count = 0;
 
-	    for (uint32_t i = 0; i < CAN_SIZE; i++) {
-		if (can_status[i]) {
-		    count++;
-	        }
-	    }
+            for (uint32_t i = 0; i < CAN_SIZE; i++) {
+                if (can_status[i]) {
+                    count++;
+                }
+            }
 
-	    uint32_t v = cortex_vec->sw_ver;
-	    if (v < 65535) {
-		io_printf(IO_LCD, "%qBMP %d.%02d  %4u slots\n",
-			LCD_POS(0, 1), v / 100, v % 100, count);
-	    } else {
-		io_printf(IO_LCD, "%qBMP %d.%d.%d %q%4u slots\n",
-			LCD_POS(0, 1), (v >> 16) & 255,
-			(v >> 8) & 255, v & 255, LCD_POS(10, 1), count);
-	    }
-	    break;
-	}
+            uint32_t v = cortex_vec->sw_ver;
+            if (v < 65535) {
+                io_printf(IO_LCD, "%qBMP %d.%02d  %4u slots\n",
+                        LCD_POS(0, 1), v / 100, v % 100, count);
+            } else {
+                io_printf(IO_LCD, "%qBMP %d.%d.%d %q%4u slots\n",
+                        LCD_POS(0, 1), (v >> 16) & 255,
+                        (v >> 8) & 255, v & 255, LCD_POS(10, 1), count);
+            }
+            break;
+        }
 
-	if (scan_next == CAN_SIZE + 1) {
-	    scan_next = 0;
-	}
+        if (scan_next == CAN_SIZE + 1) {
+            scan_next = 0;
+        }
 
-	if (can_status[scan_next]) {
-	    board_stat_t *stat = &board_stat[scan_next];
+        if (can_status[scan_next]) {
+            board_stat_t *stat = &board_stat[scan_next];
 
-	    if (stat->shutdown) {
-		set_text("Shut VIEF ", stat->shutdown);
-	    } else if (stat->warning) {
-		set_text("Warn VIEF ", stat->warning);
-	    } else {
-		continue;
-	    }
+            if (stat->shutdown) {
+                set_text("Shut VIEF ", stat->shutdown);
+            } else if (stat->warning) {
+                set_text("Warn VIEF ", stat->warning);
+            } else {
+                continue;
+            }
 
-	    io_printf(IO_LCD, "%qSlot %u  %q%s\n",
-		    LCD_POS(0, 1), can2board[scan_next],
-		    LCD_POS(10, 1), text);
-	    break;
-	}
+            io_printf(IO_LCD, "%qSlot %u  %q%s\n",
+                    LCD_POS(0, 1), can2board[scan_next],
+                    LCD_POS(10, 1), text);
+            break;
+        }
     }
 }
 
@@ -149,38 +149,38 @@ static uint8_t fan = 0;
 static void fan_control(void)
 {
     if (!bp_ctrl) {
-	return;
+        return;
     }
 
     uint32_t size = (ee_data.hw_ver == 0) ? 6 : 8;
     int32_t max = INT32_MIN;
 
     for (uint32_t i = 0; i < size; i++) {
-	board_stat_t *stat = &board_stat[can_ID + i];
+        board_stat_t *stat = &board_stat[can_ID + i];
 
-	for (uint32_t t = 0; t < 4; t++) {
-	    if (stat->t_int[t] > max) {
-		max = stat->t_int[t];
-	    }
+        for (uint32_t t = 0; t < 4; t++) {
+            if (stat->t_int[t] > max) {
+                max = stat->t_int[t];
+            }
         }
     }
 
     max /= 256;
 
     if (max > 70 && fan == 2) {
-	fan = 3;
+        fan = 3;
     } else if (max > 55 && fan == 1) {
-	fan = 2;
+        fan = 2;
     } else if (max > 40 && fan == 0) {
-	fan = 1;
+        fan = 1;
     }
 
     if (max <= 35 && fan == 1) {
-	fan = 0;
+        fan = 0;
     } else if (max <= 50 && fan == 2) {
-	fan = 1;
+        fan = 1;
     } else if (max <= 65 && fan == 3) {
-	fan = 2;
+        fan = 2;
     }
 
     // io_printf(IO_STD, "Fan max %d fan %d\n", max, fan);
@@ -200,82 +200,82 @@ static void check_status(void)
     // Bits 0-7 are voltage readings
 
     for (uint32_t i = 0; i < 8; i++) {
-	uint32_t volts = stat->adc[i];
+        uint32_t volts = stat->adc[i];
 
-	if (volts == UINT16_MAX) {	// Ignore unused channels
-	    continue;
+        if (volts == UINT16_MAX) {      // Ignore unused channels
+            continue;
         }
 
-	// Ignore all except V33, VPWR if power off
-	if (i < 6 && power_state == POWER_OFF) {
-	    continue;
+        // Ignore all except V33, VPWR if power off
+        if (i < 6 && power_state == POWER_OFF) {
+            continue;
         }
 
-	uint32_t wv = ee_data.warn_vhigh[i] << 4;
-	uint32_t sv = ee_data.shut_vhigh[i] << 4;
+        uint32_t wv = ee_data.warn_vhigh[i] << 4;
+        uint32_t sv = ee_data.shut_vhigh[i] << 4;
 
-	warning |= (wv != 0 && volts > wv) << i;
-	shutdown |= (sv != 0 && volts > sv) << i;
+        warning |= (wv != 0 && volts > wv) << i;
+        shutdown |= (sv != 0 && volts > sv) << i;
 
-	wv = ee_data.warn_vlow[i] << 4;
-	sv = ee_data.shut_vlow[i] << 4;
+        wv = ee_data.warn_vlow[i] << 4;
+        sv = ee_data.shut_vlow[i] << 4;
 
-	warning |= (wv != 0 && volts < wv) << i;
-	shutdown |= (sv != 0 && volts < sv) << i;
+        warning |= (wv != 0 && volts < wv) << i;
+        shutdown |= (sv != 0 && volts < sv) << i;
     }
 
     // Bits 8-11 are on-board temperature sensors
 
     for (uint32_t i = 0; i < 4; i++) {
-	int32_t temp = stat->t_int[i];
-	int32_t wt = ee_data.warn_int[i] * 256;
-	int32_t st = ee_data.shut_int[i] * 256;
+        int32_t temp = stat->t_int[i];
+        int32_t wt = ee_data.warn_int[i] * 256;
+        int32_t st = ee_data.shut_int[i] * 256;
 
-	warning |= (temp != INT16_MIN && wt != 0 && temp > wt) << (i + 8);
-	shutdown |= (temp != INT16_MIN && st != 0 && temp > st) << (i + 8);
+        warning |= (temp != INT16_MIN && wt != 0 && temp > wt) << (i + 8);
+        shutdown |= (temp != INT16_MIN && st != 0 && temp > st) << (i + 8);
     }
 
     if (bp_ctrl) {
-	// Bits 12-15 are off-board temperature sensors
+        // Bits 12-15 are off-board temperature sensors
 
-	for (uint32_t i = 0; i < 4; i++) {
-	    int32_t temp = stat->t_ext[i];
-	    int32_t wt = ee_data.warn_ext[i] * 256;
-	    int32_t st = ee_data.shut_ext[i] * 256;
+        for (uint32_t i = 0; i < 4; i++) {
+            int32_t temp = stat->t_ext[i];
+            int32_t wt = ee_data.warn_ext[i] * 256;
+            int32_t st = ee_data.shut_ext[i] * 256;
 
-	    warning |= (wt != 0 && temp > wt) << (i + 12);
-	    shutdown |= (temp != INT16_MIN && st != 0 && temp > st) << (i + 12);
-	}
+            warning |= (wt != 0 && temp > wt) << (i + 12);
+            shutdown |= (temp != INT16_MIN && st != 0 && temp > st) << (i + 12);
+        }
     }
 
     if (fan_sense) {
-	// Bits 16-19 are fan speeds
+        // Bits 16-19 are fan speeds
 
-	for (uint32_t i = 0; i < 4; i++) {
-	    uint32_t speed = stat->fan[i];
-	    uint32_t wf = ee_data.warn_fan[i] << 4;
-	    uint32_t sf = ee_data.shut_fan[i] << 4;
+        for (uint32_t i = 0; i < 4; i++) {
+            uint32_t speed = stat->fan[i];
+            uint32_t wf = ee_data.warn_fan[i] << 4;
+            uint32_t sf = ee_data.shut_fan[i] << 4;
 
-	    warning |= (wf != 0 && speed < wf) << (i + 16);
-	    shutdown |= (speed != UINT16_MAX && sf != 0 && speed < sf) << (i + 16);
-	}
+            warning |= (wf != 0 && speed < wf) << (i + 16);
+            shutdown |= (speed != UINT16_MAX && sf != 0 && speed < sf) << (i + 16);
+        }
     }
 
     stat->warning = warning;
 
     if (shutdown && stat->shutdown == 0) {
-	if (shut_count++ == 10) {
-	    stat->shutdown = shutdown;
-	    set_power(POWER_SHUT);
-	}
+        if (shut_count++ == 10) {
+            stat->shutdown = shutdown;
+            set_power(POWER_SHUT);
+        }
     } else {
-	shut_count = 0;
+        shut_count = 0;
     }
 
     led2_period = (stat->shutdown) ? 10 : (warning) ? 25 : 0;
 
     if (lcd_active) {
-	update_lcd();
+        update_lcd();
     }
 }
 
@@ -285,62 +285,62 @@ static void proc_100hz(uint32_t arg1, uint32_t arg2)
     refresh_wdt();
 
     if (can_ID < CAN_SIZE) {
-	can_timer();
+        can_timer();
     }
 
     iptag_timer();
 
     if (ticks == 0) {
-	LPC_GPIO0->FIOCLR = LED_0 + LED_2;
-	led2_timer = led2_period;
-	read_temp();
+        LPC_GPIO0->FIOCLR = LED_0 + LED_2;
+        led2_timer = led2_period;
+        read_temp();
     } else if (ticks == 49) {
-	LPC_GPIO0->FIOSET = LED_0;
-	check_status();
+        LPC_GPIO0->FIOSET = LED_0;
+        check_status();
     } else if (ticks == 75) {
-	fan_control();
+        fan_control();
     }
 
-    if (ticks % 8 == 0) {	// Every 80ms
-	read_adc();
+    if (ticks % 8 == 0) {       // Every 80ms
+        read_adc();
     }
 
     if (--led2_timer == 0) {
-	led2_timer = led2_period;
-	LPC_GPIO0->FIOPIN ^= LED_2;
+        led2_timer = led2_period;
+        LPC_GPIO0->FIOPIN ^= LED_2;
     }
 
     if (eth_timeout && --eth_timeout == 0) {
-	LPC_GPIO0->FIOCLR = LED_6;
+        LPC_GPIO0->FIOCLR = LED_6;
     }
 
     if (ticks++ == 99) {
-	ticks = 0;
-	uni_vec[2]++;
+        ticks = 0;
+        uni_vec[2]++;
     }
 }
 
 void SysTick_Handler(void)
 {
     if (fan_sense) {
-	read_fans();
+        read_fans();
     }
 
     if (ms_tens++ == 9) {
-	ms_tens = 0;
+        ms_tens = 0;
 
-	event_t *e = event_new(proc_100hz, 0, 0);
+        event_t *e = event_new(proc_100hz, 0, 0);
 
-	if (e != NULL) {
-	    proc_queue_add(e);
+        if (e != NULL) {
+            proc_queue_add(e);
         }
     }
 }
 
 void c_main(cortex_vec_t *cortex_vec_tmp,
-	bool data_ok_tmp,
-	uint32_t arg3,
-	uint32_t arg4)
+        bool data_ok_tmp,
+        uint32_t arg3,
+        uint32_t arg4)
 {
     cortex_vec = cortex_vec_tmp;
     data_ok = data_ok_tmp;
@@ -350,16 +350,16 @@ void c_main(cortex_vec_t *cortex_vec_tmp,
     configure_hw();
 
     while (1) {
-	if (msg_queue_size () != 0) {
-	    route_msg(msg_queue_remove());
+        if (msg_queue_size () != 0) {
+            route_msg(msg_queue_remove());
         }
 
-	if (eth_rx_rdy()) {
-	    LPC_GPIO0->FIOSET = LED_6;
-	    eth_timeout = 25;
-	    eth_receive();
-	}
+        if (eth_rx_rdy()) {
+            LPC_GPIO0->FIOSET = LED_6;
+            eth_timeout = 25;
+            eth_receive();
+        }
 
-	proc_queue_run();
+        proc_queue_run();
     }
 }

--- a/bmp/bmp_net.c
+++ b/bmp/bmp_net.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_net.c	    Networking code for BMP LPC1768
+// bmp_net.c        Networking code for BMP LPC1768
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -18,31 +18,31 @@
 
 // Internet constants and structs
 
-#define ntohs(t)	((((t) & 0x00ff) << 8) | (((t) & 0xff00) >> 8))
-#define htons(t)	((((t) & 0x00ff) << 8) | (((t) & 0xff00) >> 8))
+#define ntohs(t)        ((((t) & 0x00ff) << 8) | (((t) & 0xff00) >> 8))
+#define htons(t)        ((((t) & 0x00ff) << 8) | (((t) & 0xff00) >> 8))
 
-#define MAC_HDR_SIZE    	14
-#define IP_HDR_SIZE     	20
-#define UDP_HDR_SIZE		8
-#define SDP_PAD_SIZE		2
+#define MAC_HDR_SIZE            14
+#define IP_HDR_SIZE             20
+#define UDP_HDR_SIZE            8
+#define SDP_PAD_SIZE            2
 
-#define IP_HDR_OFFSET   	MAC_HDR_SIZE
-#define IP_DATA_OFFSET  	(IP_HDR_OFFSET + IP_HDR_SIZE)
+#define IP_HDR_OFFSET           MAC_HDR_SIZE
+#define IP_DATA_OFFSET          (IP_HDR_OFFSET + IP_HDR_SIZE)
 
-#define UDP_HDR_OFFSET		IP_DATA_OFFSET
-#define UDP_DATA_OFFSET		(UDP_HDR_OFFSET + UDP_HDR_SIZE)
+#define UDP_HDR_OFFSET          IP_DATA_OFFSET
+#define UDP_DATA_OFFSET         (UDP_HDR_OFFSET + UDP_HDR_SIZE)
 
-#define ETYPE_IP  		0x0800
-#define ETYPE_ARP 		0x0806
+#define ETYPE_IP                0x0800
+#define ETYPE_ARP               0x0806
 
-#define PROT_ICMP 		1
-#define PROT_UDP  		17
+#define PROT_ICMP               1
+#define PROT_UDP                17
 
-#define ARP_REQ 		1
-#define ARP_REPLY 		2
+#define ARP_REQ                 1
+#define ARP_REPLY               2
 
-#define ICMP_ECHO_REPLY 	0
-#define ICMP_ECHO_REQ 		8
+#define ICMP_ECHO_REPLY         0
+#define ICMP_ECHO_REQ           8
 
 
 typedef struct {
@@ -93,9 +93,9 @@ typedef struct {
 
 //------------------------------------------------------------------------------
 
-#define NUM_MSGS 	        8
-#define MAX_MSG  		(NUM_MSGS - 1)
-#define MSG_QUEUE_SIZE 		NUM_MSGS
+#define NUM_MSGS                8
+#define MAX_MSG                 (NUM_MSGS - 1)
+#define MSG_QUEUE_SIZE          NUM_MSGS
 
 typedef struct msg_queue_t {
     uint8_t insert;
@@ -124,7 +124,7 @@ static const uint8_t zero_mac[] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 ip_data_t spin_ip;
 ip_data_t bmp_ip;
 
-uint32_t tag_tto = 9;	// 2.56s = 10ms * (1 << (9-1))
+uint32_t tag_tto = 9;   // 2.56s = 10ms * (1 << (9-1))
 
 //------------------------------------------------------------------------------
 
@@ -133,8 +133,8 @@ void msg_init()
     sdp_msg_t *msg = msg_root = msg_bufs;
 
     for (uint32_t i = 0; i < NUM_MSGS; i++) {
-	msg->next = (i != MAX_MSG) ? msg + 1 : NULL;
-	msg++;
+        msg->next = (i != MAX_MSG) ? msg + 1 : NULL;
+        msg++;
     }
 
     msg_queue.insert = 1;
@@ -147,12 +147,12 @@ sdp_msg_t* msg_get()
     sdp_msg_t *msg = msg_root;
 
     if (msg != NULL) {
-	msg_root = msg->next;
-	msg->next = NULL; // !! Needed??
+        msg_root = msg->next;
+        msg->next = NULL; // !! Needed??
 
-	msg_count++;
-	if (msg_count > msg_max) {
-	    msg_max = msg_count;
+        msg_count++;
+        if (msg_count > msg_max) {
+            msg_max = msg_count;
         }
     }
 
@@ -174,9 +174,9 @@ void msg_free(sdp_msg_t *msg)
 
 uint32_t msg_queue_insert(sdp_msg_t *msg)
 {
-    if (msg_queue.count >= MSG_QUEUE_SIZE) {	// !! Fatal error? - free msg?
-	//##      sw_error (SW_ERR + 0);
-	return 0;
+    if (msg_queue.count >= MSG_QUEUE_SIZE) {    // !! Fatal error? - free msg?
+        //##      sw_error (SW_ERR + 0);
+        return 0;
     }
 
     uint32_t cpsr = cpu_int_off();
@@ -185,7 +185,7 @@ uint32_t msg_queue_insert(sdp_msg_t *msg)
     msg_queue.count++;
 
     if (msg_queue.count > msg_queue.max) {
-	msg_queue.max = msg_queue.count;
+        msg_queue.max = msg_queue.count;
     }
 
     msg_queue.insert = (msg_queue.insert + 1) % MSG_QUEUE_SIZE;
@@ -215,15 +215,15 @@ uint32_t msg_queue_size(void)
 uint32_t ipsum(uint8_t *d, uint32_t len, uint32_t sum) // Use shorts for speed??
 {
     if (len & 1) {
-	sum += d[--len] << 8;
+        sum += d[--len] << 8;
     }
 
     for (uint32_t i = 0; i < len; i += 2) {
-	sum += (d[i] << 8) + d[i+1];
+        sum += (d[i] << 8) + d[i+1];
     }
 
     while (sum >> 16) {
-	sum = (sum >> 16) + (sum & 0xffff);
+        sum = (sum >> 16) + (sum & 0xffff);
     }
 
     return sum;
@@ -263,21 +263,21 @@ void iptag_timer()
     iptag_t *tag = tag_table;
 
     for (uint32_t i = 0; i < TAG_TABLE_SIZE; i++) {
-	if ((tag->flags & IPTAG_VALID) && (tag->timeout > 0)) {
-	    tag->timeout--;
-	    if (tag->timeout == 0) {
-		tag->flags = 0;
-	    }
-	}
-	tag++;
+        if ((tag->flags & IPTAG_VALID) && (tag->timeout > 0)) {
+            tag->timeout--;
+            if (tag->timeout == 0) {
+                tag->flags = 0;
+            }
+        }
+        tag++;
     }
 }
 
 uint32_t iptag_new()
 {
     for (uint32_t i = FIRST_POOL_TAG; i <= LAST_POOL_TAG; i++) {
-	if (tag_table[i].flags == 0) {
-	  return i;
+        if (tag_table[i].flags == 0) {
+          return i;
         }
     }
 
@@ -289,16 +289,16 @@ uint32_t transient_tag(uint8_t *ip, uint8_t *mac, uint32_t port, uint32_t timeou
     uint32_t tag = iptag_new();
 
     if (tag != TAG_NONE) {
-	iptag_t *tt = tag_table+tag;
+        iptag_t *tt = tag_table+tag;
 
-	tt->flags = IPTAG_VALID + IPTAG_TRANS + timeout;
-	tt->port = port;
-	copy_ip(ip, tt->ip);
-	copy_mac(mac, tt->mac);
-	if (timeout != 0) {
-	    timeout = 1 << (timeout - 1);
+        tt->flags = IPTAG_VALID + IPTAG_TRANS + timeout;
+        tt->port = port;
+        copy_ip(ip, tt->ip);
+        copy_mac(mac, tt->mac);
+        if (timeout != 0) {
+            timeout = 1 << (timeout - 1);
         }
-	tt->timeout = timeout;
+        tt->timeout = timeout;
     }
 
     return tag;
@@ -312,12 +312,12 @@ void copy_ip_hdr(uint8_t *dest, uint32_t prot, ip_hdr_t *ip, uint32_t len)
     ip->DS = 0;
     ip->length = htons(len);
     ip->ident = htons(0);
-    ip->flg_off = htons(2 << 13);	// Flags = 010, offset = 0
+    ip->flg_off = htons(2 << 13);       // Flags = 010, offset = 0
     ip->TTL = 64;
-    ip->protocol = prot;		// Insert protocol
+    ip->protocol = prot;                // Insert protocol
     ip->checksum = htons(0);
-    copy_ip(dest, ip->dest);		// Source IP address
-    copy_ip(bmp_ip.ip_addr, ip->srce);	// My IP address
+    copy_ip(dest, ip->dest);            // Source IP address
+    copy_ip(bmp_ip.ip_addr, ip->srce);  // My IP address
 
     uint32_t sum = ipsum((uint8_t *) ip, IP_HDR_SIZE, 0);// Update checksum
     ip->checksum = htons(~sum);
@@ -327,15 +327,15 @@ void copy_udp(uint8_t *buf, uint32_t len, uint32_t dest, uint32_t srce)
 {
     udp_hdr_t *udp_hdr = (udp_hdr_t *) (buf+UDP_HDR_OFFSET);
 
-    udp_hdr->srce = htons(srce);	// Source port
-    udp_hdr->dest = htons(dest);	// Dest port
-    udp_hdr->length = htons(len);	// Insert length
-    udp_hdr->checksum = 0;		// Zero checksum
+    udp_hdr->srce = htons(srce);        // Source port
+    udp_hdr->dest = htons(dest);        // Dest port
+    udp_hdr->length = htons(len);       // Insert length
+    udp_hdr->checksum = 0;              // Zero checksum
 
     uint32_t t;
     t = ipsum(buf+IP_HDR_OFFSET+12, 8, 0); // Sum IP hdr addresses
-    t += len;				// add in UDP data length
-    t += PROT_UDP;			// and UDP protocol number
+    t += len;                           // add in UDP data length
+    t += PROT_UDP;                      // and UDP protocol number
     t = ipsum((uint8_t *) udp_hdr, len, t); // Final UDP checksum
 
     udp_hdr->checksum = htons(~t);
@@ -344,7 +344,7 @@ void copy_udp(uint8_t *buf, uint32_t len, uint32_t dest, uint32_t srce)
 //------------------------------------------------------------------------------
 
 void eth_transmit(uint8_t *buf, uint32_t len, uint32_t type,
-	const uint8_t *dest)
+        const uint8_t *dest)
 {
     mac_hdr_t *mac_hdr = (mac_hdr_t *) buf;
 
@@ -353,11 +353,11 @@ void eth_transmit(uint8_t *buf, uint32_t len, uint32_t type,
     mac_hdr->type = htons(type);
 
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
 
     while (! eth_tx_rdy()) {
-	continue;
+        continue;
     }
 
     eth_copy_txbuf((uint32_t *) buf, len);
@@ -365,21 +365,21 @@ void eth_transmit(uint8_t *buf, uint32_t len, uint32_t type,
 }
 
 void send_arp_pkt(uint8_t *buf, const uint8_t *dest, const uint8_t *tha,
-	const uint8_t *tpa, uint32_t type)
+        const uint8_t *tpa, uint32_t type)
 {
     arp_pkt_t *arp = (arp_pkt_t *) (buf + MAC_HDR_SIZE);
 
-    arp->htype = htons(0x0001);		// Ethernet
-    arp->ptype = htons(0x0800);		// IPv4
+    arp->htype = htons(0x0001);         // Ethernet
+    arp->ptype = htons(0x0800);         // IPv4
     arp->hlen = 6;
     arp->plen = 4;
     arp->op = htons(type);
 
-    copy_mac(tha, arp->tha);		// Copy to THA
-    copy_ip(tpa, arp->tpa);		// Copy to TPA
+    copy_mac(tha, arp->tha);            // Copy to THA
+    copy_ip(tpa, arp->tpa);             // Copy to TPA
 
     copy_mac(bmp_ip.mac_addr, arp->sha);// Copy my MAC addr
-    copy_ip(bmp_ip.ip_addr, arp->spa); 	// Copy my IP addr
+    copy_ip(bmp_ip.ip_addr, arp->spa);  // Copy my IP addr
 
     eth_transmit(buf, 42, ETYPE_ARP, dest);
 }
@@ -389,28 +389,28 @@ void arp_pkt(uint8_t *buf, uint32_t rx_len)
     arp_pkt_t *arp = (arp_pkt_t *) (buf + MAC_HDR_SIZE);
 
     if (!cmp_ip(arp->tpa, bmp_ip.ip_addr)) { // Ignore unless TPA matches
-	return;
+        return;
     }
 
     uint32_t op = ntohs(arp->op);
 
     if (op == ARP_REQ) {
-	send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
-    } else if (op == ARP_REPLY) {	// Reply & TPA matches
-	iptag_t *tt = tag_table;
+        send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
+    } else if (op == ARP_REPLY) {       // Reply & TPA matches
+        iptag_t *tt = tag_table;
 
-	for (uint32_t i = 0; i < TAG_TABLE_SIZE; i++) {
-	    uint32_t f = tt->flags;
+        for (uint32_t i = 0; i < TAG_TABLE_SIZE; i++) {
+            uint32_t f = tt->flags;
 
-	    if ((f & IPTAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
-		copy_mac(arp->sha, tt->mac);
-		f &= ~IPTAG_ARP;
-		tt->flags = f | IPTAG_VALID;
-		break;
-	    }
+            if ((f & IPTAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
+                copy_mac(arp->sha, tt->mac);
+                f &= ~IPTAG_ARP;
+                tt->flags = f | IPTAG_VALID;
+                break;
+            }
 
-	    tt++;
-	}
+            tt++;
+        }
     }
 }
 
@@ -419,7 +419,7 @@ void icmp_pkt(uint8_t *buf, uint32_t rx_len)
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (buf + IP_HDR_OFFSET);
 
     if (!cmp_ip (ip_hdr->dest, bmp_ip.ip_addr)) {
-	return;
+        return;
     }
 
     uint32_t ip_hdr_len = (ip_hdr->ver_len & 15) * 4;
@@ -427,23 +427,23 @@ void icmp_pkt(uint8_t *buf, uint32_t rx_len)
     icmp_hdr_t *icmp = (icmp_hdr_t *) (buf + IP_HDR_OFFSET + ip_hdr_len);
 
     if (icmp->type == ICMP_ECHO_REQ) {
-	uint32_t icmp_len = ntohs(ip_hdr->length) - ip_hdr_len;	// Size of ICMP hdr+data
+        uint32_t icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
 
-	copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
+        copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
 
-	if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
-	    icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET); // 'new' ICMP hdr
-	    memcpy((uint8_t *) icmp, (uint8_t *) icmp + ip_hdr_len, icmp_len);
-	}
+        if (ip_hdr_len > IP_HDR_SIZE) {         // Copy down ICMP header & data
+            icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET); // 'new' ICMP hdr
+            memcpy((uint8_t *) icmp, (uint8_t *) icmp + ip_hdr_len, icmp_len);
+        }
 
-	icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
-	icmp->code = 0;				// ICMP code = 0
-	icmp->checksum = 0;
+        icmp->type = ICMP_ECHO_REPLY;           // ICMP reply
+        icmp->code = 0;                         // ICMP code = 0
+        icmp->checksum = 0;
 
-	uint32_t sum = ipsum((uint8_t *) icmp, icmp_len, 0);
-	icmp->checksum = htons(~sum);
+        uint32_t sum = ipsum((uint8_t *) icmp, icmp_len, 0);
+        icmp->checksum = htons(~sum);
 
-	eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
+        eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
     }
 }
 
@@ -456,49 +456,49 @@ void udp_pkt(uint8_t *rx_pkt, uint32_t rx_len)
     uint32_t udp_dest = ntohs(udp_hdr->dest);
 
     if ((udp_dest == bmp_ip.udp_port) && cmp_ip(ip_hdr->dest, bmp_ip.ip_addr)
-	    && rx_len > 52) {			//const NB 52
-	uint32_t udp_srce = ntohs(udp_hdr->srce);
-	int32_t len = ntohs(udp_hdr->length) - 10; //const UDP_HDR + UDP_PAD
+            && rx_len > 52) {                   //const NB 52
+        uint32_t udp_srce = ntohs(udp_hdr->srce);
+        int32_t len = ntohs(udp_hdr->length) - 10; //const UDP_HDR + UDP_PAD
 
-	if (len > (24 + 256)) {			// SDP=8, CMD=16
-	    return;
-	}
+        if (len > (24 + 256)) {                 // SDP=8, CMD=16
+            return;
+        }
 
-	sdp_msg_t *msg = msg_get();
-	if (msg == NULL) {			// !! fix this - reply somehow?
-	    return;
-	}
+        sdp_msg_t *msg = msg_get();
+        if (msg == NULL) {                      // !! fix this - reply somehow?
+            return;
+        }
 
-	memcpy(&msg->flags, (uint8_t *) udp_hdr+10, len); //const
+        memcpy(&msg->flags, (uint8_t *) udp_hdr+10, len); //const
 
-	msg->length = len;
-	msg->srce_port = (7 << PORT_SHIFT) + board_ID;
-	msg->srce_addr = ee_data.frame_ID;
+        msg->length = len;
+        msg->srce_port = (7 << PORT_SHIFT) + board_ID;
+        msg->srce_addr = ee_data.frame_ID;
 
-	uint32_t flags = msg->flags;
-	uint32_t tag = msg->tag;
+        uint32_t flags = msg->flags;
+        uint32_t tag = msg->tag;
 
-	if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
-	    tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
-	}
+        if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
+            tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
+        }
 
-	if (((flags & SDPF_REPLY) == 0) ||
-		(tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
-	    msg_queue_insert(msg);
-	} else {
-	    msg_free(msg);
-	}
+        if (((flags & SDPF_REPLY) == 0) ||
+                (tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
+            msg_queue_insert(msg);
+        } else {
+            msg_free(msg);
+        }
     }
 }
 
 void eth_receive()
 {
     uint8_t *rx_pkt = eth_buf;
-    int32_t len = eth_rx_size() - 3;	// Removes CRC ??
+    int32_t len = eth_rx_size() - 3;    // Removes CRC ??
 
     if (len > 384) {
-	eth_rx_discard();
-	return;
+        eth_rx_discard();
+        return;
     }
 
     eth_copy_rxbuf((uint32_t *) eth_buf, len);
@@ -507,15 +507,15 @@ void eth_receive()
     uint32_t etype = (rx_pkt[12] << 8) + rx_pkt[13];
 
     if (etype == ETYPE_IP) {
-	uint32_t ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
+        uint32_t ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
 
-	if (ip_prot == PROT_UDP) {
-	    udp_pkt(rx_pkt, len);
-	} else if (ip_prot == PROT_ICMP) {
-	    icmp_pkt(rx_pkt, len);
+        if (ip_prot == PROT_UDP) {
+            udp_pkt(rx_pkt, len);
+        } else if (ip_prot == PROT_ICMP) {
+            icmp_pkt(rx_pkt, len);
         }
     } else if (etype == ETYPE_ARP) {
-	arp_pkt(rx_pkt, len);
+        arp_pkt(rx_pkt, len);
     }
 }
 
@@ -533,10 +533,10 @@ void eth_transmit2(uint8_t *hdr, uint8_t *buf, uint32_t len, uint8_t *dest)
     len += 44;
 
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
     while (! eth_tx_rdy()) {
-	continue;
+        continue;
     }
     eth_copy_txbuf((uint32_t *) eth_buf, len);
     eth_update_tx();
@@ -548,7 +548,7 @@ void eth_send_msg(uint32_t tag, sdp_msg_t *msg)
     iptag_t *iptag = tag_table + tag;
 
     if ((iptag->flags & IPTAG_VALID) == 0) {
-	return;
+        return;
     }
 
     uint32_t len = msg->length;
@@ -556,30 +556,30 @@ void eth_send_msg(uint32_t tag, sdp_msg_t *msg)
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (hdr + IP_HDR_OFFSET);
 
     copy_ip_hdr(iptag->ip, PROT_UDP, ip_hdr,
-	    len + IP_HDR_SIZE + UDP_HDR_SIZE + SDP_PAD_SIZE);
+            len + IP_HDR_SIZE + UDP_HDR_SIZE + SDP_PAD_SIZE);
 
     udp_hdr_t *udp_hdr = (udp_hdr_t *) (hdr + UDP_HDR_OFFSET);
 
     udp_hdr->srce = htons(bmp_ip.udp_port);
     udp_hdr->dest = htons(iptag->port);
     udp_hdr->length = htons(len+UDP_HDR_SIZE+SDP_PAD_SIZE);// Insert length
-    udp_hdr->checksum = 0;			// Zero checksum
+    udp_hdr->checksum = 0;                      // Zero checksum
 
     uint32_t t;
-    t = ipsum(hdr+IP_HDR_OFFSET+12, 8, 0);	// Sum IP hdr addresses
-    t += len + UDP_HDR_SIZE + SDP_PAD_SIZE;	// add in UDP data length
-    t += PROT_UDP;				// and UDP protocol number
-    t = ipsum((uint8_t *) udp_hdr, 10, t);	// and UDP header and pad
-    t = ipsum(&msg->flags, len, t);		// and finally the data
+    t = ipsum(hdr+IP_HDR_OFFSET+12, 8, 0);      // Sum IP hdr addresses
+    t += len + UDP_HDR_SIZE + SDP_PAD_SIZE;     // add in UDP data length
+    t += PROT_UDP;                              // and UDP protocol number
+    t = ipsum((uint8_t *) udp_hdr, 10, t);      // and UDP header and pad
+    t = ipsum(&msg->flags, len, t);             // and finally the data
 
     udp_hdr->checksum = htons(~t);
 
     eth_transmit2(hdr, &msg->flags, len, iptag->mac);
 
-    if (iptag->flags & IPTAG_TRANS) {		//transient tag
-	iptag->flags = 0;
+    if (iptag->flags & IPTAG_TRANS) {           //transient tag
+        iptag->flags = 0;
     } else {
-	iptag->count++;
+        iptag->count++;
     }
 }
 
@@ -600,17 +600,17 @@ void return_msg(sdp_msg_t *msg, uint32_t rc) // Zero "rc" skips updating cmd_hdr
     uint32_t f = msg->flags;
 
     if (f & SDPF_REPLY) {
-	msg->flags = f & ~SDPF_REPLY;
-	swap_sdp_hdr(msg);
+        msg->flags = f & ~SDPF_REPLY;
+        swap_sdp_hdr(msg);
 
-	if (rc != 0) {
-	    msg->cmd_rc = rc;
-	    msg->length = 12;
-	}
+        if (rc != 0) {
+            msg->cmd_rc = rc;
+            msg->length = 12;
+        }
 
-	msg_queue_insert(msg);
+        msg_queue_insert(msg);
     } else {
-	msg_free(msg);
+        msg_free(msg);
     }
 }
 
@@ -619,26 +619,26 @@ void route_msg(sdp_msg_t *msg)
     uint32_t dest = msg->dest_port & BOARD_MASK;
 
     if (dest != board_ID) {
-	uint32_t rc = can_send_msg(dest, msg);
+        uint32_t rc = can_send_msg(dest, msg);
 
-	if (rc == RC_OK) {
-	    msg_free(msg);
+        if (rc == RC_OK) {
+            msg_free(msg);
         } else {
             return_msg(msg, rc);
-	}
-	return;
+        }
+        return;
     }
 
     uint32_t port = msg->dest_port >> PORT_SHIFT;
 
     if (port == 0) {
-	msg->length = 12 + debug(msg);
-	return_msg(msg, 0);
+        msg->length = 12 + debug(msg);
+        return_msg(msg, 0);
     } else if (port == 7) {
-	eth_send_msg(msg->tag, msg);
-	msg_free(msg);
+        eth_send_msg(msg->tag, msg);
+        msg_free(msg);
     } else {
-	return_msg(msg, RC_PORT);
+        return_msg(msg, RC_PORT);
     }
 }
 
@@ -654,7 +654,7 @@ void arp_lookup(iptag_t *iptag)
     const uint8_t *target_ip = addr;
 
     if ((*my_ip & *mask) != (*ip & *mask)) {
-	target_ip = bmp_ip.gw_addr;
+        target_ip = bmp_ip.gw_addr;
     }
 
     copy_ip(target_ip, iptag->mac); // !! Bodge - target IP in MAC field!
@@ -671,31 +671,31 @@ static uint32_t tube_ptr;
 
 void eth_putc(uint32_t c)
 {
-    uint8_t *buf = (uint8_t *) tube_buf + 56; 	// Point at start of msg buffer
+    uint8_t *buf = (uint8_t *) tube_buf + 56;   // Point at start of msg buffer
 
-    buf[tube_ptr++] = c;			// Insert char at end
+    buf[tube_ptr++] = c;                        // Insert char at end
 
     if (c == 0 || c == '\n' || tube_ptr == 256) {
-	iptag_t *tag = tag_table;
+        iptag_t *tag = tag_table;
 
-	if (tag->flags & IPTAG_VALID) {
-	    sdp_msg_t *msg = (sdp_msg_t *) (buf - 20);
+        if (tag->flags & IPTAG_VALID) {
+            sdp_msg_t *msg = (sdp_msg_t *) (buf - 20);
 
-	    msg->cmd_rc = 64;
-	    msg->srce_port = board_ID;
-	    msg->srce_addr = ee_data.frame_ID;
+            msg->cmd_rc = 64;
+            msg->srce_port = board_ID;
+            msg->srce_addr = ee_data.frame_ID;
 
-	    ip_hdr_t *ip_hdr = (ip_hdr_t *) (tube_buf + IP_HDR_OFFSET);
+            ip_hdr_t *ip_hdr = (ip_hdr_t *) (tube_buf + IP_HDR_OFFSET);
 
-	    copy_ip_hdr(tag->ip, PROT_UDP, ip_hdr,
-		    IP_HDR_SIZE + UDP_HDR_SIZE + 14 + tube_ptr);
+            copy_ip_hdr(tag->ip, PROT_UDP, ip_hdr,
+                    IP_HDR_SIZE + UDP_HDR_SIZE + 14 + tube_ptr);
 
-	    copy_udp(tube_buf, UDP_HDR_SIZE + 14 + tube_ptr, tag->port, 0);
+            copy_udp(tube_buf, UDP_HDR_SIZE + 14 + tube_ptr, tag->port, 0);
 
-	    eth_transmit(tube_buf, 56 + tube_ptr, ETYPE_IP, tag->mac);
-	}
+            eth_transmit(tube_buf, 56 + tube_ptr, ETYPE_IP, tag->mac);
+        }
 
-	tube_ptr = 0;
+        tube_ptr = 0;
     }
 }
 
@@ -709,13 +709,13 @@ void copy_ip_data(void)
 
     // Fill in defaults if not programmed
     if (bmp_ip.flags == 0xffff || !data_ok) {
-	bmp_ip.flags = 0x8000;
-	bmp_ip.udp_port = 17893;
+        bmp_ip.flags = 0x8000;
+        bmp_ip.udp_port = 17893;
     }
 
     if (spin_ip.flags == 0xffff || !data_ok) {
-	spin_ip.flags = 0x8059;
-	spin_ip.udp_port = 17893;
+        spin_ip.flags = 0x8059;
+        spin_ip.udp_port = 17893;
     }
 }
 

--- a/bmp/bmp_ssp.c
+++ b/bmp/bmp_ssp.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// bmp_ssp.c	    SSP peripheral handling for BC&MP
+// bmp_ssp.c        SSP peripheral handling for BC&MP
 //
 // Copyright (C)    The University of Manchester - 2012-2015
 //
@@ -31,21 +31,21 @@
 
 //------------------------------------------------------------------------------
 
-static void delay(uint32_t n)		// 30ns per loop?
+static void delay(uint32_t n)           // 30ns per loop?
 {
     while (n--) {
-	continue;
+        continue;
     }
 }
 
 void ssp1_copy(uint32_t count, uint8_t *buf)
 {
     while (count--) {
-	while ((LPC_SSP1->SR & 2) == 0)	{// Loop while full
-	    continue;
-	}
+        while ((LPC_SSP1->SR & 2) == 0) {// Loop while full
+            continue;
+        }
 
-	LPC_SSP1->DR = *buf++;
+        LPC_SSP1->DR = *buf++;
     }
 }
 
@@ -56,11 +56,11 @@ void fpga_word(uint32_t addr, uint32_t fpga, uint32_t *buf, uint32_t dir)
     // Assert select
 
     if (fpga == 0) {
-	LPC_GPIO3->FIOCLR = XFSEL_0;
+        LPC_GPIO3->FIOCLR = XFSEL_0;
     } else if (fpga == 1) {
-	LPC_GPIO3->FIOCLR = XFSEL_1;
+        LPC_GPIO3->FIOCLR = XFSEL_1;
     } else {
-	LPC_GPIO4->FIOCLR = XFSEL_2;
+        LPC_GPIO4->FIOCLR = XFSEL_2;
     }
     delay(10);
 
@@ -69,54 +69,54 @@ void fpga_word(uint32_t addr, uint32_t fpga, uint32_t *buf, uint32_t dir)
     addr = addr & ~3;
 
     if (dir == FPGA_WRITE) {
-	addr += 1;
-	data = *buf;
+        addr += 1;
+        data = *buf;
     }
 
     // Wait until TxFIFO empties & flush RxFIFO
     while ((LPC_SSP1->SR & 1) == 0) {
-	continue;
+        continue;
     }
     while ((LPC_SSP1->SR & 4) != 0) {
-	(void) LPC_SSP1->DR;
+        (void) LPC_SSP1->DR;
     }
 
     // Send address word
     for (uint32_t i = 0; i < 4; i++) {
-	LPC_SSP1->DR = addr >> 24;
-	addr <<= 8;
+        LPC_SSP1->DR = addr >> 24;
+        addr <<= 8;
     }
 
     // and data word (or zero)
     for (uint32_t i = 0; i < 4; i++) {
-	LPC_SSP1->DR = data >> 24;
-	data <<= 8;
+        LPC_SSP1->DR = data >> 24;
+        data <<= 8;
     }
 
     // Wait until TxFIFO empties
     while ((LPC_SSP1->SR & 1) == 0) {
-	continue;
+        continue;
     }
 
     // Throw away returned address
     for (uint32_t i = 0; i < 4; i++) {
-	while ((LPC_SSP1->SR & 4) == 0)	{	// Wait for NotEmpty
-	    continue;
-	}
-	(void) LPC_SSP1->DR;
+        while ((LPC_SSP1->SR & 4) == 0) {       // Wait for NotEmpty
+            continue;
+        }
+        (void) LPC_SSP1->DR;
     }
 
     // Read returned data
     for (uint32_t i = 0; i < 4; i++) {
-	while ((LPC_SSP1->SR & 4) == 0) {	// Wait for NotEmpty
-	    continue;
-	}
-	data <<= 8;
-	data |= LPC_SSP1->DR;
+        while ((LPC_SSP1->SR & 4) == 0) {       // Wait for NotEmpty
+            continue;
+        }
+        data <<= 8;
+        data |= LPC_SSP1->DR;
     }
 
     if (dir == FPGA_READ) {
-	*buf = data;
+        *buf = data;
     }
     delay(30);
 
@@ -128,82 +128,82 @@ void fpga_word(uint32_t addr, uint32_t fpga, uint32_t *buf, uint32_t dir)
 
 static void ssp0_send(uint32_t d)
 {
-    while ((LPC_SSP0->SR & 2) == 0) {	// Loop while full
-	continue;
+    while ((LPC_SSP0->SR & 2) == 0) {   // Loop while full
+        continue;
     }
     LPC_SSP0->DR = d;
 }
 
 void ssp0_write(uint32_t cmd, uint32_t addr, uint32_t len, uint8_t *buf)
 {
-    LPC_GPIO0->FIOCLR = SF_NCS;		// Assert NCS
+    LPC_GPIO0->FIOCLR = SF_NCS;         // Assert NCS
 
-    ssp0_send(0x06);			// Sent write enable
+    ssp0_send(0x06);                    // Sent write enable
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
 
     delay(10);
-    LPC_GPIO0->FIOSET = SF_NCS;		// Deassert NCS
+    LPC_GPIO0->FIOSET = SF_NCS;         // Deassert NCS
 
-    delay(10);				// Ensure NCS high for a while
-    LPC_GPIO0->FIOCLR = SF_NCS;		// Assert NCS
+    delay(10);                          // Ensure NCS high for a while
+    LPC_GPIO0->FIOCLR = SF_NCS;         // Assert NCS
 
     ssp0_send(cmd);
 
     if (addr != 0xffffffff) {
-	ssp0_send(addr >> 16);
-	ssp0_send(addr >> 8);
-	ssp0_send(addr);
+        ssp0_send(addr >> 16);
+        ssp0_send(addr >> 8);
+        ssp0_send(addr);
     }
 
     while (len--) {
-	while ((LPC_SSP0->SR & 2) == 0)	{ // Loop while full
-	    continue;
+        while ((LPC_SSP0->SR & 2) == 0) { // Loop while full
+            continue;
         }
-	LPC_SSP0->DR = *buf++;
+        LPC_SSP0->DR = *buf++;
     }
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
     delay(10);
-    LPC_GPIO0->FIOSET = SF_NCS;		// Deassert NCS
+    LPC_GPIO0->FIOSET = SF_NCS;         // Deassert NCS
 }
 
 void ssp0_read(uint32_t cmd, uint32_t addr, uint32_t len, uint8_t *buf)
 {
-    LPC_GPIO0->FIOCLR = SF_NCS;		// Assert NCS
+    LPC_GPIO0->FIOCLR = SF_NCS;         // Assert NCS
 
     ssp0_send(cmd);
 
     if (addr != 0xffffffff) {
-	ssp0_send(addr >> 16);
-	ssp0_send(addr >> 8);
-	ssp0_send(addr);
+        ssp0_send(addr >> 16);
+        ssp0_send(addr >> 8);
+        ssp0_send(addr);
     }
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
-    while ((LPC_SSP0->SR & 4) != 0) {	// Flush RxFIFO
-	(void) LPC_SSP0->DR;
+    while ((LPC_SSP0->SR & 4) != 0) {   // Flush RxFIFO
+        (void) LPC_SSP0->DR;
     }
     while (len--) {
-	LPC_SSP0->DR = 0;		// Trigger read
+        LPC_SSP0->DR = 0;               // Trigger read
 
-	while ((LPC_SSP0->SR & 4) == 0) { // Loop while empty
-	    continue;
+        while ((LPC_SSP0->SR & 4) == 0) { // Loop while empty
+            continue;
         }
-	*buf++ = LPC_SSP0->DR;
+        *buf++ = LPC_SSP0->DR;
     }
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
     delay(10);
-    LPC_GPIO0->FIOSET = SF_NCS;		// Deassert NCS
+    LPC_GPIO0->FIOSET = SF_NCS;         // Deassert NCS
 }
 
 //------------------------------------------------------------------------------
@@ -212,7 +212,7 @@ void ssp0_read(uint32_t cmd, uint32_t addr, uint32_t len, uint8_t *buf)
 
 void ssp0_copy(uint32_t addr, uint32_t len)
 {
-    LPC_GPIO0->FIOCLR = SF_NCS;		// Assert NCS
+    LPC_GPIO0->FIOCLR = SF_NCS;         // Assert NCS
 
     ssp0_send(0x03);
 
@@ -220,26 +220,26 @@ void ssp0_copy(uint32_t addr, uint32_t len)
     ssp0_send(addr >> 8);
     ssp0_send(addr);
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
-    while ((LPC_SSP0->SR & 4) != 0) {	// Flush RxFIFO
-	(void) LPC_SSP0->DR;
+    while ((LPC_SSP0->SR & 4) != 0) {   // Flush RxFIFO
+        (void) LPC_SSP0->DR;
     }
     while (len--) {
-	LPC_SSP0->DR = 0;		// Trigger read
+        LPC_SSP0->DR = 0;               // Trigger read
 
-	while ((LPC_SSP0->SR & 4) == 0) { // Loop while empty
-	    continue;
+        while ((LPC_SSP0->SR & 4) == 0) { // Loop while empty
+            continue;
         }
-	LPC_SSP1->DR = LPC_SSP0->DR;	// Copy to SSP1
+        LPC_SSP1->DR = LPC_SSP0->DR;    // Copy to SSP1
     }
 
-    while ((LPC_SSP0->SR & 1) == 0) {	// Wait until TxFIFO empties
-	continue;
+    while ((LPC_SSP0->SR & 1) == 0) {   // Wait until TxFIFO empties
+        continue;
     }
     delay(10);
-    LPC_GPIO0->FIOSET = SF_NCS;		// Deassert NCS
+    LPC_GPIO0->FIOSET = SF_NCS;         // Deassert NCS
 }
 
 //------------------------------------------------------------------------------
@@ -249,24 +249,24 @@ void sf_write(uint32_t addr, uint32_t len, uint8_t *buf)
     uint8_t status[4];
 
     while (len != 0) {
-	if ((addr & 0xfff) == 0) {		// On 4K boundary?
-	    ssp0_write(0x39, addr, 0, NULL);	// Unprotect sector
-	    ssp0_write(0x20, addr, 0, NULL);	// Erase 4K sector
+        if ((addr & 0xfff) == 0) {              // On 4K boundary?
+            ssp0_write(0x39, addr, 0, NULL);    // Unprotect sector
+            ssp0_write(0x20, addr, 0, NULL);    // Erase 4K sector
 
-	    do {
-		ssp0_read(0x05, 0xffffffff, 4, status);
-	    } while (status[0] & 1);
-	}
+            do {
+                ssp0_read(0x05, 0xffffffff, 4, status);
+            } while (status[0] & 1);
+        }
 
-	uint32_t bytes = (len > 256) ? 256 : len;
-	ssp0_write(0x02, addr, bytes, buf);
+        uint32_t bytes = (len > 256) ? 256 : len;
+        ssp0_write(0x02, addr, bytes, buf);
 
-	do {
-	    ssp0_read(0x05, 0xffffffff, 4, status);
-	} while (status[0] & 1);
-	len -= bytes;
-	addr += bytes;
-	buf += bytes;
+        do {
+            ssp0_read(0x05, 0xffffffff, 4, status);
+        } while (status[0] & 1);
+        len -= bytes;
+        addr += bytes;
+        buf += bytes;
     }
 }
 
@@ -281,11 +281,11 @@ uint32_t sf_crc32(uint32_t addr, uint32_t len)
     uint32_t crc = 0xffffffff;
 
     while (len != 0) {
-	uint32_t size = (len > FLASH_BYTES) ? FLASH_BYTES : len;
-	ssp0_read(0x03, addr, size, buf);
-	crc = crc32(buf, size, crc);
-	len -= size;
-	addr += size;
+        uint32_t size = (len > FLASH_BYTES) ? FLASH_BYTES : len;
+        ssp0_read(0x03, addr, size, buf);
+        crc = crc32(buf, size, crc);
+        len -= size;
+        addr += size;
     }
 
     return ~crc;
@@ -293,9 +293,9 @@ uint32_t sf_crc32(uint32_t addr, uint32_t len)
 
 //------------------------------------------------------------------------------
 
-#define SSP0_CLK   25000000	// 25 MHz
-#define SSP1_CLK_H 25000000	// 25 MHz
-#define SSP1_CLK_L  5000000	//  5 MHz
+#define SSP0_CLK   25000000     // 25 MHz
+#define SSP1_CLK_H 25000000     // 25 MHz
+#define SSP1_CLK_L  5000000     //  5 MHz
 
 void ssp1_slow(void)
 {

--- a/bmp/lpc17xx.h
+++ b/bmp/lpc17xx.h
@@ -82,8 +82,8 @@ typedef enum IRQn {
   MCPWM_IRQn                    = 30,       /*!< Motor Control PWM Interrupt                      */
   QEI_IRQn                      = 31,       /*!< Quadrature Encoder Interface Interrupt           */
   PLL1_IRQn                     = 32,       /*!< PLL1 Lock (USB PLL) Interrupt                    */
-  USBActivity_IRQn				= 33,		/*!< USB Activity Interrupt 						  */
-  CANActivity_IRQn				= 34,		/*!< CAN Activity Interrupt 						  */
+  USBActivity_IRQn                              = 33,           /*!< USB Activity Interrupt                                               */
+  CANActivity_IRQn                              = 34,           /*!< CAN Activity Interrupt                                               */
 } IRQn_Type;
 
 
@@ -133,8 +133,8 @@ typedef struct {
   __IO uint32_t CCLKCFG;
   __IO uint32_t USBCLKCFG;
   __IO uint32_t CLKSRCSEL;
-  __IO uint32_t	CANSLEEPCLR;
-  __IO uint32_t	CANWAKEFLAGS;
+  __IO uint32_t CANSLEEPCLR;
+  __IO uint32_t CANWAKEFLAGS;
        uint32_t RESERVED4[10];
   __IO uint32_t EXTINT;                 /* External Interrupts                */
        uint32_t RESERVED5;

--- a/bmp/lpc17xx_clkpwr.h
+++ b/bmp/lpc17xx_clkpwr.h
@@ -1,10 +1,10 @@
 /***********************************************************************//**
- * @file		lpc17xx_clkpwr.h
- * @brief		Contains all macro definitions and function prototypes
- * 				support for Clock and Power Control firmware library on LPC17xx
- * @version		2.0
- * @date		21. May. 2010
- * @author		NXP MCU SW Application Team
+ * @file                lpc17xx_clkpwr.h
+ * @brief               Contains all macro definitions and function prototypes
+ *                              support for Clock and Power Control firmware library on LPC17xx
+ * @version             2.0
+ * @date                21. May. 2010
+ * @author              NXP MCU SW Application Team
  **************************************************************************
  * Software that is described herein is for illustrative purposes only
  * which provides customers with programming information regarding the
@@ -45,129 +45,129 @@ extern "C"
  * Peripheral Clock Selection Definitions
  **********************************************************************/
 /** Peripheral clock divider bit position for WDT */
-#define	CLKPWR_PCLKSEL_WDT  		((uint32_t)(0))
+#define CLKPWR_PCLKSEL_WDT              ((uint32_t)(0))
 /** Peripheral clock divider bit position for TIMER0 */
-#define	CLKPWR_PCLKSEL_TIMER0  		((uint32_t)(2))
+#define CLKPWR_PCLKSEL_TIMER0           ((uint32_t)(2))
 /** Peripheral clock divider bit position for TIMER1 */
-#define	CLKPWR_PCLKSEL_TIMER1  		((uint32_t)(4))
+#define CLKPWR_PCLKSEL_TIMER1           ((uint32_t)(4))
 /** Peripheral clock divider bit position for UART0 */
-#define	CLKPWR_PCLKSEL_UART0  		((uint32_t)(6))
+#define CLKPWR_PCLKSEL_UART0            ((uint32_t)(6))
 /** Peripheral clock divider bit position for UART1 */
-#define	CLKPWR_PCLKSEL_UART1  		((uint32_t)(8))
+#define CLKPWR_PCLKSEL_UART1            ((uint32_t)(8))
 /** Peripheral clock divider bit position for PWM1 */
-#define	CLKPWR_PCLKSEL_PWM1  		((uint32_t)(12))
+#define CLKPWR_PCLKSEL_PWM1             ((uint32_t)(12))
 /** Peripheral clock divider bit position for I2C0 */
-#define	CLKPWR_PCLKSEL_I2C0  		((uint32_t)(14))
+#define CLKPWR_PCLKSEL_I2C0             ((uint32_t)(14))
 /** Peripheral clock divider bit position for SPI */
-#define	CLKPWR_PCLKSEL_SPI  		((uint32_t)(16))
+#define CLKPWR_PCLKSEL_SPI              ((uint32_t)(16))
 /** Peripheral clock divider bit position for SSP1 */
-#define	CLKPWR_PCLKSEL_SSP1  		((uint32_t)(20))
+#define CLKPWR_PCLKSEL_SSP1             ((uint32_t)(20))
 /** Peripheral clock divider bit position for DAC */
-#define	CLKPWR_PCLKSEL_DAC  		((uint32_t)(22))
+#define CLKPWR_PCLKSEL_DAC              ((uint32_t)(22))
 /** Peripheral clock divider bit position for ADC */
-#define	CLKPWR_PCLKSEL_ADC  		((uint32_t)(24))
+#define CLKPWR_PCLKSEL_ADC              ((uint32_t)(24))
 /** Peripheral clock divider bit position for CAN1 */
-#define	CLKPWR_PCLKSEL_CAN1 		((uint32_t)(26))
+#define CLKPWR_PCLKSEL_CAN1             ((uint32_t)(26))
 /** Peripheral clock divider bit position for CAN2 */
-#define	CLKPWR_PCLKSEL_CAN2 		((uint32_t)(28))
+#define CLKPWR_PCLKSEL_CAN2             ((uint32_t)(28))
 /** Peripheral clock divider bit position for ACF */
-#define	CLKPWR_PCLKSEL_ACF  		((uint32_t)(30))
+#define CLKPWR_PCLKSEL_ACF              ((uint32_t)(30))
 /** Peripheral clock divider bit position for QEI */
-#define	CLKPWR_PCLKSEL_QEI  		((uint32_t)(32))
+#define CLKPWR_PCLKSEL_QEI              ((uint32_t)(32))
 /** Peripheral clock divider bit position for PCB */
-#define	CLKPWR_PCLKSEL_PCB  		((uint32_t)(36))
+#define CLKPWR_PCLKSEL_PCB              ((uint32_t)(36))
 /** Peripheral clock divider bit position for  I2C1 */
-#define	CLKPWR_PCLKSEL_I2C1  		((uint32_t)(38))
+#define CLKPWR_PCLKSEL_I2C1             ((uint32_t)(38))
 /** Peripheral clock divider bit position for SSP0 */
-#define	CLKPWR_PCLKSEL_SSP0  		((uint32_t)(42))
+#define CLKPWR_PCLKSEL_SSP0             ((uint32_t)(42))
 /** Peripheral clock divider bit position for TIMER2 */
-#define	CLKPWR_PCLKSEL_TIMER2  		((uint32_t)(44))
+#define CLKPWR_PCLKSEL_TIMER2           ((uint32_t)(44))
 /** Peripheral clock divider bit position for  TIMER3 */
-#define	CLKPWR_PCLKSEL_TIMER3  		((uint32_t)(46))
+#define CLKPWR_PCLKSEL_TIMER3           ((uint32_t)(46))
 /** Peripheral clock divider bit position for UART2 */
-#define	CLKPWR_PCLKSEL_UART2  		((uint32_t)(48))
+#define CLKPWR_PCLKSEL_UART2            ((uint32_t)(48))
 /** Peripheral clock divider bit position for UART3 */
-#define	CLKPWR_PCLKSEL_UART3  		((uint32_t)(50))
+#define CLKPWR_PCLKSEL_UART3            ((uint32_t)(50))
 /** Peripheral clock divider bit position for I2C2 */
-#define	CLKPWR_PCLKSEL_I2C2  		((uint32_t)(52))
+#define CLKPWR_PCLKSEL_I2C2             ((uint32_t)(52))
 /** Peripheral clock divider bit position for I2S */
-#define	CLKPWR_PCLKSEL_I2S  		((uint32_t)(54))
+#define CLKPWR_PCLKSEL_I2S              ((uint32_t)(54))
 /** Peripheral clock divider bit position for RIT */
-#define	CLKPWR_PCLKSEL_RIT  		((uint32_t)(58))
+#define CLKPWR_PCLKSEL_RIT              ((uint32_t)(58))
 /** Peripheral clock divider bit position for SYSCON */
-#define	CLKPWR_PCLKSEL_SYSCON  		((uint32_t)(60))
+#define CLKPWR_PCLKSEL_SYSCON           ((uint32_t)(60))
 /** Peripheral clock divider bit position for MC */
-#define	CLKPWR_PCLKSEL_MC  			((uint32_t)(62))
+#define CLKPWR_PCLKSEL_MC                       ((uint32_t)(62))
 
 /** Macro for Peripheral Clock Selection register bit values
  * Note: When CCLK_DIV_8, Peripherals clock is selected to
  * PCLK_xyz = CCLK/8 except for CAN1, CAN2, and CAN filtering
  * when 11selects PCLK_xyz = CCLK/6 */
 /* Peripheral clock divider is set to 4 from CCLK */
-#define	CLKPWR_PCLKSEL_CCLK_DIV_4  ((uint32_t)(0))
+#define CLKPWR_PCLKSEL_CCLK_DIV_4  ((uint32_t)(0))
 /** Peripheral clock divider is the same with CCLK */
-#define	CLKPWR_PCLKSEL_CCLK_DIV_1  ((uint32_t)(1))
+#define CLKPWR_PCLKSEL_CCLK_DIV_1  ((uint32_t)(1))
 /** Peripheral clock divider is set to 2 from CCLK */
-#define	CLKPWR_PCLKSEL_CCLK_DIV_2  ((uint32_t)(2))
+#define CLKPWR_PCLKSEL_CCLK_DIV_2  ((uint32_t)(2))
 
 
 /********************************************************************
 * Power Control for Peripherals Definitions
 **********************************************************************/
 /** Timer/Counter 0 power/clock control bit */
-#define	 CLKPWR_PCONP_PCTIM0	((uint32_t)(1<<1))
+#define  CLKPWR_PCONP_PCTIM0    ((uint32_t)(1<<1))
 /* Timer/Counter 1 power/clock control bit */
-#define	 CLKPWR_PCONP_PCTIM1	((uint32_t)(1<<2))
+#define  CLKPWR_PCONP_PCTIM1    ((uint32_t)(1<<2))
 /** UART0 power/clock control bit */
-#define	 CLKPWR_PCONP_PCUART0  	((uint32_t)(1<<3))
+#define  CLKPWR_PCONP_PCUART0   ((uint32_t)(1<<3))
 /** UART1 power/clock control bit */
-#define	 CLKPWR_PCONP_PCUART1  	((uint32_t)(1<<4))
+#define  CLKPWR_PCONP_PCUART1   ((uint32_t)(1<<4))
 /** PWM1 power/clock control bit */
-#define	 CLKPWR_PCONP_PCPWM1	((uint32_t)(1<<6))
+#define  CLKPWR_PCONP_PCPWM1    ((uint32_t)(1<<6))
 /** The I2C0 interface power/clock control bit */
-#define	 CLKPWR_PCONP_PCI2C0	((uint32_t)(1<<7))
+#define  CLKPWR_PCONP_PCI2C0    ((uint32_t)(1<<7))
 /** The SPI interface power/clock control bit */
-#define	 CLKPWR_PCONP_PCSPI  	((uint32_t)(1<<8))
+#define  CLKPWR_PCONP_PCSPI     ((uint32_t)(1<<8))
 /** The RTC power/clock control bit */
-#define	 CLKPWR_PCONP_PCRTC  	((uint32_t)(1<<9))
+#define  CLKPWR_PCONP_PCRTC     ((uint32_t)(1<<9))
 /** The SSP1 interface power/clock control bit */
-#define	 CLKPWR_PCONP_PCSSP1	((uint32_t)(1<<10))
+#define  CLKPWR_PCONP_PCSSP1    ((uint32_t)(1<<10))
 /** A/D converter 0 (ADC0) power/clock control bit */
-#define	 CLKPWR_PCONP_PCAD  	((uint32_t)(1<<12))
+#define  CLKPWR_PCONP_PCAD      ((uint32_t)(1<<12))
 /** CAN Controller 1 power/clock control bit */
-#define	 CLKPWR_PCONP_PCAN1  	((uint32_t)(1<<13))
+#define  CLKPWR_PCONP_PCAN1     ((uint32_t)(1<<13))
 /** CAN Controller 2 power/clock control bit */
-#define	 CLKPWR_PCONP_PCAN2 	((uint32_t)(1<<14))
+#define  CLKPWR_PCONP_PCAN2     ((uint32_t)(1<<14))
 /** GPIO power/clock control bit */
-#define	CLKPWR_PCONP_PCGPIO 	((uint32_t)(1<<15))
+#define CLKPWR_PCONP_PCGPIO     ((uint32_t)(1<<15))
 /** Repetitive Interrupt Timer power/clock control bit */
-#define	CLKPWR_PCONP_PCRIT 		((uint32_t)(1<<16))
+#define CLKPWR_PCONP_PCRIT              ((uint32_t)(1<<16))
 /** Motor Control PWM */
-#define CLKPWR_PCONP_PCMC 		((uint32_t)(1<<17))
+#define CLKPWR_PCONP_PCMC               ((uint32_t)(1<<17))
 /** Quadrature Encoder Interface power/clock control bit */
-#define CLKPWR_PCONP_PCQEI 		((uint32_t)(1<<18))
+#define CLKPWR_PCONP_PCQEI              ((uint32_t)(1<<18))
 /** The I2C1 interface power/clock control bit */
-#define	 CLKPWR_PCONP_PCI2C1  	((uint32_t)(1<<19))
+#define  CLKPWR_PCONP_PCI2C1    ((uint32_t)(1<<19))
 /** The SSP0 interface power/clock control bit */
-#define	 CLKPWR_PCONP_PCSSP0	((uint32_t)(1<<21))
+#define  CLKPWR_PCONP_PCSSP0    ((uint32_t)(1<<21))
 /** Timer 2 power/clock control bit */
-#define	 CLKPWR_PCONP_PCTIM2	((uint32_t)(1<<22))
+#define  CLKPWR_PCONP_PCTIM2    ((uint32_t)(1<<22))
 /** Timer 3 power/clock control bit */
-#define	 CLKPWR_PCONP_PCTIM3	((uint32_t)(1<<23))
+#define  CLKPWR_PCONP_PCTIM3    ((uint32_t)(1<<23))
 /** UART 2 power/clock control bit */
-#define	 CLKPWR_PCONP_PCUART2  	((uint32_t)(1<<24))
+#define  CLKPWR_PCONP_PCUART2   ((uint32_t)(1<<24))
 /** UART 3 power/clock control bit */
-#define	 CLKPWR_PCONP_PCUART3  	((uint32_t)(1<<25))
+#define  CLKPWR_PCONP_PCUART3   ((uint32_t)(1<<25))
 /** I2C interface 2 power/clock control bit */
-#define	 CLKPWR_PCONP_PCI2C2	((uint32_t)(1<<26))
+#define  CLKPWR_PCONP_PCI2C2    ((uint32_t)(1<<26))
 /** I2S interface power/clock control bit*/
-#define	 CLKPWR_PCONP_PCI2S  	((uint32_t)(1<<27))
+#define  CLKPWR_PCONP_PCI2S     ((uint32_t)(1<<27))
 /** GP DMA function power/clock control bit*/
-#define	 CLKPWR_PCONP_PCGPDMA  	((uint32_t)(1<<29))
+#define  CLKPWR_PCONP_PCGPDMA   ((uint32_t)(1<<29))
 /** Ethernet block power/clock control bit*/
-#define	 CLKPWR_PCONP_PCENET	((uint32_t)(1<<30))
+#define  CLKPWR_PCONP_PCENET    ((uint32_t)(1<<30))
 /** USB interface power/clock control bit*/
-#define	 CLKPWR_PCONP_PCUSB  	((uint32_t)(1<<31))
+#define  CLKPWR_PCONP_PCUSB     ((uint32_t)(1<<31))
 
 
 /**
@@ -183,179 +183,179 @@ extern "C"
  * Macro defines for Clock Source Select Register
  **********************************************************************/
 /** Internal RC oscillator */
-#define CLKPWR_CLKSRCSEL_CLKSRC_IRC			((uint32_t)(0x00))
+#define CLKPWR_CLKSRCSEL_CLKSRC_IRC                     ((uint32_t)(0x00))
 /** Main oscillator */
-#define CLKPWR_CLKSRCSEL_CLKSRC_MAINOSC		((uint32_t)(0x01))
+#define CLKPWR_CLKSRCSEL_CLKSRC_MAINOSC         ((uint32_t)(0x01))
 /** RTC oscillator */
-#define CLKPWR_CLKSRCSEL_CLKSRC_RTC			((uint32_t)(0x02))
+#define CLKPWR_CLKSRCSEL_CLKSRC_RTC                     ((uint32_t)(0x02))
 /** Clock source selection bit mask */
-#define CLKPWR_CLKSRCSEL_BITMASK			((uint32_t)(0x03))
+#define CLKPWR_CLKSRCSEL_BITMASK                        ((uint32_t)(0x03))
 
 /*********************************************************************//**
  * Macro defines for Clock Output Configuration Register
  **********************************************************************/
 /* Clock Output Configuration register definition */
 /** Selects the CPU clock as the CLKOUT source */
-#define CLKPWR_CLKOUTCFG_CLKOUTSEL_CPU		((uint32_t)(0x00))
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_CPU          ((uint32_t)(0x00))
 /** Selects the main oscillator as the CLKOUT source */
-#define CLKPWR_CLKOUTCFG_CLKOUTSEL_MAINOSC	((uint32_t)(0x01))
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_MAINOSC      ((uint32_t)(0x01))
 /** Selects the Internal RC oscillator as the CLKOUT source */
-#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RC		((uint32_t)(0x02))
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RC           ((uint32_t)(0x02))
 /** Selects the USB clock as the CLKOUT source */
-#define CLKPWR_CLKOUTCFG_CLKOUTSEL_USB		((uint32_t)(0x03))
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_USB          ((uint32_t)(0x03))
 /** Selects the RTC oscillator as the CLKOUT source */
-#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RTC		((uint32_t)(0x04))
+#define CLKPWR_CLKOUTCFG_CLKOUTSEL_RTC          ((uint32_t)(0x04))
 /** Integer value to divide the output clock by, minus one */
-#define CLKPWR_CLKOUTCFG_CLKOUTDIV(n)		((uint32_t)((n&0x0F)<<4))
+#define CLKPWR_CLKOUTCFG_CLKOUTDIV(n)           ((uint32_t)((n&0x0F)<<4))
 /** CLKOUT enable control */
-#define CLKPWR_CLKOUTCFG_CLKOUT_EN			((uint32_t)(1<<8))
+#define CLKPWR_CLKOUTCFG_CLKOUT_EN                      ((uint32_t)(1<<8))
 /** CLKOUT activity indication */
-#define CLKPWR_CLKOUTCFG_CLKOUT_ACT			((uint32_t)(1<<9))
+#define CLKPWR_CLKOUTCFG_CLKOUT_ACT                     ((uint32_t)(1<<9))
 /** Clock source selection bit mask */
-#define CLKPWR_CLKOUTCFG_BITMASK			((uint32_t)(0x3FF))
+#define CLKPWR_CLKOUTCFG_BITMASK                        ((uint32_t)(0x3FF))
 
 /*********************************************************************//**
  * Macro defines for PPL0 Control Register
  **********************************************************************/
 /** PLL 0 control enable */
-#define CLKPWR_PLL0CON_ENABLE		((uint32_t)(0x01))
+#define CLKPWR_PLL0CON_ENABLE           ((uint32_t)(0x01))
 /** PLL 0 control connect */
-#define CLKPWR_PLL0CON_CONNECT		((uint32_t)(0x02))
+#define CLKPWR_PLL0CON_CONNECT          ((uint32_t)(0x02))
 /** PLL 0 control bit mask */
-#define CLKPWR_PLL0CON_BITMASK		((uint32_t)(0x03))
+#define CLKPWR_PLL0CON_BITMASK          ((uint32_t)(0x03))
 
 /*********************************************************************//**
  * Macro defines for PPL0 Configuration Register
  **********************************************************************/
 /** PLL 0 Configuration MSEL field */
-#define CLKPWR_PLL0CFG_MSEL(n)		((uint32_t)(n&0x7FFF))
+#define CLKPWR_PLL0CFG_MSEL(n)          ((uint32_t)(n&0x7FFF))
 /** PLL 0 Configuration NSEL field */
-#define CLKPWR_PLL0CFG_NSEL(n)		((uint32_t)((n<<16)&0xFF0000))
+#define CLKPWR_PLL0CFG_NSEL(n)          ((uint32_t)((n<<16)&0xFF0000))
 /** PLL 0 Configuration bit mask */
-#define CLKPWR_PLL0CFG_BITMASK		((uint32_t)(0xFF7FFF))
+#define CLKPWR_PLL0CFG_BITMASK          ((uint32_t)(0xFF7FFF))
 
 
 /*********************************************************************//**
  * Macro defines for PPL0 Status Register
  **********************************************************************/
 /** PLL 0 MSEL value */
-#define CLKPWR_PLL0STAT_MSEL(n)		((uint32_t)(n&0x7FFF))
+#define CLKPWR_PLL0STAT_MSEL(n)         ((uint32_t)(n&0x7FFF))
 /** PLL NSEL get value  */
-#define CLKPWR_PLL0STAT_NSEL(n)		((uint32_t)((n>>16)&0xFF))
+#define CLKPWR_PLL0STAT_NSEL(n)         ((uint32_t)((n>>16)&0xFF))
 /** PLL status enable bit */
-#define CLKPWR_PLL0STAT_PLLE		((uint32_t)(1<<24))
+#define CLKPWR_PLL0STAT_PLLE            ((uint32_t)(1<<24))
 /** PLL status Connect bit */
-#define CLKPWR_PLL0STAT_PLLC		((uint32_t)(1<<25))
+#define CLKPWR_PLL0STAT_PLLC            ((uint32_t)(1<<25))
 /** PLL status lock */
-#define CLKPWR_PLL0STAT_PLOCK		((uint32_t)(1<<26))
+#define CLKPWR_PLL0STAT_PLOCK           ((uint32_t)(1<<26))
 
 /*********************************************************************//**
  * Macro defines for PPL0 Feed Register
  **********************************************************************/
 /** PLL0 Feed bit mask */
-#define CLKPWR_PLL0FEED_BITMASK			((uint32_t)0xFF)
+#define CLKPWR_PLL0FEED_BITMASK                 ((uint32_t)0xFF)
 
 /*********************************************************************//**
  * Macro defines for PLL1 Control Register
  **********************************************************************/
 /** USB PLL control enable */
-#define CLKPWR_PLL1CON_ENABLE		((uint32_t)(0x01))
+#define CLKPWR_PLL1CON_ENABLE           ((uint32_t)(0x01))
 /** USB PLL control connect */
-#define CLKPWR_PLL1CON_CONNECT		((uint32_t)(0x02))
+#define CLKPWR_PLL1CON_CONNECT          ((uint32_t)(0x02))
 /** USB PLL control bit mask */
-#define CLKPWR_PLL1CON_BITMASK		((uint32_t)(0x03))
+#define CLKPWR_PLL1CON_BITMASK          ((uint32_t)(0x03))
 
 /*********************************************************************//**
  * Macro defines for PLL1 Configuration Register
  **********************************************************************/
 /** USB PLL MSEL set value */
-#define CLKPWR_PLL1CFG_MSEL(n)		((uint32_t)(n&0x1F))
+#define CLKPWR_PLL1CFG_MSEL(n)          ((uint32_t)(n&0x1F))
 /** USB PLL PSEL set value */
-#define CLKPWR_PLL1CFG_PSEL(n)		((uint32_t)((n&0x03)<<5))
+#define CLKPWR_PLL1CFG_PSEL(n)          ((uint32_t)((n&0x03)<<5))
 /** USB PLL configuration bit mask */
-#define CLKPWR_PLL1CFG_BITMASK		((uint32_t)(0x7F))
+#define CLKPWR_PLL1CFG_BITMASK          ((uint32_t)(0x7F))
 
 /*********************************************************************//**
  * Macro defines for PLL1 Status Register
  **********************************************************************/
 /** USB PLL MSEL get value  */
-#define CLKPWR_PLL1STAT_MSEL(n)		((uint32_t)(n&0x1F))
+#define CLKPWR_PLL1STAT_MSEL(n)         ((uint32_t)(n&0x1F))
 /** USB PLL PSEL get value  */
-#define CLKPWR_PLL1STAT_PSEL(n)		((uint32_t)((n>>5)&0x03))
+#define CLKPWR_PLL1STAT_PSEL(n)         ((uint32_t)((n>>5)&0x03))
 /** USB PLL status enable bit */
-#define CLKPWR_PLL1STAT_PLLE		((uint32_t)(1<<8))
+#define CLKPWR_PLL1STAT_PLLE            ((uint32_t)(1<<8))
 /** USB PLL status Connect bit */
-#define CLKPWR_PLL1STAT_PLLC		((uint32_t)(1<<9))
+#define CLKPWR_PLL1STAT_PLLC            ((uint32_t)(1<<9))
 /** USB PLL status lock */
-#define CLKPWR_PLL1STAT_PLOCK		((uint32_t)(1<<10))
+#define CLKPWR_PLL1STAT_PLOCK           ((uint32_t)(1<<10))
 
 /*********************************************************************//**
  * Macro defines for PLL1 Feed Register
  **********************************************************************/
 /** PLL1 Feed bit mask */
-#define CLKPWR_PLL1FEED_BITMASK		((uint32_t)0xFF)
+#define CLKPWR_PLL1FEED_BITMASK         ((uint32_t)0xFF)
 
 /*********************************************************************//**
  * Macro defines for CPU Clock Configuration Register
  **********************************************************************/
 /** CPU Clock configuration bit mask */
-#define CLKPWR_CCLKCFG_BITMASK		((uint32_t)(0xFF))
+#define CLKPWR_CCLKCFG_BITMASK          ((uint32_t)(0xFF))
 
 /*********************************************************************//**
  * Macro defines for USB Clock Configuration Register
  **********************************************************************/
 /** USB Clock Configuration bit mask */
-#define CLKPWR_USBCLKCFG_BITMASK	((uint32_t)(0x0F))
+#define CLKPWR_USBCLKCFG_BITMASK        ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro defines for IRC Trim Register
  **********************************************************************/
 /** IRC Trim bit mask */
-#define CLKPWR_IRCTRIM_BITMASK		((uint32_t)(0x0F))
+#define CLKPWR_IRCTRIM_BITMASK          ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro defines for Peripheral Clock Selection Register 0 and 1
  **********************************************************************/
 /** Peripheral Clock Selection 0 mask bit */
-#define CLKPWR_PCLKSEL0_BITMASK		((uint32_t)(0xFFF3F3FF))
+#define CLKPWR_PCLKSEL0_BITMASK         ((uint32_t)(0xFFF3F3FF))
 /** Peripheral Clock Selection 1 mask bit */
-#define CLKPWR_PCLKSEL1_BITMASK		((uint32_t)(0xFCF3F0F3))
+#define CLKPWR_PCLKSEL1_BITMASK         ((uint32_t)(0xFCF3F0F3))
 /** Macro to set peripheral clock of each type
  * p: position of two bits that hold divider of peripheral clock
  * n: value of divider of peripheral clock  to be set */
-#define CLKPWR_PCLKSEL_SET(p, n)	_SBF(p, n)
+#define CLKPWR_PCLKSEL_SET(p, n)        _SBF(p, n)
 /** Macro to mask peripheral clock of each type */
-#define CLKPWR_PCLKSEL_BITMASK(p)	_SBF(p, 0x03)
+#define CLKPWR_PCLKSEL_BITMASK(p)       _SBF(p, 0x03)
 /** Macro to get peripheral clock of each type */
-#define CLKPWR_PCLKSEL_GET(p, n)	((uint32_t)((n>>p)&0x03))
+#define CLKPWR_PCLKSEL_GET(p, n)        ((uint32_t)((n>>p)&0x03))
 
 /*********************************************************************//**
  * Macro defines for Power Mode Control Register
  **********************************************************************/
 /** Power mode control bit 0 */
-#define CLKPWR_PCON_PM0			((uint32_t)(1<<0))
+#define CLKPWR_PCON_PM0                 ((uint32_t)(1<<0))
 /** Power mode control bit 1 */
-#define CLKPWR_PCON_PM1			((uint32_t)(1<<1))
+#define CLKPWR_PCON_PM1                 ((uint32_t)(1<<1))
 /** Brown-Out Reduced Power Mode */
-#define CLKPWR_PCON_BODPDM		((uint32_t)(1<<2))
+#define CLKPWR_PCON_BODPDM              ((uint32_t)(1<<2))
 /** Brown-Out Global Disable */
-#define CLKPWR_PCON_BOGD		((uint32_t)(1<<3))
+#define CLKPWR_PCON_BOGD                ((uint32_t)(1<<3))
 /** Brown Out Reset Disable */
-#define CLKPWR_PCON_BORD		((uint32_t)(1<<4))
+#define CLKPWR_PCON_BORD                ((uint32_t)(1<<4))
 /** Sleep Mode entry flag */
-#define CLKPWR_PCON_SMFLAG		((uint32_t)(1<<8))
+#define CLKPWR_PCON_SMFLAG              ((uint32_t)(1<<8))
 /** Deep Sleep entry flag */
-#define CLKPWR_PCON_DSFLAG		((uint32_t)(1<<9))
+#define CLKPWR_PCON_DSFLAG              ((uint32_t)(1<<9))
 /** Power-down entry flag */
-#define CLKPWR_PCON_PDFLAG		((uint32_t)(1<<10))
+#define CLKPWR_PCON_PDFLAG              ((uint32_t)(1<<10))
 /** Deep Power-down entry flag */
-#define CLKPWR_PCON_DPDFLAG		((uint32_t)(1<<11))
+#define CLKPWR_PCON_DPDFLAG             ((uint32_t)(1<<11))
 
 /*********************************************************************//**
  * Macro defines for Power Control for Peripheral Register
  **********************************************************************/
 /** Power Control for Peripherals bit mask */
-#define CLKPWR_PCONP_BITMASK	0xEFEFF7DE
+#define CLKPWR_PCONP_BITMASK    0xEFEFF7DE
 
 /**
  * @}

--- a/bmp/lpc17xx_emac.h
+++ b/bmp/lpc17xx_emac.h
@@ -1,10 +1,10 @@
 /***********************************************************************//**
- * @file		lpc17xx_emac.h
- * @brief		Contains all macro definitions and function prototypes
- * 				support for Ethernet MAC firmware library on LPC17xx
- * @version		2.0
- * @date		21. May. 2010
- * @author		NXP MCU SW Application Team
+ * @file                lpc17xx_emac.h
+ * @brief               Contains all macro definitions and function prototypes
+ *                              support for Ethernet MAC firmware library on LPC17xx
+ * @version             2.0
+ * @date                21. May. 2010
+ * @author              NXP MCU SW Application Team
  **************************************************************************
  * Software that is described herein is for illustrative purposes only
  * which provides customers with programming information regarding the
@@ -47,16 +47,16 @@ extern "C"
 
 
 /* EMAC PHY status type definitions */
-#define EMAC_PHY_STAT_LINK			(0)		/**< Link Status */
-#define EMAC_PHY_STAT_SPEED			(1)		/**< Speed Status */
-#define EMAC_PHY_STAT_DUP			(2)		/**< Duplex Status */
+#define EMAC_PHY_STAT_LINK                      (0)             /**< Link Status */
+#define EMAC_PHY_STAT_SPEED                     (1)             /**< Speed Status */
+#define EMAC_PHY_STAT_DUP                       (2)             /**< Duplex Status */
 
 /* EMAC PHY device Speed definitions */
-#define EMAC_MODE_AUTO				(0)		/**< Auto-negotiation mode */
-#define EMAC_MODE_10M_FULL			(1)		/**< 10Mbps FullDuplex mode */
-#define EMAC_MODE_10M_HALF			(2)		/**< 10Mbps HalfDuplex mode */
-#define EMAC_MODE_100M_FULL			(3)		/**< 100Mbps FullDuplex mode */
-#define EMAC_MODE_100M_HALF			(4)		/**< 100Mbps HalfDuplex mode */
+#define EMAC_MODE_AUTO                          (0)             /**< Auto-negotiation mode */
+#define EMAC_MODE_10M_FULL                      (1)             /**< 10Mbps FullDuplex mode */
+#define EMAC_MODE_10M_HALF                      (2)             /**< 10Mbps HalfDuplex mode */
+#define EMAC_MODE_100M_FULL                     (3)             /**< 100Mbps FullDuplex mode */
+#define EMAC_MODE_100M_HALF                     (4)             /**< 100Mbps HalfDuplex mode */
 
 /**
  * @}
@@ -111,11 +111,11 @@ extern "C"
  **********************************************************************/
 /** Programmable field representing the nibble time offset of the minimum possible period
  * between the end of any transmitted packet to the beginning of the next */
-#define EMAC_IPGT_BBIPG(n)		(n&0x7F)
+#define EMAC_IPGT_BBIPG(n)              (n&0x7F)
 /** Recommended value for Full Duplex of Programmable field representing the nibble time
  * offset of the minimum possible period between the end of any transmitted packet to the
  * beginning of the next */
-#define EMAC_IPGT_FULL_DUP		(EMAC_IPGT_BBIPG(0x15))
+#define EMAC_IPGT_FULL_DUP              (EMAC_IPGT_BBIPG(0x15))
 /** Recommended value for Half Duplex of Programmable field representing the nibble time
  * offset of the minimum possible period between the end of any transmitted packet to the
  * beginning of the next */
@@ -125,13 +125,13 @@ extern "C"
  * Macro defines for Non Back-to-Back Inter-Packet-Gap Register
  **********************************************************************/
 /** Programmable field representing the Non-Back-to-Back Inter-Packet-Gap */
-#define EMAC_IPGR_NBBIPG_P2(n)	(n&0x7F)
+#define EMAC_IPGR_NBBIPG_P2(n)  (n&0x7F)
 /** Recommended value for Programmable field representing the Non-Back-to-Back
  * Inter-Packet-Gap Part 1 */
-#define EMAC_IPGR_P2_DEF		(EMAC_IPGR_NBBIPG_P2(0x12))
+#define EMAC_IPGR_P2_DEF                (EMAC_IPGR_NBBIPG_P2(0x12))
 /** Programmable field representing the optional carrierSense window referenced in
  * IEEE 802.3/4.2.3.2.1 'Carrier Deference' */
-#define EMAC_IPGR_NBBIPG_P1(n)	((n&0x7F)<<8)
+#define EMAC_IPGR_NBBIPG_P1(n)  ((n&0x7F)<<8)
 /** Recommended value for Programmable field representing the Non-Back-to-Back
  * Inter-Packet-Gap Part 2 */
 #define EMAC_IPGR_P1_DEF        EMAC_IPGR_NBBIPG_P1(0x0C)
@@ -141,10 +141,10 @@ extern "C"
  **********************************************************************/
 /** Programmable field specifying the number of retransmission attempts
  * following a collision before aborting the packet due to excessive collisions */
-#define EMAC_CLRT_MAX_RETX(n)	(n&0x0F)
+#define EMAC_CLRT_MAX_RETX(n)   (n&0x0F)
 /** Programmable field representing the slot time or collision window during
  * which collisions occur in properly configured networks */
-#define EMAC_CLRT_COLL(n)		((n&0x3F)<<8)
+#define EMAC_CLRT_COLL(n)               ((n&0x3F)<<8)
 /** Default value for Collision Window / Retry register */
 #define EMAC_CLRT_DEF           ((EMAC_CLRT_MAX_RETX(0x0F))|(EMAC_CLRT_COLL(0x37)))
 
@@ -152,62 +152,62 @@ extern "C"
  * Macro defines for Maximum Frame Register
  **********************************************************************/
 /** Represents a maximum receive frame of 1536 octets */
-#define EMAC_MAXF_MAXFRMLEN(n)	(n&0xFFFF)
+#define EMAC_MAXF_MAXFRMLEN(n)  (n&0xFFFF)
 
 /*********************************************************************//**
  * Macro defines for PHY Support Register
  **********************************************************************/
-#define EMAC_SUPP_SPEED			0x00000100  	/**< Reduced MII Logic Current Speed   */
-#define EMAC_SUPP_RES_RMII      0x00000800  	/**< Reset Reduced MII Logic           */
+#define EMAC_SUPP_SPEED                 0x00000100      /**< Reduced MII Logic Current Speed   */
+#define EMAC_SUPP_RES_RMII      0x00000800      /**< Reset Reduced MII Logic           */
 
 /*********************************************************************//**
  * Macro defines for Test Register
  **********************************************************************/
-#define EMAC_TEST_SHCUT_PQUANTA  0x00000001  	/**< Shortcut Pause Quanta             */
-#define EMAC_TEST_TST_PAUSE      0x00000002  	/**< Test Pause                        */
-#define EMAC_TEST_TST_BACKP      0x00000004  	/**< Test Back Pressure                */
+#define EMAC_TEST_SHCUT_PQUANTA  0x00000001     /**< Shortcut Pause Quanta             */
+#define EMAC_TEST_TST_PAUSE      0x00000002     /**< Test Pause                        */
+#define EMAC_TEST_TST_BACKP      0x00000004     /**< Test Back Pressure                */
 
 /*********************************************************************//**
  * Macro defines for MII Management Configuration Register
  **********************************************************************/
-#define EMAC_MCFG_SCAN_INC       0x00000001  	/**< Scan Increment PHY Address        */
-#define EMAC_MCFG_SUPP_PREAM     0x00000002  	/**< Suppress Preamble                 */
+#define EMAC_MCFG_SCAN_INC       0x00000001     /**< Scan Increment PHY Address        */
+#define EMAC_MCFG_SUPP_PREAM     0x00000002     /**< Suppress Preamble                 */
 #define EMAC_MCFG_CLK_SEL(n)     ((n&0x0F)<<2)  /**< Clock Select Field                 */
-#define EMAC_MCFG_RES_MII        0x00008000  	/**< Reset MII Management Hardware     */
-#define EMAC_MCFG_MII_MAXCLK	 2500000UL	/**< MII Clock max */
+#define EMAC_MCFG_RES_MII        0x00008000     /**< Reset MII Management Hardware     */
+#define EMAC_MCFG_MII_MAXCLK     2500000UL      /**< MII Clock max */
 
 /*********************************************************************//**
  * Macro defines for MII Management Command Register
  **********************************************************************/
-#define EMAC_MCMD_READ           0x00000001  	/**< MII Read                          */
-#define EMAC_MCMD_SCAN           0x00000002  	/**< MII Scan continuously             */
+#define EMAC_MCMD_READ           0x00000001     /**< MII Read                          */
+#define EMAC_MCMD_SCAN           0x00000002     /**< MII Scan continuously             */
 
-#define EMAC_MII_WR_TOUT         0x00050000  	/**< MII Write timeout count           */
-#define EMAC_MII_RD_TOUT         0x00050000  	/**< MII Read timeout count            */
+#define EMAC_MII_WR_TOUT         0x00050000     /**< MII Write timeout count           */
+#define EMAC_MII_RD_TOUT         0x00050000     /**< MII Read timeout count            */
 
 /*********************************************************************//**
  * Macro defines for MII Management Address Register
  **********************************************************************/
-#define EMAC_MADR_REG_ADR(n)     (n&0x1F)  		/**< MII Register Address field         */
+#define EMAC_MADR_REG_ADR(n)     (n&0x1F)               /**< MII Register Address field         */
 #define EMAC_MADR_PHY_ADR(n)     ((n&0x1F)<<8)  /**< PHY Address Field                  */
 
 /*********************************************************************//**
  * Macro defines for MII Management Write Data Register
  **********************************************************************/
-#define EMAC_MWTD_DATA(n)	(n&0xFFFF)	/**< Data field for MMI Management Write Data register */
+#define EMAC_MWTD_DATA(n)       (n&0xFFFF)      /**< Data field for MMI Management Write Data register */
 
 /*********************************************************************//**
  * Macro defines for MII Management Read Data Register
  **********************************************************************/
-#define EMAC_MRDD_DATA(n)	(n&0xFFFF)	/**< Data field for MMI Management Read Data register */
+#define EMAC_MRDD_DATA(n)       (n&0xFFFF)      /**< Data field for MMI Management Read Data register */
 
 /*********************************************************************//**
  * Macro defines for MII Management Indicators Register
  **********************************************************************/
-#define EMAC_MIND_BUSY           0x00000001  	/**< MII is Busy                       */
-#define EMAC_MIND_SCAN           0x00000002  	/**< MII Scanning in Progress          */
-#define EMAC_MIND_NOT_VAL        0x00000004  	/**< MII Read Data not valid           */
-#define EMAC_MIND_MII_LINK_FAIL  0x00000008  	/**< MII Link Failed                   */
+#define EMAC_MIND_BUSY           0x00000001     /**< MII is Busy                       */
+#define EMAC_MIND_SCAN           0x00000002     /**< MII Scanning in Progress          */
+#define EMAC_MIND_NOT_VAL        0x00000004     /**< MII Read Data not valid           */
+#define EMAC_MIND_MII_LINK_FAIL  0x00000008     /**< MII Link Failed                   */
 
 /* Station Address 0 Register */
 /* Station Address 1 Register */
@@ -218,22 +218,22 @@ extern "C"
 /*********************************************************************//**
  * Macro defines for Command Register
  **********************************************************************/
-#define EMAC_CR_RX_EN            0x00000001  	/**< Enable Receive                    */
-#define EMAC_CR_TX_EN            0x00000002  	/**< Enable Transmit                   */
-#define EMAC_CR_REG_RES          0x00000008  	/**< Reset Host Registers              */
-#define EMAC_CR_TX_RES           0x00000010  	/**< Reset Transmit Datapath           */
-#define EMAC_CR_RX_RES           0x00000020  	/**< Reset Receive Datapath            */
-#define EMAC_CR_PASS_RUNT_FRM    0x00000040  	/**< Pass Runt Frames                  */
-#define EMAC_CR_PASS_RX_FILT     0x00000080  	/**< Pass RX Filter                    */
-#define EMAC_CR_TX_FLOW_CTRL     0x00000100  	/**< TX Flow Control                   */
-#define EMAC_CR_RMII             0x00000200  	/**< Reduced MII Interface             */
-#define EMAC_CR_FULL_DUP         0x00000400  	/**< Full Duplex                       */
+#define EMAC_CR_RX_EN            0x00000001     /**< Enable Receive                    */
+#define EMAC_CR_TX_EN            0x00000002     /**< Enable Transmit                   */
+#define EMAC_CR_REG_RES          0x00000008     /**< Reset Host Registers              */
+#define EMAC_CR_TX_RES           0x00000010     /**< Reset Transmit Datapath           */
+#define EMAC_CR_RX_RES           0x00000020     /**< Reset Receive Datapath            */
+#define EMAC_CR_PASS_RUNT_FRM    0x00000040     /**< Pass Runt Frames                  */
+#define EMAC_CR_PASS_RX_FILT     0x00000080     /**< Pass RX Filter                    */
+#define EMAC_CR_TX_FLOW_CTRL     0x00000100     /**< TX Flow Control                   */
+#define EMAC_CR_RMII             0x00000200     /**< Reduced MII Interface             */
+#define EMAC_CR_FULL_DUP         0x00000400     /**< Full Duplex                       */
 
 /*********************************************************************//**
  * Macro defines for Status Register
  **********************************************************************/
-#define EMAC_SR_RX_EN            0x00000001  	/**< Enable Receive                    */
-#define EMAC_SR_TX_EN            0x00000002  	/**< Enable Transmit                   */
+#define EMAC_SR_RX_EN            0x00000001     /**< Enable Receive                    */
+#define EMAC_SR_TX_EN            0x00000002     /**< Enable Transmit                   */
 
 /*********************************************************************//**
  * Macro defines for Transmit Status Vector 0 Register
@@ -285,13 +285,13 @@ extern "C"
 /*********************************************************************//**
  * Macro defines for Flow Control Counter Register
  **********************************************************************/
-#define EMAC_FCC_MIRR_CNT(n)	(n&0xFFFF)  	/**< Mirror Counter                    */
-#define EMAC_FCC_PAUSE_TIM(n)	((n&0xFFFF)<<16) /**< Pause Timer                      */
+#define EMAC_FCC_MIRR_CNT(n)    (n&0xFFFF)      /**< Mirror Counter                    */
+#define EMAC_FCC_PAUSE_TIM(n)   ((n&0xFFFF)<<16) /**< Pause Timer                      */
 
 /*********************************************************************//**
  * Macro defines for Flow Control Status Register
  **********************************************************************/
-#define EMAC_FCS_MIRR_CNT(n)	(n&0xFFFF)	/**< Mirror Counter Current            */
+#define EMAC_FCS_MIRR_CNT(n)    (n&0xFFFF)      /**< Mirror Counter Current            */
 
 
 /* Receive filter register definitions -------------------------------------------------------- */
@@ -318,7 +318,7 @@ extern "C"
 #define EMAC_WOL_PERFECT         0x00000020  /**< Perfect Filter WoL                */
 #define EMAC_WOL_RX_FILTER       0x00000080  /**< RX Filter caused WoL              */
 #define EMAC_WOL_MAG_PACKET      0x00000100  /**< Magic Packet Filter caused WoL    */
-#define EMAC_WOL_BITMASK	     0x01BF  /**< Receive Filter WoL Status/Clear bitmasl value */
+#define EMAC_WOL_BITMASK             0x01BF  /**< Receive Filter WoL Status/Clear bitmasl value */
 
 
 /* Module control register definitions ---------------------------------------------------- */
@@ -345,14 +345,14 @@ extern "C"
 /*********************************************************************//**
  * Macro defines for RX Descriptor Control Word
  **********************************************************************/
-#define EMAC_RCTRL_SIZE(n)       (n&0x7FF)  	/**< Buffer size field                  */
-#define EMAC_RCTRL_INT           0x80000000  	/**< Generate RxDone Interrupt         */
+#define EMAC_RCTRL_SIZE(n)       (n&0x7FF)      /**< Buffer size field                  */
+#define EMAC_RCTRL_INT           0x80000000     /**< Generate RxDone Interrupt         */
 
 /*********************************************************************//**
  * Macro defines for RX Status Hash CRC Word
  **********************************************************************/
-#define EMAC_RHASH_SA            0x000001FF  	/**< Hash CRC for Source Address       */
-#define EMAC_RHASH_DA            0x001FF000  	/**< Hash CRC for Destination Address  */
+#define EMAC_RHASH_SA            0x000001FF     /**< Hash CRC for Source Address       */
+#define EMAC_RHASH_DA            0x001FF000     /**< Hash CRC for Destination Address  */
 
 /*********************************************************************//**
  * Macro defines for RX Status Information Word
@@ -402,7 +402,7 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 /* DP83848C PHY definition ------------------------------------------------------------ */
 
 /** PHY device reset time out definition */
-#define EMAC_PHY_RESP_TOUT		0x100000UL
+#define EMAC_PHY_RESP_TOUT              0x100000UL
 
 /* ENET Device Revision ID */
 #define EMAC_OLD_EMAC_MODULE_ID  0x39022000  /**< Rev. ID for first rev '-'         */
@@ -418,7 +418,7 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 #define EMAC_PHY_REG_ANLPAR      0x05        /**< Auto-Neg. Link Partner Abitily    */
 #define EMAC_PHY_REG_ANER        0x06        /**< Auto-Neg. Expansion Register      */
 #define EMAC_PHY_REG_ANNPTR      0x07        /**< Auto-Neg. Next Page TX            */
-#define EMAC_PHY_REG_LPNPA		 0x08
+#define EMAC_PHY_REG_LPNPA               0x08
 
 /*********************************************************************//**
  * Macro defines for PHY Extended Registers
@@ -439,39 +439,39 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 /*********************************************************************//**
  * Macro defines for PHY Basic Mode Control Register
  **********************************************************************/
-#define EMAC_PHY_BMCR_RESET     			(1<<15)		/**< Reset bit */
-#define EMAC_PHY_BMCR_LOOPBACK      		(1<<14)		/**< Loop back */
-#define EMAC_PHY_BMCR_SPEED_SEL     		(1<<13)		/**< Speed selection */
-#define EMAC_PHY_BMCR_AN					(1<<12)		/**< Auto Negotiation */
-#define EMAC_PHY_BMCR_POWERDOWN				(1<<11)		/**< Power down mode */
-#define EMAC_PHY_BMCR_ISOLATE				(1<<10)		/**< Isolate */
-#define EMAC_PHY_BMCR_RE_AN					(1<<9)		/**< Restart auto negotiation */
-#define EMAC_PHY_BMCR_DUPLEX				(1<<8)		/**< Duplex mode */
+#define EMAC_PHY_BMCR_RESET                             (1<<15)         /**< Reset bit */
+#define EMAC_PHY_BMCR_LOOPBACK                  (1<<14)         /**< Loop back */
+#define EMAC_PHY_BMCR_SPEED_SEL                 (1<<13)         /**< Speed selection */
+#define EMAC_PHY_BMCR_AN                                        (1<<12)         /**< Auto Negotiation */
+#define EMAC_PHY_BMCR_POWERDOWN                         (1<<11)         /**< Power down mode */
+#define EMAC_PHY_BMCR_ISOLATE                           (1<<10)         /**< Isolate */
+#define EMAC_PHY_BMCR_RE_AN                                     (1<<9)          /**< Restart auto negotiation */
+#define EMAC_PHY_BMCR_DUPLEX                            (1<<8)          /**< Duplex mode */
 
 /*********************************************************************//**
  * Macro defines for PHY Basic Mode Status Status Register
  **********************************************************************/
-#define EMAC_PHY_BMSR_100BE_T4        	   	(1<<15)		/**< 100 base T4 */
-#define EMAC_PHY_BMSR_100TX_FULL			(1<<14)		/**< 100 base full duplex */
-#define EMAC_PHY_BMSR_100TX_HALF			(1<<13)		/**< 100 base half duplex */
-#define EMAC_PHY_BMSR_10BE_FULL				(1<<12)		/**< 10 base T full duplex */
-#define EMAC_PHY_BMSR_10BE_HALF				(1<<11)		/**< 10 base T half duplex */
-#define EMAC_PHY_BMSR_NOPREAM				(1<<6)		/**< MF Preamable Supress */
-#define EMAC_PHY_BMSR_AUTO_DONE				(1<<5)		/**< Auto negotiation complete */
-#define EMAC_PHY_BMSR_REMOTE_FAULT			(1<<4)		/**< Remote fault */
-#define EMAC_PHY_BMSR_NO_AUTO				(1<<3)		/**< Auto Negotiation ability */
-#define EMAC_PHY_BMSR_LINK_ESTABLISHED		(1<<2)		/**< Link status */
+#define EMAC_PHY_BMSR_100BE_T4                  (1<<15)         /**< 100 base T4 */
+#define EMAC_PHY_BMSR_100TX_FULL                        (1<<14)         /**< 100 base full duplex */
+#define EMAC_PHY_BMSR_100TX_HALF                        (1<<13)         /**< 100 base half duplex */
+#define EMAC_PHY_BMSR_10BE_FULL                         (1<<12)         /**< 10 base T full duplex */
+#define EMAC_PHY_BMSR_10BE_HALF                         (1<<11)         /**< 10 base T half duplex */
+#define EMAC_PHY_BMSR_NOPREAM                           (1<<6)          /**< MF Preamable Supress */
+#define EMAC_PHY_BMSR_AUTO_DONE                         (1<<5)          /**< Auto negotiation complete */
+#define EMAC_PHY_BMSR_REMOTE_FAULT                      (1<<4)          /**< Remote fault */
+#define EMAC_PHY_BMSR_NO_AUTO                           (1<<3)          /**< Auto Negotiation ability */
+#define EMAC_PHY_BMSR_LINK_ESTABLISHED          (1<<2)          /**< Link status */
 
 /*********************************************************************//**
  * Macro defines for PHY Status Register
  **********************************************************************/
-#define EMAC_PHY_SR_REMOTE_FAULT   			(1<<6)		/**< Remote Fault */
-#define EMAC_PHY_SR_JABBER					(1<<5)		/**< Jabber detect */
-#define EMAC_PHY_SR_AUTO_DONE				(1<<4)		/**< Auto Negotiation complete */
-#define EMAC_PHY_SR_LOOPBACK				(1<<3)		/**< Loop back status */
-#define EMAC_PHY_SR_DUP						(1<<2)		/**< Duplex status */
-#define EMAC_PHY_SR_SPEED					(1<<1)		/**< Speed status */
-#define EMAC_PHY_SR_LINK					(1<<0)		/**< Link Status */
+#define EMAC_PHY_SR_REMOTE_FAULT                        (1<<6)          /**< Remote Fault */
+#define EMAC_PHY_SR_JABBER                                      (1<<5)          /**< Jabber detect */
+#define EMAC_PHY_SR_AUTO_DONE                           (1<<4)          /**< Auto Negotiation complete */
+#define EMAC_PHY_SR_LOOPBACK                            (1<<3)          /**< Loop back status */
+#define EMAC_PHY_SR_DUP                                         (1<<2)          /**< Duplex status */
+#define EMAC_PHY_SR_SPEED                                       (1<<1)          /**< Speed status */
+#define EMAC_PHY_SR_LINK                                        (1<<0)          /**< Link Status */
 
 #define EMAC_PHY_FULLD_100M      0x2100      /**< Full Duplex 100Mbit               */
 #define EMAC_PHY_HALFD_100M      0x2000      /**< Half Duplex 100Mbit               */
@@ -482,14 +482,14 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 #define EMAC_DEF_ADR    0x0100      /**< Default PHY device address        */
 #define EMAC_DP83848C_ID         0x20005C90  /**< PHY Identifier                    */
 
-#define EMAC_PHY_SR_100_SPEED		((1<<14)|(1<<13))
-#define EMAC_PHY_SR_FULL_DUP		((1<<14)|(1<<12))
-#define EMAC_PHY_BMSR_LINK_STATUS			(1<<2)		/**< Link status */
+#define EMAC_PHY_SR_100_SPEED           ((1<<14)|(1<<13))
+#define EMAC_PHY_SR_FULL_DUP            ((1<<14)|(1<<12))
+#define EMAC_PHY_BMSR_LINK_STATUS                       (1<<2)          /**< Link status */
 
 #elif defined(IAR_LPC_1768)
 /* KSZ8721BL PHY definition ------------------------------------------------------------ */
 /** PHY device reset time out definition */
-#define EMAC_PHY_RESP_TOUT		0x100000UL
+#define EMAC_PHY_RESP_TOUT              0x100000UL
 
 /* ENET Device Revision ID */
 #define EMAC_OLD_EMAC_MODULE_ID  0x39022000  /**< Rev. ID for first rev '-'         */
@@ -505,62 +505,62 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 #define EMAC_PHY_REG_ANLPAR      0x05        /**< Auto-Neg. Link Partner Abitily    */
 #define EMAC_PHY_REG_ANER        0x06        /**< Auto-Neg. Expansion Register      */
 #define EMAC_PHY_REG_ANNPTR      0x07        /**< Auto-Neg. Next Page TX            */
-#define EMAC_PHY_REG_LPNPA		 0x08		 /**< Link Partner Next Page Ability    */
-#define EMAC_PHY_REG_REC		 0x15		 /**< RXError Counter Register			*/
-#define EMAC_PHY_REG_ISC		 0x1b		 /**< Interrupt Control/Status Register */
-#define EMAC_PHY_REG_100BASE	 0x1f		 /**< 100BASE-TX PHY Control Register   */
+#define EMAC_PHY_REG_LPNPA               0x08            /**< Link Partner Next Page Ability    */
+#define EMAC_PHY_REG_REC                 0x15            /**< RXError Counter Register                  */
+#define EMAC_PHY_REG_ISC                 0x1b            /**< Interrupt Control/Status Register */
+#define EMAC_PHY_REG_100BASE     0x1f            /**< 100BASE-TX PHY Control Register   */
 
 /*********************************************************************//**
  * Macro defines for PHY Basic Mode Control Register
  **********************************************************************/
-#define EMAC_PHY_BMCR_RESET     			(1<<15)		/**< Reset bit */
-#define EMAC_PHY_BMCR_LOOPBACK      		(1<<14)		/**< Loop back */
-#define EMAC_PHY_BMCR_SPEED_SEL     		(1<<13)		/**< Speed selection */
-#define EMAC_PHY_BMCR_AN					(1<<12)		/**< Auto Negotiation */
-#define EMAC_PHY_BMCR_POWERDOWN				(1<<11)		/**< Power down mode */
-#define EMAC_PHY_BMCR_ISOLATE				(1<<10)		/**< Isolate */
-#define EMAC_PHY_BMCR_RE_AN					(1<<9)		/**< Restart auto negotiation */
-#define EMAC_PHY_BMCR_DUPLEX				(1<<8)		/**< Duplex mode */
-#define EMAC_PHY_BMCR_COLLISION				(1<<7)		/**< Collision test */
-#define EMAC_PHY_BMCR_TXDIS					(1<<0)		/**< Disable transmit */
+#define EMAC_PHY_BMCR_RESET                             (1<<15)         /**< Reset bit */
+#define EMAC_PHY_BMCR_LOOPBACK                  (1<<14)         /**< Loop back */
+#define EMAC_PHY_BMCR_SPEED_SEL                 (1<<13)         /**< Speed selection */
+#define EMAC_PHY_BMCR_AN                                        (1<<12)         /**< Auto Negotiation */
+#define EMAC_PHY_BMCR_POWERDOWN                         (1<<11)         /**< Power down mode */
+#define EMAC_PHY_BMCR_ISOLATE                           (1<<10)         /**< Isolate */
+#define EMAC_PHY_BMCR_RE_AN                                     (1<<9)          /**< Restart auto negotiation */
+#define EMAC_PHY_BMCR_DUPLEX                            (1<<8)          /**< Duplex mode */
+#define EMAC_PHY_BMCR_COLLISION                         (1<<7)          /**< Collision test */
+#define EMAC_PHY_BMCR_TXDIS                                     (1<<0)          /**< Disable transmit */
 
 /*********************************************************************//**
  * Macro defines for PHY Basic Mode Status Register
  **********************************************************************/
-#define EMAC_PHY_BMSR_100BE_T4        	   	(1<<15)		/**< 100 base T4 */
-#define EMAC_PHY_BMSR_100TX_FULL			(1<<14)		/**< 100 base full duplex */
-#define EMAC_PHY_BMSR_100TX_HALF			(1<<13)		/**< 100 base half duplex */
-#define EMAC_PHY_BMSR_10BE_FULL				(1<<12)		/**< 10 base T full duplex */
-#define EMAC_PHY_BMSR_10BE_HALF				(1<<11)		/**< 10 base T half duplex */
-#define EMAC_PHY_BMSR_NOPREAM				(1<<6)		/**< MF Preamable Supress */
-#define EMAC_PHY_BMSR_AUTO_DONE				(1<<5)		/**< Auto negotiation complete */
-#define EMAC_PHY_BMSR_REMOTE_FAULT			(1<<4)		/**< Remote fault */
-#define EMAC_PHY_BMSR_NO_AUTO				(1<<3)		/**< Auto Negotiation ability */
-#define EMAC_PHY_BMSR_LINK_STATUS			(1<<2)		/**< Link status */
-#define EMAC_PHY_BMSR_JABBER_DETECT			(1<<1)		/**< Jabber detect */
-#define EMAC_PHY_BMSR_EXTEND				(1<<0)		/**< Extended support */
+#define EMAC_PHY_BMSR_100BE_T4                  (1<<15)         /**< 100 base T4 */
+#define EMAC_PHY_BMSR_100TX_FULL                        (1<<14)         /**< 100 base full duplex */
+#define EMAC_PHY_BMSR_100TX_HALF                        (1<<13)         /**< 100 base half duplex */
+#define EMAC_PHY_BMSR_10BE_FULL                         (1<<12)         /**< 10 base T full duplex */
+#define EMAC_PHY_BMSR_10BE_HALF                         (1<<11)         /**< 10 base T half duplex */
+#define EMAC_PHY_BMSR_NOPREAM                           (1<<6)          /**< MF Preamable Supress */
+#define EMAC_PHY_BMSR_AUTO_DONE                         (1<<5)          /**< Auto negotiation complete */
+#define EMAC_PHY_BMSR_REMOTE_FAULT                      (1<<4)          /**< Remote fault */
+#define EMAC_PHY_BMSR_NO_AUTO                           (1<<3)          /**< Auto Negotiation ability */
+#define EMAC_PHY_BMSR_LINK_STATUS                       (1<<2)          /**< Link status */
+#define EMAC_PHY_BMSR_JABBER_DETECT                     (1<<1)          /**< Jabber detect */
+#define EMAC_PHY_BMSR_EXTEND                            (1<<0)          /**< Extended support */
 
 /*********************************************************************//**
  * Macro defines for PHY Identifier
  **********************************************************************/
 /* PHY Identifier 1 bitmap definitions */
-#define EMAC_PHY_IDR1(n)		(n & 0xFFFF)		/**< PHY ID1 Number */
+#define EMAC_PHY_IDR1(n)                (n & 0xFFFF)            /**< PHY ID1 Number */
 
 /* PHY Identifier 2 bitmap definitions */
-#define EMAC_PHY_IDR2(n)		(n & 0xFFFF)		/**< PHY ID2 Number */
+#define EMAC_PHY_IDR2(n)                (n & 0xFFFF)            /**< PHY ID2 Number */
 
 /*********************************************************************//**
  * Macro defines for Auto-Negotiation Advertisement
  **********************************************************************/
-#define EMAC_PHY_AN_NEXTPAGE					(1<<15)		/**<  Next page capable */
-#define EMAC_PHY_AN_REMOTE_FAULT				(1<<13)		/**< Remote Fault support */
-#define EMAC_PHY_AN_PAUSE						(1<<10)		/**< Pause support */
-#define EMAC_PHY_AN_100BASE_T4					(1<<9)		/**< T4 capable */
-#define EMAC_PHY_AN_100BASE_TX_FD				(1<<8)		/**< TX with Full-duplex capable */
-#define EMAC_PHY_AN_100BASE_TX					(1<<7)		/**< TX capable */
-#define EMAC_PHY_AN_10BASE_T_FD					(1<<6)		/**< 10Mbps with full-duplex capable */
-#define EMAC_PHY_AN_10BASE_T					(1<<5)		/**< 10Mbps capable */
-#define EMAC_PHY_AN_FIELD(n)					(n & 0x1F)  /**< Selector Field */
+#define EMAC_PHY_AN_NEXTPAGE                                    (1<<15)         /**<  Next page capable */
+#define EMAC_PHY_AN_REMOTE_FAULT                                (1<<13)         /**< Remote Fault support */
+#define EMAC_PHY_AN_PAUSE                                               (1<<10)         /**< Pause support */
+#define EMAC_PHY_AN_100BASE_T4                                  (1<<9)          /**< T4 capable */
+#define EMAC_PHY_AN_100BASE_TX_FD                               (1<<8)          /**< TX with Full-duplex capable */
+#define EMAC_PHY_AN_100BASE_TX                                  (1<<7)          /**< TX capable */
+#define EMAC_PHY_AN_10BASE_T_FD                                 (1<<6)          /**< 10Mbps with full-duplex capable */
+#define EMAC_PHY_AN_10BASE_T                                    (1<<5)          /**< 10Mbps capable */
+#define EMAC_PHY_AN_FIELD(n)                                    (n & 0x1F)  /**< Selector Field */
 
 #define EMAC_PHY_FULLD_100M      0x2100      /**< Full Duplex 100Mbit               */
 #define EMAC_PHY_HALFD_100M      0x2000      /**< Half Duplex 100Mbit               */
@@ -568,11 +568,11 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
 #define EMAC_PHY_HALFD_10M       0x0000      /**< Half Duplex 10MBit                */
 #define EMAC_PHY_AUTO_NEG        0x3000      /**< Select Auto Negotiation           */
 
-#define EMAC_PHY_SR_100_SPEED		((1<<14)|(1<<13))
-#define EMAC_PHY_SR_FULL_DUP		((1<<14)|(1<<12))
+#define EMAC_PHY_SR_100_SPEED           ((1<<14)|(1<<13))
+#define EMAC_PHY_SR_FULL_DUP            ((1<<14)|(1<<12))
 
-#define EMAC_DEF_ADR    (0x01<<8)		/**< Default PHY device address        */
-#define EMAC_KSZ8721BL_ID 	((0x22 << 16) | 0x1619 ) /**< PHY Identifier */
+#define EMAC_DEF_ADR    (0x01<<8)               /**< Default PHY device address        */
+#define EMAC_KSZ8721BL_ID       ((0x22 << 16) | 0x1619 ) /**< PHY Identifier */
 #endif
 
 /**
@@ -591,31 +591,31 @@ EMAC_RINFO_LEN_ERR   | EMAC_RINFO_ALIGN_ERR | EMAC_RINFO_OVERRUN)
  * @brief RX Descriptor structure type definition
  */
 typedef struct {
-	uint32_t Packet;	/**< Receive Packet Descriptor */
-	uint32_t Ctrl;		/**< Receive Control Descriptor */
+        uint32_t Packet;        /**< Receive Packet Descriptor */
+        uint32_t Ctrl;          /**< Receive Control Descriptor */
 } RX_Desc;
 
 /**
  * @brief RX Status structure type definition
  */
 typedef struct {
-	uint32_t Info;		/**< Receive Information Status */
-	uint32_t HashCRC;	/**< Receive Hash CRC Status */
+        uint32_t Info;          /**< Receive Information Status */
+        uint32_t HashCRC;       /**< Receive Hash CRC Status */
 } RX_Stat;
 
 /**
  * @brief TX Descriptor structure type definition
  */
 typedef struct {
-	uint32_t Packet;	/**< Transmit Packet Descriptor */
-	uint32_t Ctrl;		/**< Transmit Control Descriptor */
+        uint32_t Packet;        /**< Transmit Packet Descriptor */
+        uint32_t Ctrl;          /**< Transmit Control Descriptor */
 } TX_Desc;
 
 /**
  * @brief TX Status structure type definition
  */
 typedef struct {
-   uint32_t Info;		/**< Transmit Information Status */
+   uint32_t Info;               /**< Transmit Information Status */
 } TX_Stat;
 
 
@@ -623,24 +623,24 @@ typedef struct {
  * @brief TX Data Buffer structure definition
  */
 typedef struct {
-	uint32_t ulDataLen;			/**< Data length */
-	uint32_t *pbDataBuf;		/**< A word-align data pointer to data buffer */
+        uint32_t ulDataLen;                     /**< Data length */
+        uint32_t *pbDataBuf;            /**< A word-align data pointer to data buffer */
 } EMAC_PACKETBUF_Type;
 
 /**
  * @brief EMAC configuration structure definition
  */
 typedef struct {
-	uint32_t	Mode;						/**< Supported EMAC PHY device speed, should be one of the following:
-											- EMAC_MODE_AUTO
-											- EMAC_MODE_10M_FULL
-											- EMAC_MODE_10M_HALF
-											- EMAC_MODE_100M_FULL
-											- EMAC_MODE_100M_HALF
-											*/
-	uint8_t 	*pbEMAC_Addr;				/**< Pointer to EMAC Station address that contains 6-bytes
-											of MAC address, it must be sorted in order (bEMAC_Addr[0]..[5])
-											*/
+        uint32_t        Mode;                                           /**< Supported EMAC PHY device speed, should be one of the following:
+                                                                                        - EMAC_MODE_AUTO
+                                                                                        - EMAC_MODE_10M_FULL
+                                                                                        - EMAC_MODE_10M_HALF
+                                                                                        - EMAC_MODE_100M_FULL
+                                                                                        - EMAC_MODE_100M_HALF
+                                                                                        */
+        uint8_t         *pbEMAC_Addr;                           /**< Pointer to EMAC Station address that contains 6-bytes
+                                                                                        of MAC address, it must be sorted in order (bEMAC_Addr[0]..[5])
+                                                                                        */
 } EMAC_CFG_Type;
 
 

--- a/bmp/lpc17xx_pinsel.h
+++ b/bmp/lpc17xx_pinsel.h
@@ -1,10 +1,10 @@
 /***********************************************************************//**
- * @file		lpc17xx_pinsel.h
- * @brief		Contains all macro definitions and function prototypes
- * 				support for Pin connect block firmware library on LPC17xx
- * @version		2.0
- * @date		21. May. 2010
- * @author		NXP MCU SW Application Team
+ * @file                lpc17xx_pinsel.h
+ * @brief               Contains all macro definitions and function prototypes
+ *                              support for Pin connect block firmware library on LPC17xx
+ * @version             2.0
+ * @date                21. May. 2010
+ * @author              NXP MCU SW Application Team
  **************************************************************************
  * Software that is described herein is for illustrative purposes only
  * which provides customers with programming information regarding the
@@ -44,74 +44,74 @@ extern "C"
 /*********************************************************************//**
  *!< Macros define for PORT Selection
  ***********************************************************************/
-#define PINSEL_PORT_0 	((0))	/**< PORT 0*/
-#define PINSEL_PORT_1 	((1))	/**< PORT 1*/
-#define PINSEL_PORT_2 	((2))	/**< PORT 2*/
-#define PINSEL_PORT_3 	((3))	/**< PORT 3*/
-#define PINSEL_PORT_4 	((4))	/**< PORT 4*/
+#define PINSEL_PORT_0   ((0))   /**< PORT 0*/
+#define PINSEL_PORT_1   ((1))   /**< PORT 1*/
+#define PINSEL_PORT_2   ((2))   /**< PORT 2*/
+#define PINSEL_PORT_3   ((3))   /**< PORT 3*/
+#define PINSEL_PORT_4   ((4))   /**< PORT 4*/
 
 /***********************************************************************
  * Macros define for Pin Function selection
  **********************************************************************/
-#define PINSEL_FUNC_0	((0))	/**< default function*/
-#define PINSEL_FUNC_1	((1))	/**< first alternate function*/
-#define PINSEL_FUNC_2	((2))	/**< second alternate function*/
-#define PINSEL_FUNC_3	((3))	/**< third or reserved alternate function*/
+#define PINSEL_FUNC_0   ((0))   /**< default function*/
+#define PINSEL_FUNC_1   ((1))   /**< first alternate function*/
+#define PINSEL_FUNC_2   ((2))   /**< second alternate function*/
+#define PINSEL_FUNC_3   ((3))   /**< third or reserved alternate function*/
 
 /***********************************************************************
  * Macros define for Pin Number of Port
  **********************************************************************/
-#define PINSEL_PIN_0 	((0)) 	/**< Pin 0 */
-#define PINSEL_PIN_1 	((1)) 	/**< Pin 1 */
-#define PINSEL_PIN_2 	((2)) 	/**< Pin 2 */
-#define PINSEL_PIN_3 	((3)) 	/**< Pin 3 */
-#define PINSEL_PIN_4 	((4)) 	/**< Pin 4 */
-#define PINSEL_PIN_5 	((5)) 	/**< Pin 5 */
-#define PINSEL_PIN_6 	((6)) 	/**< Pin 6 */
-#define PINSEL_PIN_7 	((7)) 	/**< Pin 7 */
-#define PINSEL_PIN_8 	((8)) 	/**< Pin 8 */
-#define PINSEL_PIN_9 	((9)) 	/**< Pin 9 */
-#define PINSEL_PIN_10 	((10)) 	/**< Pin 10 */
-#define PINSEL_PIN_11 	((11)) 	/**< Pin 11 */
-#define PINSEL_PIN_12 	((12)) 	/**< Pin 12 */
-#define PINSEL_PIN_13 	((13)) 	/**< Pin 13 */
-#define PINSEL_PIN_14 	((14)) 	/**< Pin 14 */
-#define PINSEL_PIN_15 	((15)) 	/**< Pin 15 */
-#define PINSEL_PIN_16 	((16)) 	/**< Pin 16 */
-#define PINSEL_PIN_17 	((17)) 	/**< Pin 17 */
-#define PINSEL_PIN_18 	((18)) 	/**< Pin 18 */
-#define PINSEL_PIN_19 	((19)) 	/**< Pin 19 */
-#define PINSEL_PIN_20 	((20)) 	/**< Pin 20 */
-#define PINSEL_PIN_21 	((21)) 	/**< Pin 21 */
-#define PINSEL_PIN_22 	((22)) 	/**< Pin 22 */
-#define PINSEL_PIN_23 	((23)) 	/**< Pin 23 */
-#define PINSEL_PIN_24 	((24)) 	/**< Pin 24 */
-#define PINSEL_PIN_25 	((25)) 	/**< Pin 25 */
-#define PINSEL_PIN_26 	((26)) 	/**< Pin 26 */
-#define PINSEL_PIN_27 	((27)) 	/**< Pin 27 */
-#define PINSEL_PIN_28 	((28)) 	/**< Pin 28 */
-#define PINSEL_PIN_29 	((29)) 	/**< Pin 29 */
-#define PINSEL_PIN_30 	((30)) 	/**< Pin 30 */
-#define PINSEL_PIN_31 	((31)) 	/**< Pin 31 */
+#define PINSEL_PIN_0    ((0))   /**< Pin 0 */
+#define PINSEL_PIN_1    ((1))   /**< Pin 1 */
+#define PINSEL_PIN_2    ((2))   /**< Pin 2 */
+#define PINSEL_PIN_3    ((3))   /**< Pin 3 */
+#define PINSEL_PIN_4    ((4))   /**< Pin 4 */
+#define PINSEL_PIN_5    ((5))   /**< Pin 5 */
+#define PINSEL_PIN_6    ((6))   /**< Pin 6 */
+#define PINSEL_PIN_7    ((7))   /**< Pin 7 */
+#define PINSEL_PIN_8    ((8))   /**< Pin 8 */
+#define PINSEL_PIN_9    ((9))   /**< Pin 9 */
+#define PINSEL_PIN_10   ((10))  /**< Pin 10 */
+#define PINSEL_PIN_11   ((11))  /**< Pin 11 */
+#define PINSEL_PIN_12   ((12))  /**< Pin 12 */
+#define PINSEL_PIN_13   ((13))  /**< Pin 13 */
+#define PINSEL_PIN_14   ((14))  /**< Pin 14 */
+#define PINSEL_PIN_15   ((15))  /**< Pin 15 */
+#define PINSEL_PIN_16   ((16))  /**< Pin 16 */
+#define PINSEL_PIN_17   ((17))  /**< Pin 17 */
+#define PINSEL_PIN_18   ((18))  /**< Pin 18 */
+#define PINSEL_PIN_19   ((19))  /**< Pin 19 */
+#define PINSEL_PIN_20   ((20))  /**< Pin 20 */
+#define PINSEL_PIN_21   ((21))  /**< Pin 21 */
+#define PINSEL_PIN_22   ((22))  /**< Pin 22 */
+#define PINSEL_PIN_23   ((23))  /**< Pin 23 */
+#define PINSEL_PIN_24   ((24))  /**< Pin 24 */
+#define PINSEL_PIN_25   ((25))  /**< Pin 25 */
+#define PINSEL_PIN_26   ((26))  /**< Pin 26 */
+#define PINSEL_PIN_27   ((27))  /**< Pin 27 */
+#define PINSEL_PIN_28   ((28))  /**< Pin 28 */
+#define PINSEL_PIN_29   ((29))  /**< Pin 29 */
+#define PINSEL_PIN_30   ((30))  /**< Pin 30 */
+#define PINSEL_PIN_31   ((31))  /**< Pin 31 */
 
 /***********************************************************************
  * Macros define for Pin mode
  **********************************************************************/
-#define PINSEL_PINMODE_PULLUP		((0))	/**< Internal pull-up resistor*/
-#define PINSEL_PINMODE_TRISTATE 	((2))	/**< Tri-state */
-#define PINSEL_PINMODE_PULLDOWN 	((3)) 	/**< Internal pull-down resistor */
+#define PINSEL_PINMODE_PULLUP           ((0))   /**< Internal pull-up resistor*/
+#define PINSEL_PINMODE_TRISTATE         ((2))   /**< Tri-state */
+#define PINSEL_PINMODE_PULLDOWN         ((3))   /**< Internal pull-down resistor */
 
 /***********************************************************************
  * Macros define for Pin mode (normal/open drain)
  **********************************************************************/
-#define	PINSEL_PINMODE_NORMAL		((0))	/**< Pin is in the normal (not open drain) mode.*/
-#define	PINSEL_PINMODE_OPENDRAIN	((1)) 	/**< Pin is in the open drain mode */
+#define PINSEL_PINMODE_NORMAL           ((0))   /**< Pin is in the normal (not open drain) mode.*/
+#define PINSEL_PINMODE_OPENDRAIN        ((1))   /**< Pin is in the open drain mode */
 
 /***********************************************************************
  * Macros define for I2C mode
  ***********************************************************************/
-#define	PINSEL_I2C_Normal_Mode		((0))	/**< The standard drive mode */
-#define	PINSEL_I2C_Fast_Mode		((1)) 	/**<  Fast Mode Plus drive mode */
+#define PINSEL_I2C_Normal_Mode          ((0))   /**< The standard drive mode */
+#define PINSEL_I2C_Fast_Mode            ((1))   /**<  Fast Mode Plus drive mode */
 
 /**
  * @}
@@ -124,10 +124,10 @@ extern "C"
 
 /* Pin selection define */
 /* I2C Pin Configuration register bit description */
-#define PINSEL_I2CPADCFG_SDADRV0 	_BIT(0) /**< Drive mode control for the SDA0 pin, P0.27 */
-#define PINSEL_I2CPADCFG_SDAI2C0	_BIT(1) /**< I2C mode control for the SDA0 pin, P0.27 */
-#define PINSEL_I2CPADCFG_SCLDRV0	_BIT(2) /**< Drive mode control for the SCL0 pin, P0.28 */
-#define PINSEL_I2CPADCFG_SCLI2C0	_BIT(3) /**< I2C mode control for the SCL0 pin, P0.28 */
+#define PINSEL_I2CPADCFG_SDADRV0        _BIT(0) /**< Drive mode control for the SDA0 pin, P0.27 */
+#define PINSEL_I2CPADCFG_SDAI2C0        _BIT(1) /**< I2C mode control for the SDA0 pin, P0.27 */
+#define PINSEL_I2CPADCFG_SCLDRV0        _BIT(2) /**< Drive mode control for the SCL0 pin, P0.28 */
+#define PINSEL_I2CPADCFG_SCLI2C0        _BIT(3) /**< I2C mode control for the SCL0 pin, P0.28 */
 
 /**
  * @}
@@ -141,19 +141,19 @@ extern "C"
 
 /** @brief Pin configuration structure */
 typedef struct {
-    uint8_t Portnum;		/**< Port Number, should be PINSEL_PORT_x,
-				 * where x should be in range from 0 to 4 */
-    uint8_t Pinnum;		/**< Pin Number, should be PINSEL_PIN_x,
-				 * where x should be in range from 0 to 31 */
-    uint8_t Funcnum;		/**< Function Number, should be PINSEL_FUNC_x,
-				 * where x should be in range from 0 to 3 */
-    uint8_t Pinmode;		/**< Pin Mode, should be:
-				 * - PINSEL_PINMODE_PULLUP: Internal pull-up resistor
-				 * - PINSEL_PINMODE_TRISTATE: Tri-state
-				 * - PINSEL_PINMODE_PULLDOWN: Internal pull-down resistor */
-    uint8_t OpenDrain;		/**< OpenDrain mode, should be:
-				 * - PINSEL_PINMODE_NORMAL: Pin is in the normal (not open drain) mode
-				 * - PINSEL_PINMODE_OPENDRAIN: Pin is in the open drain mode */
+    uint8_t Portnum;            /**< Port Number, should be PINSEL_PORT_x,
+                                 * where x should be in range from 0 to 4 */
+    uint8_t Pinnum;             /**< Pin Number, should be PINSEL_PIN_x,
+                                 * where x should be in range from 0 to 31 */
+    uint8_t Funcnum;            /**< Function Number, should be PINSEL_FUNC_x,
+                                 * where x should be in range from 0 to 3 */
+    uint8_t Pinmode;            /**< Pin Mode, should be:
+                                 * - PINSEL_PINMODE_PULLUP: Internal pull-up resistor
+                                 * - PINSEL_PINMODE_TRISTATE: Tri-state
+                                 * - PINSEL_PINMODE_PULLDOWN: Internal pull-down resistor */
+    uint8_t OpenDrain;          /**< OpenDrain mode, should be:
+                                 * - PINSEL_PINMODE_NORMAL: Pin is in the normal (not open drain) mode
+                                 * - PINSEL_PINMODE_OPENDRAIN: Pin is in the open drain mode */
 } PINSEL_CFG_Type;
 
 /**

--- a/bmp/lpc17xx_ssp.h
+++ b/bmp/lpc17xx_ssp.h
@@ -1,12 +1,12 @@
 /**********************************************************************
-* $Id$		lpc17xx_ssp.h				2010-06-18
+* $Id$          lpc17xx_ssp.h                           2010-06-18
 *//**
-* @file		lpc17xx_ssp.h
-* @brief	Contains all macro definitions and function prototypes
-* 			support for SSP firmware library on LPC17xx
-* @version	3.0
-* @date		18. June. 2010
-* @author	NXP MCU SW Application Team
+* @file         lpc17xx_ssp.h
+* @brief        Contains all macro definitions and function prototypes
+*                       support for SSP firmware library on LPC17xx
+* @version      3.0
+* @date         18. June. 2010
+* @author       NXP MCU SW Application Team
 *
 * Copyright(C) 2010, NXP Semiconductor
 * All rights reserved.
@@ -52,8 +52,8 @@ extern "C"
  * SSP configuration parameter defines
  **********************************************************************/
 /** Clock phase control bit */
-#define SSP_CPHA_FIRST			((uint32_t)(0))
-#define SSP_CPHA_SECOND			SSP_CR0_CPHA_SECOND
+#define SSP_CPHA_FIRST                  ((uint32_t)(0))
+#define SSP_CPHA_SECOND                 SSP_CR0_CPHA_SECOND
 
 
 /** Clock polarity control bit */
@@ -63,107 +63,107 @@ extern "C"
  * - If bit[6] in SSPnCR0 is 1 (SSP_CR0_CPOL_HI): SSP controller maintains the bus clock
  * high between frames. That means the active clock is in LO state.
  */
-#define SSP_CPOL_HI				((uint32_t)(0))
-#define SSP_CPOL_LO				SSP_CR0_CPOL_HI
+#define SSP_CPOL_HI                             ((uint32_t)(0))
+#define SSP_CPOL_LO                             SSP_CR0_CPOL_HI
 
 /** SSP master mode enable */
-#define SSP_SLAVE_MODE			SSP_CR1_SLAVE_EN
-#define SSP_MASTER_MODE			((uint32_t)(0))
+#define SSP_SLAVE_MODE                  SSP_CR1_SLAVE_EN
+#define SSP_MASTER_MODE                 ((uint32_t)(0))
 
 /** SSP data bit number defines */
-#define SSP_DATABIT_4		SSP_CR0_DSS(4) 			/*!< Databit number = 4 */
-#define SSP_DATABIT_5		SSP_CR0_DSS(5) 			/*!< Databit number = 5 */
-#define SSP_DATABIT_6		SSP_CR0_DSS(6) 			/*!< Databit number = 6 */
-#define SSP_DATABIT_7		SSP_CR0_DSS(7) 			/*!< Databit number = 7 */
-#define SSP_DATABIT_8		SSP_CR0_DSS(8) 			/*!< Databit number = 8 */
-#define SSP_DATABIT_9		SSP_CR0_DSS(9) 			/*!< Databit number = 9 */
-#define SSP_DATABIT_10		SSP_CR0_DSS(10) 		/*!< Databit number = 10 */
-#define SSP_DATABIT_11		SSP_CR0_DSS(11) 		/*!< Databit number = 11 */
-#define SSP_DATABIT_12		SSP_CR0_DSS(12) 		/*!< Databit number = 12 */
-#define SSP_DATABIT_13		SSP_CR0_DSS(13) 		/*!< Databit number = 13 */
-#define SSP_DATABIT_14		SSP_CR0_DSS(14) 		/*!< Databit number = 14 */
-#define SSP_DATABIT_15		SSP_CR0_DSS(15) 		/*!< Databit number = 15 */
-#define SSP_DATABIT_16		SSP_CR0_DSS(16) 		/*!< Databit number = 16 */
+#define SSP_DATABIT_4           SSP_CR0_DSS(4)                  /*!< Databit number = 4 */
+#define SSP_DATABIT_5           SSP_CR0_DSS(5)                  /*!< Databit number = 5 */
+#define SSP_DATABIT_6           SSP_CR0_DSS(6)                  /*!< Databit number = 6 */
+#define SSP_DATABIT_7           SSP_CR0_DSS(7)                  /*!< Databit number = 7 */
+#define SSP_DATABIT_8           SSP_CR0_DSS(8)                  /*!< Databit number = 8 */
+#define SSP_DATABIT_9           SSP_CR0_DSS(9)                  /*!< Databit number = 9 */
+#define SSP_DATABIT_10          SSP_CR0_DSS(10)                 /*!< Databit number = 10 */
+#define SSP_DATABIT_11          SSP_CR0_DSS(11)                 /*!< Databit number = 11 */
+#define SSP_DATABIT_12          SSP_CR0_DSS(12)                 /*!< Databit number = 12 */
+#define SSP_DATABIT_13          SSP_CR0_DSS(13)                 /*!< Databit number = 13 */
+#define SSP_DATABIT_14          SSP_CR0_DSS(14)                 /*!< Databit number = 14 */
+#define SSP_DATABIT_15          SSP_CR0_DSS(15)                 /*!< Databit number = 15 */
+#define SSP_DATABIT_16          SSP_CR0_DSS(16)                 /*!< Databit number = 16 */
 
 /** SSP Frame Format definition */
 /** Motorola SPI mode */
-#define SSP_FRAME_SPI		SSP_CR0_FRF_SPI
+#define SSP_FRAME_SPI           SSP_CR0_FRF_SPI
 /** TI synchronous serial mode */
-#define SSP_FRAME_TI		SSP_CR0_FRF_TI
+#define SSP_FRAME_TI            SSP_CR0_FRF_TI
 /** National Micro-wire mode */
-#define SSP_FRAME_MICROWIRE	SSP_CR0_FRF_MICROWIRE
+#define SSP_FRAME_MICROWIRE     SSP_CR0_FRF_MICROWIRE
 
 /*********************************************************************//**
  * SSP Status defines
  **********************************************************************/
 /** SSP status TX FIFO Empty bit */
-#define SSP_STAT_TXFIFO_EMPTY		SSP_SR_TFE
+#define SSP_STAT_TXFIFO_EMPTY           SSP_SR_TFE
 /** SSP status TX FIFO not full bit */
-#define SSP_STAT_TXFIFO_NOTFULL		SSP_SR_TNF
+#define SSP_STAT_TXFIFO_NOTFULL         SSP_SR_TNF
 /** SSP status RX FIFO not empty bit */
-#define SSP_STAT_RXFIFO_NOTEMPTY	SSP_SR_RNE
+#define SSP_STAT_RXFIFO_NOTEMPTY        SSP_SR_RNE
 /** SSP status RX FIFO full bit */
-#define SSP_STAT_RXFIFO_FULL		SSP_SR_RFF
+#define SSP_STAT_RXFIFO_FULL            SSP_SR_RFF
 /** SSP status SSP Busy bit */
-#define SSP_STAT_BUSY				SSP_SR_BSY
+#define SSP_STAT_BUSY                           SSP_SR_BSY
 
 /*********************************************************************//**
  * SSP Interrupt Configuration defines
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_INTCFG_ROR		SSP_IMSC_ROR
+#define SSP_INTCFG_ROR          SSP_IMSC_ROR
 /** Receive TimeOut */
-#define SSP_INTCFG_RT		SSP_IMSC_RT
+#define SSP_INTCFG_RT           SSP_IMSC_RT
 /** Rx FIFO is at least half full */
-#define SSP_INTCFG_RX		SSP_IMSC_RX
+#define SSP_INTCFG_RX           SSP_IMSC_RX
 /** Tx FIFO is at least half empty */
-#define SSP_INTCFG_TX		SSP_IMSC_TX
+#define SSP_INTCFG_TX           SSP_IMSC_TX
 
 /*********************************************************************//**
  * SSP Configured Interrupt Status defines
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_INTSTAT_ROR		SSP_MIS_ROR
+#define SSP_INTSTAT_ROR         SSP_MIS_ROR
 /** Receive TimeOut */
-#define SSP_INTSTAT_RT		SSP_MIS_RT
+#define SSP_INTSTAT_RT          SSP_MIS_RT
 /** Rx FIFO is at least half full */
-#define SSP_INTSTAT_RX		SSP_MIS_RX
+#define SSP_INTSTAT_RX          SSP_MIS_RX
 /** Tx FIFO is at least half empty */
-#define SSP_INTSTAT_TX		SSP_MIS_TX
+#define SSP_INTSTAT_TX          SSP_MIS_TX
 
 /*********************************************************************//**
  * SSP Raw Interrupt Status defines
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_INTSTAT_RAW_ROR		SSP_RIS_ROR
+#define SSP_INTSTAT_RAW_ROR             SSP_RIS_ROR
 /** Receive TimeOut */
-#define SSP_INTSTAT_RAW_RT		SSP_RIS_RT
+#define SSP_INTSTAT_RAW_RT              SSP_RIS_RT
 /** Rx FIFO is at least half full */
-#define SSP_INTSTAT_RAW_RX		SSP_RIS_RX
+#define SSP_INTSTAT_RAW_RX              SSP_RIS_RX
 /** Tx FIFO is at least half empty */
-#define SSP_INTSTAT_RAW_TX		SSP_RIS_TX
+#define SSP_INTSTAT_RAW_TX              SSP_RIS_TX
 
 /*********************************************************************//**
  * SSP Interrupt Clear defines
  **********************************************************************/
 /** Writing a 1 to this bit clears the "frame was received when
  * RxFIFO was full" interrupt */
-#define SSP_INTCLR_ROR		SSP_ICR_ROR
+#define SSP_INTCLR_ROR          SSP_ICR_ROR
 /** Writing a 1 to this bit clears the "Rx FIFO was not empty and
  * has not been read for a timeout period" interrupt */
-#define SSP_INTCLR_RT		SSP_ICR_RT
+#define SSP_INTCLR_RT           SSP_ICR_RT
 
 /*********************************************************************//**
  * SSP DMA defines
  **********************************************************************/
 /** SSP bit for enabling RX DMA */
-#define SSP_DMA_RX		SSP_DMA_RXDMA_EN
+#define SSP_DMA_RX              SSP_DMA_RXDMA_EN
 /** SSP bit for enabling TX DMA */
-#define SSP_DMA_TX		SSP_DMA_TXDMA_EN
+#define SSP_DMA_TX              SSP_DMA_TXDMA_EN
 
 /* SSP Status Implementation definitions */
-#define SSP_STAT_DONE		(1UL<<8)		/**< Done */
-#define SSP_STAT_ERROR		(1UL<<9)		/**< Error */
+#define SSP_STAT_DONE           (1UL<<8)                /**< Done */
+#define SSP_STAT_ERROR          (1UL<<9)                /**< Error */
 
 /**
  * @}
@@ -179,39 +179,39 @@ extern "C"
  * Macro defines for CR0 register
  **********************************************************************/
 /** SSP data size select, must be 4 bits to 16 bits */
-#define SSP_CR0_DSS(n)   		((uint32_t)((n-1)&0xF))
+#define SSP_CR0_DSS(n)                  ((uint32_t)((n-1)&0xF))
 /** SSP control 0 Motorola SPI mode */
-#define SSP_CR0_FRF_SPI  		((uint32_t)(0<<4))
+#define SSP_CR0_FRF_SPI                 ((uint32_t)(0<<4))
 /** SSP control 0 TI synchronous serial mode */
-#define SSP_CR0_FRF_TI   		((uint32_t)(1<<4))
+#define SSP_CR0_FRF_TI                  ((uint32_t)(1<<4))
 /** SSP control 0 National Micro-wire mode */
-#define SSP_CR0_FRF_MICROWIRE  	((uint32_t)(2<<4))
+#define SSP_CR0_FRF_MICROWIRE   ((uint32_t)(2<<4))
 /** SPI clock polarity bit (used in SPI mode only), (1) = maintains the
    bus clock high between frames, (0) = low */
-#define SSP_CR0_CPOL_HI		((uint32_t)(1<<6))
+#define SSP_CR0_CPOL_HI         ((uint32_t)(1<<6))
 /** SPI clock out phase bit (used in SPI mode only), (1) = captures data
    on the second clock transition of the frame, (0) = first */
-#define SSP_CR0_CPHA_SECOND	((uint32_t)(1<<7))
+#define SSP_CR0_CPHA_SECOND     ((uint32_t)(1<<7))
 /** SSP serial clock rate value load macro, divider rate is
    PERIPH_CLK / (cpsr * (SCR + 1)) */
-#define SSP_CR0_SCR(n)   	((uint32_t)((n&0xFF)<<8))
+#define SSP_CR0_SCR(n)          ((uint32_t)((n&0xFF)<<8))
 /** SSP CR0 bit mask */
-#define SSP_CR0_BITMASK		((uint32_t)(0xFFFF))
+#define SSP_CR0_BITMASK         ((uint32_t)(0xFFFF))
 
 /*********************************************************************//**
  * Macro defines for CR1 register
  **********************************************************************/
 /** SSP control 1 loopback mode enable bit */
-#define SSP_CR1_LBM_EN		((uint32_t)(1<<0))
+#define SSP_CR1_LBM_EN          ((uint32_t)(1<<0))
 /** SSP control 1 enable bit */
-#define SSP_CR1_SSP_EN		((uint32_t)(1<<1))
+#define SSP_CR1_SSP_EN          ((uint32_t)(1<<1))
 /** SSP control 1 slave enable */
-#define SSP_CR1_SLAVE_EN	((uint32_t)(1<<2))
+#define SSP_CR1_SLAVE_EN        ((uint32_t)(1<<2))
 /** SSP control 1 slave out disable bit, disables transmit line in slave
    mode */
-#define SSP_CR1_SO_DISABLE	((uint32_t)(1<<3))
+#define SSP_CR1_SO_DISABLE      ((uint32_t)(1<<3))
 /** SSP CR1 bit mask */
-#define SSP_CR1_BITMASK		((uint32_t)(0x0F))
+#define SSP_CR1_BITMASK         ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro defines for DR register
@@ -233,97 +233,97 @@ extern "C"
 /** SSP status SSP Busy bit */
 #define SSP_SR_BSY      ((uint32_t)(1<<4))
 /** SSP SR bit mask */
-#define SSP_SR_BITMASK	((uint32_t)(0x1F))
+#define SSP_SR_BITMASK  ((uint32_t)(0x1F))
 
 /*********************************************************************//**
  * Macro defines for CPSR register
  **********************************************************************/
 /** SSP clock prescaler */
-#define SSP_CPSR_CPDVSR(n) 	((uint32_t)(n&0xFF))
+#define SSP_CPSR_CPDVSR(n)      ((uint32_t)(n&0xFF))
 /** SSP CPSR bit mask */
-#define SSP_CPSR_BITMASK	((uint32_t)(0xFF))
+#define SSP_CPSR_BITMASK        ((uint32_t)(0xFF))
 
 /*********************************************************************//**
  * Macro define for (IMSC) Interrupt Mask Set/Clear registers
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_IMSC_ROR	((uint32_t)(1<<0))
+#define SSP_IMSC_ROR    ((uint32_t)(1<<0))
 /** Receive TimeOut */
-#define SSP_IMSC_RT		((uint32_t)(1<<1))
+#define SSP_IMSC_RT             ((uint32_t)(1<<1))
 /** Rx FIFO is at least half full */
-#define SSP_IMSC_RX		((uint32_t)(1<<2))
+#define SSP_IMSC_RX             ((uint32_t)(1<<2))
 /** Tx FIFO is at least half empty */
-#define SSP_IMSC_TX		((uint32_t)(1<<3))
+#define SSP_IMSC_TX             ((uint32_t)(1<<3))
 /** IMSC bit mask */
-#define SSP_IMSC_BITMASK	((uint32_t)(0x0F))
+#define SSP_IMSC_BITMASK        ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro define for (RIS) Raw Interrupt Status registers
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_RIS_ROR		((uint32_t)(1<<0))
+#define SSP_RIS_ROR             ((uint32_t)(1<<0))
 /** Receive TimeOut */
-#define SSP_RIS_RT		((uint32_t)(1<<1))
+#define SSP_RIS_RT              ((uint32_t)(1<<1))
 /** Rx FIFO is at least half full */
-#define SSP_RIS_RX		((uint32_t)(1<<2))
+#define SSP_RIS_RX              ((uint32_t)(1<<2))
 /** Tx FIFO is at least half empty */
-#define SSP_RIS_TX		((uint32_t)(1<<3))
+#define SSP_RIS_TX              ((uint32_t)(1<<3))
 /** RIS bit mask */
-#define SSP_RIS_BITMASK	((uint32_t)(0x0F))
+#define SSP_RIS_BITMASK ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro define for (MIS) Masked Interrupt Status registers
  **********************************************************************/
 /** Receive Overrun */
-#define SSP_MIS_ROR		((uint32_t)(1<<0))
+#define SSP_MIS_ROR             ((uint32_t)(1<<0))
 /** Receive TimeOut */
-#define SSP_MIS_RT		((uint32_t)(1<<1))
+#define SSP_MIS_RT              ((uint32_t)(1<<1))
 /** Rx FIFO is at least half full */
-#define SSP_MIS_RX		((uint32_t)(1<<2))
+#define SSP_MIS_RX              ((uint32_t)(1<<2))
 /** Tx FIFO is at least half empty */
-#define SSP_MIS_TX		((uint32_t)(1<<3))
+#define SSP_MIS_TX              ((uint32_t)(1<<3))
 /** MIS bit mask */
-#define SSP_MIS_BITMASK	((uint32_t)(0x0F))
+#define SSP_MIS_BITMASK ((uint32_t)(0x0F))
 
 /*********************************************************************//**
  * Macro define for (ICR) Interrupt Clear registers
  **********************************************************************/
 /** Writing a 1 to this bit clears the "frame was received when
  * RxFIFO was full" interrupt */
-#define SSP_ICR_ROR		((uint32_t)(1<<0))
+#define SSP_ICR_ROR             ((uint32_t)(1<<0))
 /** Writing a 1 to this bit clears the "Rx FIFO was not empty and
  * has not been read for a timeout period" interrupt */
-#define SSP_ICR_RT		((uint32_t)(1<<1))
+#define SSP_ICR_RT              ((uint32_t)(1<<1))
 /** ICR bit mask */
-#define SSP_ICR_BITMASK	((uint32_t)(0x03))
+#define SSP_ICR_BITMASK ((uint32_t)(0x03))
 
 /*********************************************************************//**
  * Macro defines for DMACR register
  **********************************************************************/
 /** SSP bit for enabling RX DMA */
-#define SSP_DMA_RXDMA_EN  	((uint32_t)(1<<0))
+#define SSP_DMA_RXDMA_EN        ((uint32_t)(1<<0))
 /** SSP bit for enabling TX DMA */
-#define SSP_DMA_TXDMA_EN  	((uint32_t)(1<<1))
-/** DMACR	bit mask */
-#define SSP_DMA_BITMASK		((uint32_t)(0x03))
+#define SSP_DMA_TXDMA_EN        ((uint32_t)(1<<1))
+/** DMACR       bit mask */
+#define SSP_DMA_BITMASK         ((uint32_t)(0x03))
 
 
 /* ---------------- CHECK PARAMETER DEFINITIONS ---------------------------- */
 /** Macro to determine if it is valid SSP port number */
-#define PARAM_SSPx(n)	((((uint32_t *)n)==((uint32_t *)LPC_SSP0)) \
+#define PARAM_SSPx(n)   ((((uint32_t *)n)==((uint32_t *)LPC_SSP0)) \
 || (((uint32_t *)n)==((uint32_t *)LPC_SSP1)))
 
 /** Macro check clock phase control mode */
-#define PARAM_SSP_CPHA(n) 		((n==SSP_CPHA_FIRST) || (n==SSP_CPHA_SECOND))
+#define PARAM_SSP_CPHA(n)               ((n==SSP_CPHA_FIRST) || (n==SSP_CPHA_SECOND))
 
 /** Macro check clock polarity mode */
-#define PARAM_SSP_CPOL(n)		((n==SSP_CPOL_HI) || (n==SSP_CPOL_LO))
+#define PARAM_SSP_CPOL(n)               ((n==SSP_CPOL_HI) || (n==SSP_CPOL_LO))
 
 /* Macro check master/slave mode */
-#define PARAM_SSP_MODE(n)		((n==SSP_SLAVE_MODE) || (n==SSP_MASTER_MODE))
+#define PARAM_SSP_MODE(n)               ((n==SSP_SLAVE_MODE) || (n==SSP_MASTER_MODE))
 
 /* Macro check databit value */
-#define PARAM_SSP_DATABIT(n) 	((n==SSP_DATABIT_4) || (n==SSP_DATABIT_5) \
+#define PARAM_SSP_DATABIT(n)    ((n==SSP_DATABIT_4) || (n==SSP_DATABIT_5) \
 || (n==SSP_DATABIT_6) || (n==SSP_DATABIT_16) \
 || (n==SSP_DATABIT_7) || (n==SSP_DATABIT_8) \
 || (n==SSP_DATABIT_9) || (n==SSP_DATABIT_10) \
@@ -341,7 +341,7 @@ extern "C"
 || (n==SSP_STAT_BUSY))
 
 /* Macro check interrupt configuration */
-#define PARAM_SSP_INTCFG(n)	((n==SSP_INTCFG_ROR) || (n==SSP_INTCFG_RT) \
+#define PARAM_SSP_INTCFG(n)     ((n==SSP_INTCFG_ROR) || (n==SSP_INTCFG_RT) \
 || (n==SSP_INTCFG_RX) || (n==SSP_INTCFG_TX))
 
 /* Macro check interrupt status value */
@@ -349,14 +349,14 @@ extern "C"
 || (n==SSP_INTSTAT_RX) || (n==SSP_INTSTAT_TX))
 
 /* Macro check interrupt status raw value */
-#define PARAM_SSP_INTSTAT_RAW(n)	((n==SSP_INTSTAT_RAW_ROR) || (n==SSP_INTSTAT_RAW_RT) \
+#define PARAM_SSP_INTSTAT_RAW(n)        ((n==SSP_INTSTAT_RAW_ROR) || (n==SSP_INTSTAT_RAW_RT) \
 || (n==SSP_INTSTAT_RAW_RX) || (n==SSP_INTSTAT_RAW_TX))
 
 /* Macro check interrupt clear mode */
-#define PARAM_SSP_INTCLR(n)	((n==SSP_INTCLR_ROR) || (n==SSP_INTCLR_RT))
+#define PARAM_SSP_INTCLR(n)     ((n==SSP_INTCLR_ROR) || (n==SSP_INTCLR_RT))
 
 /* Macro check DMA mode */
-#define PARAM_SSP_DMA(n)	((n==SSP_DMA_TX) || (n==SSP_DMA_RX))
+#define PARAM_SSP_DMA(n)        ((n==SSP_DMA_TX) || (n==SSP_DMA_RX))
 /**
  * @}
  */
@@ -369,42 +369,42 @@ extern "C"
 
 /** @brief SSP configuration structure */
 typedef struct {
-	uint32_t Databit; 		/** Databit number, should be SSP_DATABIT_x,
-							where x is in range from 4 - 16 */
-	uint32_t CPHA;			/** Clock phase, should be:
-							- SSP_CPHA_FIRST: first clock edge
-							- SSP_CPHA_SECOND: second clock edge */
-	uint32_t CPOL;			/** Clock polarity, should be:
-							- SSP_CPOL_HI: high level
-							- SSP_CPOL_LO: low level */
-	uint32_t Mode;			/** SSP mode, should be:
-							- SSP_MASTER_MODE: Master mode
-							- SSP_SLAVE_MODE: Slave mode */
-	uint32_t FrameFormat;	/** Frame Format:
-							- SSP_FRAME_SPI: Motorola SPI frame format
-							- SSP_FRAME_TI: TI frame format
-							- SSP_FRAME_MICROWIRE: National Microwire frame format */
-	uint32_t ClockRate;		/** Clock rate,in Hz */
+        uint32_t Databit;               /** Databit number, should be SSP_DATABIT_x,
+                                                        where x is in range from 4 - 16 */
+        uint32_t CPHA;                  /** Clock phase, should be:
+                                                        - SSP_CPHA_FIRST: first clock edge
+                                                        - SSP_CPHA_SECOND: second clock edge */
+        uint32_t CPOL;                  /** Clock polarity, should be:
+                                                        - SSP_CPOL_HI: high level
+                                                        - SSP_CPOL_LO: low level */
+        uint32_t Mode;                  /** SSP mode, should be:
+                                                        - SSP_MASTER_MODE: Master mode
+                                                        - SSP_SLAVE_MODE: Slave mode */
+        uint32_t FrameFormat;   /** Frame Format:
+                                                        - SSP_FRAME_SPI: Motorola SPI frame format
+                                                        - SSP_FRAME_TI: TI frame format
+                                                        - SSP_FRAME_MICROWIRE: National Microwire frame format */
+        uint32_t ClockRate;             /** Clock rate,in Hz */
 } SSP_CFG_Type;
 
 /**
  * @brief SSP Transfer Type definitions
  */
 typedef enum {
-	SSP_TRANSFER_POLLING = 0,	/**< Polling transfer */
-	SSP_TRANSFER_INTERRUPT		/**< Interrupt transfer */
+        SSP_TRANSFER_POLLING = 0,       /**< Polling transfer */
+        SSP_TRANSFER_INTERRUPT          /**< Interrupt transfer */
 } SSP_TRANSFER_Type;
 
 /**
  * @brief SPI Data configuration structure definitions
  */
 typedef struct {
-	void *tx_data;				/**< Pointer to transmit data */
-	uint32_t tx_cnt;			/**< Transmit counter */
-	void *rx_data;				/**< Pointer to transmit data */
-	uint32_t rx_cnt;			/**< Receive counter */
-	uint32_t length;			/**< Length of transfer data */
-	uint32_t status;			/**< Current status of SSP activity */
+        void *tx_data;                          /**< Pointer to transmit data */
+        uint32_t tx_cnt;                        /**< Transmit counter */
+        void *rx_data;                          /**< Pointer to transmit data */
+        uint32_t rx_cnt;                        /**< Receive counter */
+        uint32_t length;                        /**< Length of transfer data */
+        uint32_t status;                        /**< Current status of SSP activity */
 } SSP_DATA_SETUP_Type;
 
 
@@ -442,7 +442,7 @@ IntStatus SSP_GetIntStatus (LPC_SSP_TypeDef *SSPx, uint32_t IntType);
 void SSP_SendData(LPC_SSP_TypeDef* SSPx, uint16_t Data);
 uint16_t SSP_ReceiveData(LPC_SSP_TypeDef* SSPx);
 int32_t SSP_ReadWrite (LPC_SSP_TypeDef *SSPx, SSP_DATA_SETUP_Type *dataCfg, \
-						SSP_TRANSFER_Type xfType);
+                                                SSP_TRANSFER_Type xfType);
 
 /* SSP IRQ function ------------------------------------------------------------*/
 void SSP_IntConfig(LPC_SSP_TypeDef *SSPx, uint32_t IntType, FunctionalState NewState);

--- a/bmp/lpc_types.h
+++ b/bmp/lpc_types.h
@@ -1,12 +1,12 @@
 /***********************************************************************//**
- * @file		lpc_types.h
- * @brief		Contains the NXP ABL typedefs for C standard types.
- *     			It is intended to be used in ISO C conforming development
- *     			environments and checks for this insofar as it is possible
- *     			to do so.
- * @version		1.0
- * @date		27 Jul. 2008
- * @author		wellsk
+ * @file                lpc_types.h
+ * @brief               Contains the NXP ABL typedefs for C standard types.
+ *                      It is intended to be used in ISO C conforming development
+ *                      environments and checks for this insofar as it is possible
+ *                      to do so.
+ * @version             1.0
+ * @date                27 Jul. 2008
+ * @author              wellsk
  **************************************************************************
  * Software that is described herein is for illustrative purposes only
  * which provides customers with programming information regarding the
@@ -52,7 +52,7 @@ typedef enum {
 typedef enum {
     RESET = 0, SET = !RESET
 } FlagStatus, IntStatus, SetState;
-#define PARAM_SETSTATE(State)	((State==RESET) || (State==SET))
+#define PARAM_SETSTATE(State)   ((State==RESET) || (State==SET))
 
 /**
  * @brief Functional State Definition
@@ -61,7 +61,7 @@ typedef enum {
     DISABLE = 0,
     ENABLE = !DISABLE
 } FunctionalState;
-#define PARAM_FUNCTIONALSTATE(State)	((State==DISABLE) || (State==ENABLE))
+#define PARAM_FUNCTIONALSTATE(State)    ((State==DISABLE) || (State==ENABLE))
 
 /**
  * @ Status type definition
@@ -76,8 +76,8 @@ typedef enum {
  * Read/Write transfer type mode (Block or non-block)
  */
 typedef enum {
-    NONE_BLOCKING = 0,		/**< None Blocking type */
-    BLOCKING,			/**< Blocking type */
+    NONE_BLOCKING = 0,          /**< None Blocking type */
+    BLOCKING,                   /**< Blocking type */
 } TRANSFER_BLOCK_Type;
 
 
@@ -103,7 +103,7 @@ typedef int32_t(*PFI)();
  */
 #undef _BIT
 /* Set bit macro */
-#define _BIT(n)	(1<<n)
+#define _BIT(n) (1<<n)
 
 /* _SBF(f,v) sets the bit field starting at position "f" to value "v".
  * _SBF(f,v) is intended to be used in "OR" and "AND" expressions:
@@ -128,21 +128,21 @@ typedef int32_t(*PFI)();
  */
 #undef _BITMASK
 /* Bitmask creation macro */
-#define _BITMASK(field_width)	(_BIT(field_width) - 1)
+#define _BITMASK(field_width)   (_BIT(field_width) - 1)
 
 /* NULL pointer */
 #ifndef NULL
-#define NULL	((void*) 0)
+#define NULL    ((void*) 0)
 #endif
 
 /* Number of elements in an array */
-#define NELEMENTS(array)	(sizeof(array) / sizeof(array[0]))
+#define NELEMENTS(array)        (sizeof(array) / sizeof(array[0]))
 
-#define STATIC	static /* Static data/function define */
-#define EXTERN	extern /* External data/function define */
+#define STATIC  static /* Static data/function define */
+#define EXTERN  extern /* External data/function define */
 
-#define MAX(a, b)	(((a) > (b)) ? (a) : (b))
-#define MIN(a, b)	(((a) < (b)) ? (a) : (b))
+#define MAX(a, b)       (((a) > (b)) ? (a) : (b))
+#define MIN(a, b)       (((a) < (b)) ? (a) : (b))
 
 /**
  * @}
@@ -164,16 +164,16 @@ typedef uint8_t UNS_8;
 typedef int8_t INT_8;
 
 /** SMA type for 16 bit unsigned value */
-typedef	uint16_t UNS_16;
+typedef uint16_t UNS_16;
 
 /** SMA type for 16 bit signed value */
-typedef	int16_t INT_16;
+typedef int16_t INT_16;
 
 /** SMA type for 32 bit unsigned value */
-typedef	uint32_t UNS_32;
+typedef uint32_t UNS_32;
 
 /** SMA type for 32 bit signed value */
-typedef	int32_t INT_32;
+typedef int32_t INT_32;
 
 /** SMA type for 64 bit signed value */
 typedef int64_t INT_64;

--- a/include/sark.h
+++ b/include/sark.h
@@ -112,8 +112,8 @@ The APLX buffer lives at the top of ITCM, starting at 0x7fc0
 
 // IPTAG definitions
 
-#define TAG_NONE        255	//!< Invalid tag/transient request
-#define TAG_HOST        0	//!< Reserved for host
+#define TAG_NONE        255     //!< Invalid tag/transient request
+#define TAG_HOST        0       //!< Reserved for host
 
 //------------------------------------------------------------------------------
 
@@ -140,14 +140,14 @@ Allocations of SysCtl Test & Set registers (locks)
 */
 
 enum spin_lock_e {
-    LOCK_MSG,		//!< Msg buffers in SysRAM
-    LOCK_MBOX,		//!< Mailbox flag variable
-    LOCK_ETHER,		//!< Ethernet Tx (unused...)
-    LOCK_GPIO,		//!< GPIO port (unused...)
-    LOCK_API_ROOT,	//!< Spin1 API
-    LOCK_SEMA,		//!< Sema access
-    LOCK_HEAP,		//!< Heap in System / SDRAM
-    LOCK_RTR		//!< Router
+    LOCK_MSG,           //!< Msg buffers in SysRAM
+    LOCK_MBOX,          //!< Mailbox flag variable
+    LOCK_ETHER,         //!< Ethernet Tx (unused...)
+    LOCK_GPIO,          //!< GPIO port (unused...)
+    LOCK_API_ROOT,      //!< Spin1 API
+    LOCK_SEMA,          //!< Sema access
+    LOCK_HEAP,          //!< Heap in System / SDRAM
+    LOCK_RTR            //!< Router
 };
 
 typedef enum spin_lock_e spin_lock; //!< Typedef for enum spin_lock_e
@@ -176,28 +176,28 @@ Run time error codes (passed as first arg to "rt_error")
 */
 
 enum rte_code_e {
-    RTE_NONE,		//!< 0 No error
-    RTE_RESET,		//!< 1 Branch through zero
-    RTE_UNDEF,		//!< 2 Undefined instruction
-    RTE_SVC,		//!< 3 Undefined SVC or no handler
-    RTE_PABT,		//!< 4 Prefetch abort
-    RTE_DABT,		//!< 5 Data abort
-    RTE_IRQ,		//!< 6 Unhandled IRQ
-    RTE_FIQ,		//!< 7 Unhandled FIQ
-    RTE_VIC,		//!< 8 Unconfigured VIC vector
+    RTE_NONE,           //!< 0 No error
+    RTE_RESET,          //!< 1 Branch through zero
+    RTE_UNDEF,          //!< 2 Undefined instruction
+    RTE_SVC,            //!< 3 Undefined SVC or no handler
+    RTE_PABT,           //!< 4 Prefetch abort
+    RTE_DABT,           //!< 5 Data abort
+    RTE_IRQ,            //!< 6 Unhandled IRQ
+    RTE_FIQ,            //!< 7 Unhandled FIQ
+    RTE_VIC,            //!< 8 Unconfigured VIC vector
 
-    RTE_ABORT,		//!< Generic user abort
-    RTE_MALLOC,		//!< "malloc" failure
-    RTE_DIV0,		//!< Divide by zero
-    RTE_EVENT,		//!< Event startup failure
-    RTE_SWERR,		//!< Fatal SW error
-    RTE_IOBUF,		//!< Failed to allocate IO buffer
-    RTE_ENABLE,		//!< Bad event enable
-    RTE_NULL,		//!< Generic null pointer error
-    RTE_PKT,		//!< Pkt startup failure
-    RTE_TIMER,		//!< Timer startup failure
-    RTE_API,		//!< API startup failure
-    RTE_VER		//!< SW version conflict
+    RTE_ABORT,          //!< Generic user abort
+    RTE_MALLOC,         //!< "malloc" failure
+    RTE_DIV0,           //!< Divide by zero
+    RTE_EVENT,          //!< Event startup failure
+    RTE_SWERR,          //!< Fatal SW error
+    RTE_IOBUF,          //!< Failed to allocate IO buffer
+    RTE_ENABLE,         //!< Bad event enable
+    RTE_NULL,           //!< Generic null pointer error
+    RTE_PKT,            //!< Pkt startup failure
+    RTE_TIMER,          //!< Timer startup failure
+    RTE_API,            //!< API startup failure
+    RTE_VER             //!< SW version conflict
 };
 
 typedef enum rte_code_e rte_code;   //!< Typedef for enum rte_code_e
@@ -226,25 +226,25 @@ respond to anything
 */
 
 enum cpu_state_e {
-    CPU_STATE_DEAD,	//!< Dead core
-    CPU_STATE_PWRDN,	//!< Powered down
-    CPU_STATE_RTE,	//!< Died with Run Time Error
-    CPU_STATE_WDOG,	//!< Watchdog expired
+    CPU_STATE_DEAD,     //!< Dead core
+    CPU_STATE_PWRDN,    //!< Powered down
+    CPU_STATE_RTE,      //!< Died with Run Time Error
+    CPU_STATE_WDOG,     //!< Watchdog expired
 
-    CPU_STATE_INIT,	//!< Initialising (transient)
-    CPU_STATE_WAIT,	//!< Ready to execute
-    CPU_STATE_SARK,	//!< Entered c_main
-    CPU_STATE_RUN,	//!< Running (API/Event)
+    CPU_STATE_INIT,     //!< Initialising (transient)
+    CPU_STATE_WAIT,     //!< Ready to execute
+    CPU_STATE_SARK,     //!< Entered c_main
+    CPU_STATE_RUN,      //!< Running (API/Event)
 
-    CPU_STATE_SYNC0,	//!< Waiting for sync 0
-    CPU_STATE_SYNC1,	//!< Waiting for sync 1
-    CPU_STATE_PAUSE,	//!< Paused in application
-    CPU_STATE_EXIT,	//!< Exited application
+    CPU_STATE_SYNC0,    //!< Waiting for sync 0
+    CPU_STATE_SYNC1,    //!< Waiting for sync 1
+    CPU_STATE_PAUSE,    //!< Paused in application
+    CPU_STATE_EXIT,     //!< Exited application
 
-    CPU_STATE_12,	//!< Spare
-    CPU_STATE_13,	//!< Spare
-    CPU_STATE_14,	//!< Spare
-    CPU_STATE_IDLE	//!< Idle (SARK stub)
+    CPU_STATE_12,       //!< Spare
+    CPU_STATE_13,       //!< Spare
+    CPU_STATE_14,       //!< Spare
+    CPU_STATE_IDLE      //!< Idle (SARK stub)
 };
 
 typedef enum cpu_state_e cpu_state; //!< Typedef for enum cpu_state_e
@@ -260,13 +260,13 @@ Types of event
 */
 
 enum event_type_e {
-    EVENT_TIMER,	//!< Timer elapsed
-    EVENT_RXPKT,	//!< MC packet received
-    EVENT_SDP,		//!< SDP packet received
-    EVENT_USER,		//!< User triggered event
-    EVENT_SIG,		//!< Signal from hosts
-    EVENT_DMA,		//!< DMA complete
-    EVENT_MAX=EVENT_DMA	//!< Maximum event number
+    EVENT_TIMER,        //!< Timer elapsed
+    EVENT_RXPKT,        //!< MC packet received
+    EVENT_SDP,          //!< SDP packet received
+    EVENT_USER,         //!< User triggered event
+    EVENT_SIG,          //!< Signal from hosts
+    EVENT_DMA,          //!< DMA complete
+    EVENT_MAX=EVENT_DMA //!< Maximum event number
 };
 
 typedef enum event_type_e event_type;   //!< typedef for enum event_type_e
@@ -282,9 +282,9 @@ State of event execution
 */
 
 enum event_state_e {    // RUN must be first (0)
-    EVENT_RUN,		//!< Running
-    EVENT_PAUSE,	//!< Paused
-    EVENT_STOP		//!< Stopped
+    EVENT_RUN,          //!< Running
+    EVENT_PAUSE,        //!< Paused
+    EVENT_STOP          //!< Stopped
 };
 
 typedef enum event_state_e event_state; //!< typedef for enum event_state_e
@@ -319,9 +319,9 @@ Mode for sw_error calls to decide if rt_error is to be called
 */
 
 enum sw_err_mode_e {
-    SW_OPT,		//!< Optional, controlled by sark.sw_rte
-    SW_NEVER,		//!< Never call rt_error
-    SW_RTE		//!< Always call rt_error
+    SW_OPT,             //!< Optional, controlled by sark.sw_rte
+    SW_NEVER,           //!< Never call rt_error
+    SW_RTE              //!< Always call rt_error
 };
 
 typedef enum sw_err_mode_e sw_err_mode; //!< Typedef for enum sw_err_mode_e
@@ -331,8 +331,8 @@ Startup syncronisation bool
 */
 
 enum sync_bool_e {
-    SYNC_NOWAIT,	//!< Don't wait
-    SYNC_WAIT		//!< Wait for synchronisation
+    SYNC_NOWAIT,        //!< Don't wait
+    SYNC_WAIT           //!< Wait for synchronisation
 };
 
 typedef enum sync_bool_e sync_bool; //!< Typedef for enum sync_bool_e
@@ -353,11 +353,11 @@ Mailbox commands passed to APs
 */
 
 enum shm_cmd_e {
-    SHM_IDLE,		//!< Idle state of mailbox
-    SHM_MSG,		//!< Passing SDP message
-    SHM_NOP,		//!< Does nothing...
-    SHM_SIGNAL,		//!< Signal application
-    SHM_CMD		//!< Command to MP
+    SHM_IDLE,           //!< Idle state of mailbox
+    SHM_MSG,            //!< Passing SDP message
+    SHM_NOP,            //!< Does nothing...
+    SHM_SIGNAL,         //!< Signal application
+    SHM_CMD             //!< Command to MP
 };
 
 typedef enum shm_cmd_e shm_cmd; //!< Typedef for enum shm_cmd_e
@@ -369,23 +369,23 @@ Signals passed to applications
 */
 
 enum signal_e {
-    SIG_INIT,		//!< Initialise cores
-    SIG_PWRDN,		//!< Powerdown cores
-    SIG_STOP,		//!< Stop application and clean up
-    SIG_START,		//!< Start application if waiting
+    SIG_INIT,           //!< Initialise cores
+    SIG_PWRDN,          //!< Powerdown cores
+    SIG_STOP,           //!< Stop application and clean up
+    SIG_START,          //!< Start application if waiting
 
-    SIG_SYNC0,		//!< Synchronisation barrier 0
-    SIG_SYNC1,		//!< Synchronisation barrier 1
-    SIG_PAUSE,		//!< Pause application
-    SIG_CONT,		//!< Continue application
+    SIG_SYNC0,          //!< Synchronisation barrier 0
+    SIG_SYNC1,          //!< Synchronisation barrier 1
+    SIG_PAUSE,          //!< Pause application
+    SIG_CONT,           //!< Continue application
 
-    SIG_EXIT,		//!< Terminate application
-    SIG_TIMER,		//!< Trigger timer for application
-    SIG_USR0,		//!< Send user signal 0
-    SIG_USR1,		//!< Send user signal 1
+    SIG_EXIT,           //!< Terminate application
+    SIG_TIMER,          //!< Trigger timer for application
+    SIG_USR0,           //!< Send user signal 0
+    SIG_USR1,           //!< Send user signal 1
 
-    SIG_USR2,		//!< Send user signal 2
-    SIG_USR3,		//!< Send user signal 3
+    SIG_USR2,           //!< Send user signal 2
+    SIG_USR3,           //!< Send user signal 3
 };
 
 typedef enum signal_e signal;   //!< Typedef for enum signal_e
@@ -469,8 +469,8 @@ Returned (div, mod) from divmod
 */
 
 typedef struct divmod {
-    uint div;		//!< Dividend
-    uint mod;		//!< Modulus
+    uint div;           //!< Dividend
+    uint mod;           //!< Modulus
 } divmod_t;
 
 /*!
@@ -478,7 +478,7 @@ Used in the block memory allocator (4 bytes)
 */
 
 typedef struct mem_link {
-    struct mem_link *next;	//!< Pointer to next free block
+    struct mem_link *next;      //!< Pointer to next free block
 } mem_link_t;
 
 /*!
@@ -486,9 +486,9 @@ Used in the block memory allocator (8 bytes)
 */
 
 typedef struct mem_block {
-    mem_link_t *free;	//!< Pointer to first free block
-    ushort count;	//!< Count of blocks in use
-    ushort max;		//!< Maximum blocks used
+    mem_link_t *free;   //!< Pointer to first free block
+    ushort count;       //!< Count of blocks in use
+    ushort max;         //!< Maximum blocks used
 } mem_block_t;
 
 
@@ -497,15 +497,15 @@ Contents of SV SROM area (32 bytes)
 */
 
 typedef struct srom_data {
-    ushort flags;	//!< 16 bit flags
-    uchar  mac_addr[6];	//!< MAC address
-    uchar  ip_addr[4];	//!< IP address
-    uchar  gw_addr[4];	//!< Gateway address
-    uchar  net_mask[4];	//!< Net mask
-    ushort udp_port;	//!< UDP port for SDP messages
-    ushort __PAD1;	//!< Spare...
-    uint   __PAD2;	//!< Spare...
-    uint   __PAD3;	//!< Spare...
+    ushort flags;       //!< 16 bit flags
+    uchar  mac_addr[6]; //!< MAC address
+    uchar  ip_addr[4];  //!< IP address
+    uchar  gw_addr[4];  //!< Gateway address
+    uchar  net_mask[4]; //!< Net mask
+    ushort udp_port;    //!< UDP port for SDP messages
+    ushort __PAD1;      //!< Spare...
+    uint   __PAD2;      //!< Spare...
+    uint   __PAD3;      //!< Spare...
 } srom_data_t;
 
 /*!
@@ -513,11 +513,11 @@ Copy of router entry (16 bytes)
 */
 
 typedef struct rtr_entry {
-    ushort next;	//!< Index of next block
-    ushort free;	//!< Index of next free block (or app_id)
-    uint route;		//!< Route word
-    uint key;		//!< Key word
-    uint mask;		//!< Mask word
+    ushort next;        //!< Index of next block
+    ushort free;        //!< Index of next free block (or app_id)
+    uint route;         //!< Route word
+    uint key;           //!< Key word
+    uint mask;          //!< Mask word
 } rtr_entry_t;
 
 /*!
@@ -526,11 +526,11 @@ is not in use.
 */
 
 typedef struct app_data {
-    uchar cores;	//!< Number of cores using this ID
-    uchar clean;	//!< Set if this ID has been cleaned
-    uchar sema;		//!< Semaphore
-    uchar lead;		//!< Lead core number
-    uint mask;		//!< Mask of cores using this ID
+    uchar cores;        //!< Number of cores using this ID
+    uchar clean;        //!< Set if this ID has been cleaned
+    uchar sema;         //!< Semaphore
+    uchar lead;         //!< Lead core number
+    uint mask;          //!< Mask of cores using this ID
 } app_data_t;
 
 
@@ -538,14 +538,14 @@ typedef struct app_data {
 
 // SDP messages
 
-#define NUM_SDP_PORTS	8	//!< Number of SDP ports (0-7)
-#define PORT_SHIFT      5	//!< Port is in top 3 bits
-#define PORT_MASK       0xe0	//!< Port is in top 3 bits
-#define CPU_MASK        0x1f	//!< CPU is in bottom 5 bits
+#define NUM_SDP_PORTS   8       //!< Number of SDP ports (0-7)
+#define PORT_SHIFT      5       //!< Port is in top 3 bits
+#define PORT_MASK       0xe0    //!< Port is in top 3 bits
+#define CPU_MASK        0x1f    //!< CPU is in bottom 5 bits
 
-#define PORT_ETH        255	//!< Special to indicate Ethernet
+#define PORT_ETH        255     //!< Special to indicate Ethernet
 
-#define SDP_BUF_SIZE    256	//!< SDP data buffer capacity
+#define SDP_BUF_SIZE    256     //!< SDP data buffer capacity
 
 /*!
 SDP message definition
@@ -554,39 +554,39 @@ checksum. It will be a minimum of 8 as the SDP header should always
 be present.
 */
 
-typedef struct sdp_msg {	// SDP message - 292 bytes
-    struct sdp_msg *next;	//!< Next in free list
-    ushort length;		//!< length
-    ushort checksum;		//!< checksum (if used)
+typedef struct sdp_msg {        // SDP message - 292 bytes
+    struct sdp_msg *next;       //!< Next in free list
+    ushort length;              //!< length
+    ushort checksum;            //!< checksum (if used)
 
     // sdp_hdr_t (mandatory)
 
-    uchar flags;		//!< Flag byte
-    uchar tag;			//!< IP tag
-    uchar dest_port;		//!< Destination port/CPU
-    uchar srce_port;		//!< Source port/CPU
-    ushort dest_addr;		//!< Destination address
-    ushort srce_addr;		//!< Source address
+    uchar flags;                //!< Flag byte
+    uchar tag;                  //!< IP tag
+    uchar dest_port;            //!< Destination port/CPU
+    uchar srce_port;            //!< Source port/CPU
+    ushort dest_addr;           //!< Destination address
+    ushort srce_addr;           //!< Source address
 
     // cmd_hdr_t (optional)
 
-    ushort cmd_rc;		//!< Command/Return Code
-    ushort seq;			//!< Sequence number
-    uint arg1;			//!< Arg 1
-    uint arg2;			//!< Arg 2
-    uint arg3;			//!< Arg 3
+    ushort cmd_rc;              //!< Command/Return Code
+    ushort seq;                 //!< Sequence number
+    uint arg1;                  //!< Arg 1
+    uint arg2;                  //!< Arg 2
+    uint arg3;                  //!< Arg 3
 
     // user data (optional)
 
-    uchar data[SDP_BUF_SIZE];	//!< User data (256 bytes)
+    uchar data[SDP_BUF_SIZE];   //!< User data (256 bytes)
 
-    uint __PAD1;		//!< Private padding
+    uint __PAD1;                //!< Private padding
 } sdp_msg_t;
 
 
 // Legacy definitions...
 
-typedef struct sdp_hdr {	// SDP header
+typedef struct sdp_hdr {        // SDP header
     uchar flags;
     uchar tag;
     uchar dest_port;
@@ -595,7 +595,7 @@ typedef struct sdp_hdr {	// SDP header
     ushort srce_addr;
 } sdp_hdr_t;
 
-typedef struct cmd_hdr {	// Command header
+typedef struct cmd_hdr {        // Command header
     ushort cmd_rc;
     ushort flags;
     uint arg1;
@@ -614,8 +614,8 @@ requires N+8
 */
 
 typedef struct block {
-    struct block *next;		//!< Chains all blocks together (in address order)
-    struct block *free;		//!< Chains free blocks together (in address order)
+    struct block *next;         //!< Chains all blocks together (in address order)
+    struct block *free;         //!< Chains free blocks together (in address order)
 } block_t;
 
 /*!
@@ -627,11 +627,11 @@ end of the heap.
 */
 
 typedef struct {
-    block_t *free;		//!< Root of free block chain
-    block_t *first;		//!< First block
-    block_t *last;		//!< Last block (zero size, never used for storage)
-    uint free_bytes;		//!< Number of free bytes left
-    uchar buffer[];		//!< Buffer for blocks
+    block_t *free;              //!< Root of free block chain
+    block_t *first;             //!< First block
+    block_t *last;              //!< Last block (zero size, never used for storage)
+    uint free_bytes;            //!< Number of free bytes left
+    uchar buffer[];             //!< Buffer for blocks
 } heap_t;
 
 
@@ -647,9 +647,9 @@ therefore constrained to live in the bottom 64K of the address space
 */
 
 typedef struct event_vec {
-    ushort proc;		//!< Handler address (squeezed into 16 bits!)
-    uchar slot;			//!< VIC slot
-    uchar priority;		//!< Priority for queued events
+    ushort proc;                //!< Handler address (squeezed into 16 bits!)
+    uchar slot;                 //!< VIC slot
+    uchar priority;             //!< Priority for queued events
 } event_vec_t;
 
 /*!
@@ -660,34 +660,34 @@ point during start-up
 */
 
 typedef struct sark_vec {
-    int_handler reset_vec;	//!< 0x20 Reset vector
-    int_handler undef_vec;	//!< 0x24 Undefined instruction vector
-    int_handler svc_vec;	//!< 0x28 SVC vector
-    int_handler pabt_vec;	//!< 0x2c Prefetch abort vector
-    int_handler dabt_vec;	//!< 0x30 Data abort vector
-    int_handler aplx_proc;	//!< 0x34 Pointer to "proc_aplx"
-    int_handler irq_vec;	//!< 0x38 IRQ vector
-    int_handler fiq_vec;	//!< 0x3c FIQ vector
+    int_handler reset_vec;      //!< 0x20 Reset vector
+    int_handler undef_vec;      //!< 0x24 Undefined instruction vector
+    int_handler svc_vec;        //!< 0x28 SVC vector
+    int_handler pabt_vec;       //!< 0x2c Prefetch abort vector
+    int_handler dabt_vec;       //!< 0x30 Data abort vector
+    int_handler aplx_proc;      //!< 0x34 Pointer to "proc_aplx"
+    int_handler irq_vec;        //!< 0x38 IRQ vector
+    int_handler fiq_vec;        //!< 0x3c FIQ vector
 
-    ushort svc_stack;		//!< 0x40 SVC stack size (words)
-    ushort irq_stack;		//!< 0x42 IRQ stack size (words)
-    ushort fiq_stack;		//!< 0x44 FIQ stack size (words)
-    ushort stack_size;		//!< 0x46 Total stack size (bytes)
+    ushort svc_stack;           //!< 0x40 SVC stack size (words)
+    ushort irq_stack;           //!< 0x42 IRQ stack size (words)
+    ushort fiq_stack;           //!< 0x44 FIQ stack size (words)
+    ushort stack_size;          //!< 0x46 Total stack size (bytes)
 
-    uint *code_top;		//!< 0x48 Points to top of code
-    uint *heap_base;		//!< 0x4c Points to base of heap
-    uint *stack_top;		//!< 0x50 Points to top of stacks
+    uint *code_top;             //!< 0x48 Points to top of code
+    uint *heap_base;            //!< 0x4c Points to base of heap
+    uint *stack_top;            //!< 0x50 Points to top of stacks
 
-    uint stack_fill;		//!< 0x54 Stack fill word
+    uint stack_fill;            //!< 0x54 Stack fill word
 
-    uchar num_msgs;		//!< 0x58 Number of SDP msgs buffers
-    uchar sark_slot;		//!< 0x59 VIC slot for MP->AP interrupt
+    uchar num_msgs;             //!< 0x58 Number of SDP msgs buffers
+    uchar sark_slot;            //!< 0x59 VIC slot for MP->AP interrupt
 
-    uchar num_events;		//!< 0x5a Number of initial events
-    uchar api;			//!< 0x5b API active
-    uchar app_id;		//!< 0x5c App ID
-    volatile uchar app_flags;	//!< 0x5d App flags
-    ushort __PAD;		//!< 0x5e Pad
+    uchar num_events;           //!< 0x5a Number of initial events
+    uchar api;                  //!< 0x5b API active
+    uchar app_id;               //!< 0x5c App ID
+    volatile uchar app_flags;   //!< 0x5d App flags
+    ushort __PAD;               //!< 0x5e Pad
 
     event_vec_t event[EVENT_COUNT]; //!< 0x60 Event vectors...
 } sark_vec_t;
@@ -706,40 +706,40 @@ NUM_CPU of these is based at SV_VCPU in System RAM and pointed to by
 "sv_vcpu"
 */
 
-typedef struct vcpu {		// 128 bytes
-    uint r[8];			//!<  0 - r0-r7
-    uint psr;			//!< 32 - cpsr
-    uint sp;			//!< 36 - sp
-    uint lr;			//!< 40 - lr
-    uchar rt_code;		//!< 44 - RT error code
-    uchar phys_cpu;		//!< 45 - Physical CPU
-    uchar cpu_state;		//!< 46 - CPU state
-    uchar app_id;		//!< 47 - Application ID
-    void *mbox_ap_msg;		//!< 48 - mbox msg MP->AP
-    void *mbox_mp_msg;		//!< 52 - mbox msg AP->MP
-    volatile uchar mbox_ap_cmd;	//!< 56 - mbox command MP->AP
-    volatile uchar mbox_mp_cmd;	//!< 57 - mbox command AP->MP
-    ushort sw_count;		//!< 58 - SW error count (saturating)
-    char *sw_file;		//!< 60 - SW source file name
-    uint sw_line;		//!< 64 - SW source line (could be short?)
-    uint time;			//!< 68 - Time of loading
-    char app_name[16];		//!< 72 - Application name
-    void *iobuf;		//!< 88 - IO buffer in SDRAM (or 0)
-    uint sw_ver;		//!< 92 - SW version
-    uint __PAD[4];		//!< 96 - (spare)
-    uint user0;			//!< 112 - User word 0
-    uint user1;			//!< 116 - User word 1
-    uint user2;			//!< 120 - User word 2
-    uint user3;			//!< 124 - User word 3
+typedef struct vcpu {           // 128 bytes
+    uint r[8];                  //!<  0 - r0-r7
+    uint psr;                   //!< 32 - cpsr
+    uint sp;                    //!< 36 - sp
+    uint lr;                    //!< 40 - lr
+    uchar rt_code;              //!< 44 - RT error code
+    uchar phys_cpu;             //!< 45 - Physical CPU
+    uchar cpu_state;            //!< 46 - CPU state
+    uchar app_id;               //!< 47 - Application ID
+    void *mbox_ap_msg;          //!< 48 - mbox msg MP->AP
+    void *mbox_mp_msg;          //!< 52 - mbox msg AP->MP
+    volatile uchar mbox_ap_cmd; //!< 56 - mbox command MP->AP
+    volatile uchar mbox_mp_cmd; //!< 57 - mbox command AP->MP
+    ushort sw_count;            //!< 58 - SW error count (saturating)
+    char *sw_file;              //!< 60 - SW source file name
+    uint sw_line;               //!< 64 - SW source line (could be short?)
+    uint time;                  //!< 68 - Time of loading
+    char app_name[16];          //!< 72 - Application name
+    void *iobuf;                //!< 88 - IO buffer in SDRAM (or 0)
+    uint sw_ver;                //!< 92 - SW version
+    uint __PAD[4];              //!< 96 - (spare)
+    uint user0;                 //!< 112 - User word 0
+    uint user1;                 //!< 116 - User word 1
+    uint user2;                 //!< 120 - User word 2
+    uint user3;                 //!< 124 - User word 3
 } vcpu_t;
 
 
 // For "sark_alib.s" (maintain sync with vcpu_t)
 
-#define VCPU_SIZE	128	//!< Size of vcpu_t
-#define VCPU_RT_CODE	44	//!< Offset of rt_code
-#define VCPU_CPU_STATE	46	//!< Offset of cpu_state
-#define VCPU_APP_ID	47	//!< Offset of app_id
+#define VCPU_SIZE       128     //!< Size of vcpu_t
+#define VCPU_RT_CODE    44      //!< Offset of rt_code
+#define VCPU_CPU_STATE  46      //!< Offset of cpu_state
+#define VCPU_APP_ID     47      //!< Offset of app_id
 
 //------------------------------------------------------------------------------
 
@@ -762,15 +762,15 @@ events which have to occur at a particular time or on a set of
 priority ordered queues for events which are processed by a scheduler.
 */
 
-typedef struct event {		// 24 bytes
-    struct event *next;		//!< Next in Q or NULL
+typedef struct event {          // 24 bytes
+    struct event *next;         //!< Next in Q or NULL
 
-    event_proc proc;		//!< Proc to be called or NULL
-    uint arg1;			//!< First arg to proc
-    uint arg2;			//!< Second arg to proc
-    uint time;			//!< Time (CPU ticks) until event due
-				//!< (or 0 if at head of Q)
-    uint ID;			//!< Unique ID for active event (0 if inactive)
+    event_proc proc;            //!< Proc to be called or NULL
+    uint arg1;                  //!< First arg to proc
+    uint arg2;                  //!< Second arg to proc
+    uint time;                  //!< Time (CPU ticks) until event due
+                                //!< (or 0 if at head of Q)
+    uint ID;                    //!< Unique ID for active event (0 if inactive)
 } event_t;
 
 /*!
@@ -778,8 +778,8 @@ Struct holding head and tail of a list of "event_t"
 */
 
 typedef struct proc_queue {
-    event_t *proc_head;		//!< List of queued "proc" events
-    event_t *proc_tail;		//!< and tail of that list
+    event_t *proc_head;         //!< List of queued "proc" events
+    event_t *proc_tail;         //!< and tail of that list
 } proc_queue_t;
 
 /*!
@@ -787,9 +787,9 @@ Struct holding a packet
 */
 
 typedef struct pkt {
-    uint ctrl;			//!< TCR in 23:16, flags in 1:0
-    uint data;			//!< Data (payload) field
-    uint key;			//!< Key (non-payload!) field
+    uint ctrl;                  //!< TCR in 23:16, flags in 1:0
+    uint data;                  //!< Data (payload) field
+    uint key;                   //!< Key (non-payload!) field
 } pkt_t;
 
 /*!
@@ -798,48 +798,48 @@ holds all the variables needed by these two packages.
 */
 
 typedef struct event_data {
-    event_t *free;		//!< List of free events
-    event_t *timer_queue;	//!< List of active timer events
+    event_t *free;              //!< List of free events
+    event_t *timer_queue;       //!< List of active timer events
 
-    ushort count;		//!< Number of events currently in use
-    ushort max;			//!< Maximum number ever used
-    uint id;			//!< Holds unique ID for active events
+    ushort count;               //!< Number of events currently in use
+    ushort max;                 //!< Maximum number ever used
+    uint id;                    //!< Holds unique ID for active events
 
-    uint failed;		//!< Counts failures of event_new
-    uint rc;			//!< Failure codes
+    uint failed;                //!< Counts failures of event_new
+    uint rc;                    //!< Failure codes
 
-    volatile uchar state;	//!< Stop/pauses event loop
-    uchar __PAD1;		//!< (Spare)
-    uchar wait;			//!< Wait state
-    uchar user;			//!< Non-zero if user event pending
+    volatile uchar state;       //!< Stop/pauses event loop
+    uchar __PAD1;               //!< (Spare)
+    uchar wait;                 //!< Wait state
+    uchar user;                 //!< Non-zero if user event pending
 
-    uint ticks;			//!< Timer tick counter
-    uint arg1;			//!< Arg1 for user event
-    uint arg2;			//!< Arg2 for user event
+    uint ticks;                 //!< Timer tick counter
+    uint arg1;                  //!< Arg1 for user event
+    uint arg2;                  //!< Arg2 for user event
 
-    sdp_msg_t *msg;		//!< Passes msg from SARK to app
-    uint signal;		//!< Passes signal from SARK to app
+    sdp_msg_t *msg;             //!< Passes msg from SARK to app
+    uint signal;                //!< Passes signal from SARK to app
 
-    event_proc pause_proc;	//!< Called on pause
-    uint pause_arg2;		//!< Arg2 to pause_proc (arg1 is pause)
+    event_proc pause_proc;      //!< Called on pause
+    uint pause_arg2;            //!< Arg2 to pause_proc (arg1 is pause)
 
-    uint exit_rc;		//!< Return value from "event_start"
+    uint exit_rc;               //!< Return value from "event_start"
 
-    uchar pkt_insert;		//!< Insert point for packet queue
-    uchar pkt_remove;		//!< Remove point for packet queue
-    volatile uchar pkt_count;	//!< Count of items in packet queue
-    uchar __PAD2;		//!< (Spare)
-    ushort pkt_size;		//!< Size of packet queue (<= 256)
-    ushort pkt_max;		//!< Max occupancy of packet queue
-    pkt_t *pkt_queue;		//!< Pointer to packet queue
+    uchar pkt_insert;           //!< Insert point for packet queue
+    uchar pkt_remove;           //!< Remove point for packet queue
+    volatile uchar pkt_count;   //!< Count of items in packet queue
+    uchar __PAD2;               //!< (Spare)
+    ushort pkt_size;            //!< Size of packet queue (<= 256)
+    ushort pkt_max;             //!< Max occupancy of packet queue
+    pkt_t *pkt_queue;           //!< Pointer to packet queue
 
-    uint vic_select;		//!< Builds VIC IRQ/FIQ select word
-    uint vic_enable;		//!< Builds VIC interrupt enable word
-    uint old_select;		//!< Keeps old state of vic_select
-    uint old_enable;		//!< Keeps old state of vic_enable
+    uint vic_select;            //!< Builds VIC IRQ/FIQ select word
+    uint vic_enable;            //!< Builds VIC interrupt enable word
+    uint old_select;            //!< Keeps old state of vic_select
+    uint old_enable;            //!< Keeps old state of vic_enable
 
-    int_handler fiq_vector;	//!< New FIQ vector (or 0)
-    int_handler old_vector;	//!< Old FIQ vector
+    int_handler fiq_vector;     //!< New FIQ vector (or 0)
+    int_handler old_vector;     //!< Old FIQ vector
 
     int_handler vic_addr[EVENT_COUNT]; //!< Record of handler for each event
 
@@ -855,27 +855,27 @@ A struct holding all of the variables maintained by SARK
 */
 
 typedef struct sark_data {
-    uint virt_cpu;		//!< 00 Virtual CPU number
-    uint phys_cpu;		//!< 04 Physical CPU number
+    uint virt_cpu;              //!< 00 Virtual CPU number
+    uint phys_cpu;              //!< 04 Physical CPU number
 
-    uint random[2];		//!< 08 Random number variable
+    uint random[2];             //!< 08 Random number variable
 
-    uint *stack_base;		//!< 10 Bottom of stack area (& heap limit)
-    uint *heap_base;		//!< 14 Bottom of heap area
-    heap_t *heap;		//!< 18 Heap in DTCM
+    uint *stack_base;           //!< 10 Bottom of stack area (& heap limit)
+    uint *heap_base;            //!< 14 Bottom of heap area
+    heap_t *heap;               //!< 18 Heap in DTCM
 
-    vcpu_t *vcpu;		//!< 1c Pointer to VCPU block
+    vcpu_t *vcpu;               //!< 1c Pointer to VCPU block
 
-    mem_block_t msg_root;	//!< 20 Control block for SDP messages
+    mem_block_t msg_root;       //!< 20 Control block for SDP messages
 
-    uint msg_rcvd;		//!< 28 Numbers of msgs received
-    uint msg_sent;		//!< 2c Numbers of msgs sent
+    uint msg_rcvd;              //!< 28 Numbers of msgs received
+    uint msg_sent;              //!< 2c Numbers of msgs sent
 
-    ushort cpu_clk;		//!< 30 CPU clock speed (MHz)
-    uchar sw_rte;		//!< 32 Set to 1 for SW error calls rt_error
-    uchar __PAD1;		//!< 33
-    void *sdram_buf;		//!< 34 Pointer to SDRAM buffer
-    uint pkt_count;		//!< 38 Count of thrown packets
+    ushort cpu_clk;             //!< 30 CPU clock speed (MHz)
+    uchar sw_rte;               //!< 32 Set to 1 for SW error calls rt_error
+    uchar __PAD1;               //!< 33
+    void *sdram_buf;            //!< 34 Pointer to SDRAM buffer
+    uint pkt_count;             //!< 38 Count of thrown packets
 } sark_data_t;
 
 //
@@ -951,102 +951,102 @@ RAM at 0xe5007f00
 */
 
 typedef struct sv {
-    ushort p2p_addr;		//!< 00 P2P address of this chip
-    ushort p2p_dims;		//!< 02 P2P dimensions
+    ushort p2p_addr;            //!< 00 P2P address of this chip
+    ushort p2p_dims;            //!< 02 P2P dimensions
 
-    ushort dbg_addr;		//!< 04 P2P address for debug messages
-    uchar  p2p_up;		//!< 06 Non-zero if P2P networking active
-    uchar  last_id;		//!< 07 Last ID used in NNBC
+    ushort dbg_addr;            //!< 04 P2P address for debug messages
+    uchar  p2p_up;              //!< 06 Non-zero if P2P networking active
+    uchar  last_id;             //!< 07 Last ID used in NNBC
 
-    ushort eth_addr;		//!< 08 P2P address of nearest Ethernet node
-    uchar hw_ver;		//!< 0a Hardware version
-    uchar eth_up;		//!< 0b Non-zero if Ethernet active
+    ushort eth_addr;            //!< 08 P2P address of nearest Ethernet node
+    uchar hw_ver;               //!< 0a Hardware version
+    uchar eth_up;               //!< 0b Non-zero if Ethernet active
 
-    uchar p2pb_repeats;		//!< 0c Number of times to send out P2PB packets
-    uchar p2p_sql;		//!< 0d P2P sequence length (**)
-    uchar clk_div;		//!< 0e Clock divisors for system & router bus
-    uchar tp_scale;		//!< 0f Scale for router phase timer
+    uchar p2pb_repeats;         //!< 0c Number of times to send out P2PB packets
+    uchar p2p_sql;              //!< 0d P2P sequence length (**)
+    uchar clk_div;              //!< 0e Clock divisors for system & router bus
+    uchar tp_scale;             //!< 0f Scale for router phase timer
 
-    volatile uint64 clock_ms;	//!< 10 Milliseconds since boot
-    volatile ushort time_ms;	//!< 18 Milliseconds in second (0..999)
-    ushort ltpc_period;		//!< 1a
+    volatile uint64 clock_ms;   //!< 10 Milliseconds since boot
+    volatile ushort time_ms;    //!< 18 Milliseconds in second (0..999)
+    ushort ltpc_period;         //!< 1a
 
-    volatile uint unix_time;	//!< 1c Seconds since 1970
-    uint tp_timer;		//!< 20 Router time phase timer
+    volatile uint unix_time;    //!< 1c Seconds since 1970
+    uint tp_timer;              //!< 20 Router time phase timer
 
-    ushort cpu_clk;		//!< 24 CPU clock in MHz
-    ushort mem_clk;		//!< 26 SDRAM clock in MHz
+    ushort cpu_clk;             //!< 24 CPU clock in MHz
+    ushort mem_clk;             //!< 26 SDRAM clock in MHz
 
-    uchar forward;		//!< 28 NNBC forward parameter
-    uchar retry;		//!< 29 NNBC retry parameter
-    uchar peek_time;		//!< 2a Timeout for link read/write (us)
-    uchar led_period;		//!< 2b LED flash period (* 10 ms)
+    uchar forward;              //!< 28 NNBC forward parameter
+    uchar retry;                //!< 29 NNBC retry parameter
+    uchar peek_time;            //!< 2a Timeout for link read/write (us)
+    uchar led_period;           //!< 2b LED flash period (* 10 ms)
 
-    uchar netinit_bc_wait;	//!< 2c Minimum time after last BC during netinit (*10 ms)
-    uchar netinit_phase;	//!< 2d Phase of boot process
-    ushort p2p_root;		//!< 2e The P2P address from which the system was booted
+    uchar netinit_bc_wait;      //!< 2c Minimum time after last BC during netinit (*10 ms)
+    uchar netinit_phase;        //!< 2d Phase of boot process
+    ushort p2p_root;            //!< 2e The P2P address from which the system was booted
 
-    uint led0;			//!< 30 LED definition words (for up
-    uint led1;			//!< 34 to 15 LEDs)
-    uint __PAD2;		//!< 38
-    uint random;		//!< 3c Random number seed
+    uint led0;                  //!< 30 LED definition words (for up
+    uint led1;                  //!< 34 to 15 LEDs)
+    uint __PAD2;                //!< 38
+    uint random;                //!< 3c Random number seed
 
-    uchar root_chip;		//!< 40 Set if we are the root chip
-    uchar num_buf;		//!< 41 Number of SHM buffers
-    uchar boot_delay;		//!< 42 Delay between boot NN pkts (us)
-    uchar soft_wdog;		//!< 43 Soft watchdog control
+    uchar root_chip;            //!< 40 Set if we are the root chip
+    uchar num_buf;              //!< 41 Number of SHM buffers
+    uchar boot_delay;           //!< 42 Delay between boot NN pkts (us)
+    uchar soft_wdog;            //!< 43 Soft watchdog control
 
-    uint __PAD3;		//!< 44
+    uint __PAD3;                //!< 44
 
-    heap_t *sysram_heap;	//!< 48 Heap in SysRAM
-    heap_t *sdram_heap;		//!< 4c Heap in SDRAM
+    heap_t *sysram_heap;        //!< 48 Heap in SysRAM
+    heap_t *sdram_heap;         //!< 4c Heap in SDRAM
 
-    uint iobuf_size;		//!< 50 Size of IO buffers (bytes)
-    uint *sdram_bufs;		//!< 54 SDRAM buffers
-    uint sysbuf_size;		//!< 58 Size of system buffers (words)
-    uint boot_sig;		//!< 5c Boot signature word
+    uint iobuf_size;            //!< 50 Size of IO buffers (bytes)
+    uint *sdram_bufs;           //!< 54 SDRAM buffers
+    uint sysbuf_size;           //!< 58 Size of system buffers (words)
+    uint boot_sig;              //!< 5c Boot signature word
 
-    uint mem_ptr;		//!< 60 Memory pointer for NNBC memory setter
+    uint mem_ptr;               //!< 60 Memory pointer for NNBC memory setter
 
-    volatile uchar lock;	//!< 64 Lock variable
-    uchar link_en;		//!< 65 Bit map of enabled links
-    uchar last_biff_id;		//!< 66 Last ID used in BIFF
-    uchar bt_flags;		//!< 67 Board Test flags
+    volatile uchar lock;        //!< 64 Lock variable
+    uchar link_en;              //!< 65 Bit map of enabled links
+    uchar last_biff_id;         //!< 66 Last ID used in BIFF
+    uchar bt_flags;             //!< 67 Board Test flags
 
-    mem_block_t shm_root;	//!< 68 Control block for SHM bufs
+    mem_block_t shm_root;       //!< 68 Control block for SHM bufs
 
-    uint utmp0;			//!< 70 Four temps...
-    uint utmp1;			//!< 74
-    uint utmp2;			//!< 78
-    uint utmp3;			//!< 7c
+    uint utmp0;                 //!< 70 Four temps...
+    uint utmp1;                 //!< 74
+    uint utmp2;                 //!< 78
+    uint utmp3;                 //!< 7c
 
-    uchar status_map[20];	//!< 80 Set during SC&MP ROM boot
-    uchar p2v_map[20];		//!< 94 Phys to Virt core map
-    uchar v2p_map[20];		//!< a8 Virt to Phys core map
+    uchar status_map[20];       //!< 80 Set during SC&MP ROM boot
+    uchar p2v_map[20];          //!< 94 Phys to Virt core map
+    uchar v2p_map[20];          //!< a8 Virt to Phys core map
 
-    uchar num_cpus;		//!< bc Number of good cores
-    uchar rom_cpus;		//!< bd SC&MP ROM good cores
-    ushort board_addr;		//!< be Position of chip on PCB
+    uchar num_cpus;             //!< bc Number of good cores
+    uchar rom_cpus;             //!< bd SC&MP ROM good cores
+    ushort board_addr;          //!< be Position of chip on PCB
 
-    uint *sdram_base;		//!< c0 Base of user SDRAM
-    uint *sysram_base;		//!< c4 Base of user SysRAM
-    uint *sdram_sys;		//!< c8 System SDRAM
-    vcpu_t *vcpu_base;		//!< cc Start of VCPU blocks
+    uint *sdram_base;           //!< c0 Base of user SDRAM
+    uint *sysram_base;          //!< c4 Base of user SysRAM
+    uint *sdram_sys;            //!< c8 System SDRAM
+    vcpu_t *vcpu_base;          //!< cc Start of VCPU blocks
 
-    heap_t *sys_heap;		//!< d0 System heap in SDRAM
-    rtr_entry_t *rtr_copy;	//!< d4 Copy of router MC tables
-    uint *hop_table;		//!< d8 P2P hop table
-    block_t** alloc_tag;	//!< dc Start of alloc_tag table
-    ushort rtr_free;		//!< e0 Start of free router entry list
-    ushort p2p_active;		//!< e2 Count of active P2P addresses
-    app_data_t *app_data;	//!< e4 Array of app_id structs
-    sdp_msg_t *shm_buf;		//!< e8 SHM buffers
-    uint mbox_flags;		//!< ec AP->MP communication flags
+    heap_t *sys_heap;           //!< d0 System heap in SDRAM
+    rtr_entry_t *rtr_copy;      //!< d4 Copy of router MC tables
+    uint *hop_table;            //!< d8 P2P hop table
+    block_t** alloc_tag;        //!< dc Start of alloc_tag table
+    ushort rtr_free;            //!< e0 Start of free router entry list
+    ushort p2p_active;          //!< e2 Count of active P2P addresses
+    app_data_t *app_data;       //!< e4 Array of app_id structs
+    sdp_msg_t *shm_buf;         //!< e8 SHM buffers
+    uint mbox_flags;            //!< ec AP->MP communication flags
 
-    uchar ip_addr[4];		//!< f0 IP address (or 0)
-    uint fr_copy;		//!< f4 (Virtual) copy of router FR reg
-    uint *board_info;		//!< f8 Pointer to board_info area !!
-    uint sw_ver;		//!< fc Software version number
+    uchar ip_addr[4];           //!< f0 IP address (or 0)
+    uint fr_copy;               //!< f4 (Virtual) copy of router FR reg
+    uint *board_info;           //!< f8 Pointer to board_info area !!
+    uint sw_ver;                //!< fc Software version number
 } sv_t;
 
 

--- a/include/spin1_api.h
+++ b/include/spin1_api.h
@@ -102,7 +102,7 @@ uint spin1_trigger_user_event(uint arg0, uint arg1);
 //  data transfer functions
 // ------------------------------------------------------------------------
 uint spin1_dma_transfer(uint tag, void *system_address, void *tcm_address,
-	uint direction, uint length);
+        uint direction, uint length);
 void spin1_memcpy(void *dst, void const *src, uint len);
 // ------------------------------------------------------------------------
 
@@ -159,26 +159,26 @@ uint  spin1_rand  (void);
 //  diagnostic data available to the application
 // ------------------------------------------------------------------------
 typedef struct {
-    uint exit_code;			// simulation exit code
-    uint warnings;			// warnings type bit map
-    uint total_mc_packets;		// total routed MC packets during simulation
-    uint dumped_mc_packets;		// total dumped MC packets by the router
-    volatile uint discarded_mc_packets;	// total discarded MC packets by API
-    uint dma_transfers;			// total DMA transfers requested
-    uint dma_bursts;			// total DMA bursts completed
-    uint dma_queue_full;		// dma queue full count
-    uint task_queue_full;		// task queue full count
-    uint tx_packet_queue_full;		// transmitter packet queue full count
-    uint writeBack_errors;		// write-back buffer error count
-    uint total_fr_packets;		// total routed FR packets during simulation
-    uint dumped_fr_packets;		// total dumped FR packets by the router
-    uint discarded_fr_packets;		// total discarded FR packets by API
-    uint in_timer_callback;		// bool which states if currently in timer callback
-    uint number_timer_tic_in_queue;	// the number of timer tic callbacks in the queue
+    uint exit_code;                     // simulation exit code
+    uint warnings;                      // warnings type bit map
+    uint total_mc_packets;              // total routed MC packets during simulation
+    uint dumped_mc_packets;             // total dumped MC packets by the router
+    volatile uint discarded_mc_packets; // total discarded MC packets by API
+    uint dma_transfers;                 // total DMA transfers requested
+    uint dma_bursts;                    // total DMA bursts completed
+    uint dma_queue_full;                // dma queue full count
+    uint task_queue_full;               // task queue full count
+    uint tx_packet_queue_full;          // transmitter packet queue full count
+    uint writeBack_errors;              // write-back buffer error count
+    uint total_fr_packets;              // total routed FR packets during simulation
+    uint dumped_fr_packets;             // total dumped FR packets by the router
+    uint discarded_fr_packets;          // total discarded FR packets by API
+    uint in_timer_callback;             // bool which states if currently in timer callback
+    uint number_timer_tic_in_queue;     // the number of timer tic callbacks in the queue
     uint largest_number_of_concurrent_timer_tic_overruns;
-					// the max number of timer tics callbacks being queued at any time
+                                        // the max number of timer tics callbacks being queued at any time
     uint total_times_tick_tic_callback_overran;
-					// the total number of times the timer tic callback overran
+                                        // the total number of times the timer tic callback overran
 } diagnostics_t;
 
 extern diagnostics_t diagnostics;

--- a/include/version.h
+++ b/include/version.h
@@ -1,18 +1,18 @@
 //------------------------------------------------------------------------------
 //
-// version.h	    Header file describing SpiNNaker low-level tool version
+// version.h        Header file describing SpiNNaker low-level tool version
 //
 // Copyright (C)    The University of Manchester - 2016
 //
-// Author	    Steve Temple, APT Group, School of Computer Science
-// Email	    steven.temple@manchester.ac.uk
+// Author           Steve Temple, APT Group, School of Computer Science
+// Email            steven.temple@manchester.ac.uk
 //
 //------------------------------------------------------------------------------
 
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"3.1.1"
-#define	SLLT_VER_NUM	0x030101
+#define SLLT_VER_STR    "3.1.1"
+#define SLLT_VER_NUM    0x030101
 
 #endif

--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_base.c	    SARK - Spinnaker Application Runtime Kernel
+// sark_base.c      SARK - Spinnaker Application Runtime Kernel
 //
 // Copyright (C)    The University of Manchester - 2010-2013
 //
@@ -20,13 +20,13 @@
 cback_t __attribute__((weak)) callback[NUM_EVENTS];
 
 void __attribute__((weak)) schedule_sysmode(uchar event_id,
-					    uint arg0, uint arg1) {}
+                                            uint arg0, uint arg1) {}
 
 #endif
 
 //------------------------------------------------------------------------------
 
-#define SARK_ID_STR		"SARK/SpiNNaker"
+#define SARK_ID_STR             "SARK/SpiNNaker"
 
 sark_data_t sark;
 
@@ -80,8 +80,8 @@ uint sark_count_bits(uint word)
     uint count = 0;
 
     while (word != 0) {
-	count++;
-	word &= word - 1;
+        count++;
+        word &= word - 1;
     }
 
     return count;
@@ -94,7 +94,7 @@ uint sark_str_len(char *string)
     uint count = 0;
 
     while (*string++) {
-	count++;
+        count++;
     }
 
     return count;
@@ -159,15 +159,15 @@ void sw_error_fl(sw_err_mode mode, char* file, uint line)
     sark.vcpu->sw_line = line;
 
     if (sark.vcpu->sw_count != 0xffff) {
-	sark.vcpu->sw_count++;
+        sark.vcpu->sw_count++;
     }
 
     if (sark.virt_cpu != 0) {
-	sv->led_period = 16;
+        sv->led_period = 16;
     }
 
     if (mode == SW_RTE || (mode == SW_OPT && sark.sw_rte)) {
-	rt_error(RTE_SWERR);
+        rt_error(RTE_SWERR);
     }
 }
 
@@ -188,14 +188,14 @@ void *sark_alloc(uint count, uint size)
     uint words = (bytes + 3) / sizeof(uint);
 
     if (words == 0) {
-	return 0;
+        return 0;
     }
 
     uint *base = sark.heap_ptr;
     uint *next = sark.heap_ptr + words;
 
     if (next > sark.stack_base) {
-	return 0;
+        return 0;
     }
 
     sark.heap_ptr = next;
@@ -226,9 +226,9 @@ void *sark_block_init(void *buf, uint count, uint size)
     mem_link_t *m = buf;
 
     while (--count) {
-	buf = (uchar *) buf + size;
-	m->next = buf;
-	m = buf;
+        buf = (uchar *) buf + size;
+        m->next = buf;
+        m = buf;
     }
 
     m->next = NULL;
@@ -248,12 +248,12 @@ sdp_msg_t *sark_msg_get(void)
     mem_link_t *blk = root->free;
 
     if (blk != NULL) {
-	root->free = blk->next;
+        root->free = blk->next;
 
-	root->count++;
-	if (root->count > root->max) {
-	    root->max = root->count;
-	}
+        root->count++;
+        if (root->count > root->max) {
+            root->max = root->count;
+        }
     }
 
     cpu_int_restore(cpsr);
@@ -291,12 +291,12 @@ void *sark_block_get(mem_block_t *root)
     mem_link_t *blk = root->free;
 
     if (blk != NULL) {
-	root->free = blk->next;
+        root->free = blk->next;
 
-	root->count++;
-	if (root->count > root->max) {
-	    root->max = root->count;
-	}
+        root->count++;
+        if (root->count > root->max) {
+            root->max = root->count;
+        }
     }
 
     cpu_int_restore(cpsr);
@@ -333,12 +333,12 @@ sdp_msg_t* sark_shmsg_get()
     mem_link_t *blk = root->free;
 
     if (blk != NULL) {
-	root->free = blk->next;
+        root->free = blk->next;
 
-	root->count++;
-	if (root->count > root->max) {
-	    root->max = root->count;
-	}
+        root->count++;
+        if (root->count > root->max) {
+            root->max = root->count;
+        }
     }
 
     sark_lock_free(cpsr, LOCK_MSG);
@@ -373,7 +373,7 @@ void sark_call_cpp_constructors(void)
 {
     // Loop through any C++ constructors that may be present and call them
     for (constructor_t *p = &__init_array_start; p < &__init_array_end; p++) {
-	(*p)();
+        (*p)();
     }
 }
 #else  // Not GCC: No C++ support
@@ -432,28 +432,28 @@ uint __attribute__((weak)) sark_init(uint *stack)
     // done if we are not the Monitor processor
 
     if (sark.phys_cpu != (sc[SC_MON_ID] & 31)) {
-	sark.vcpu = sv_vcpu + sark.virt_cpu;
-	sark.sdram_buf = (void *)
-		(sv->sdram_bufs + sv->sysbuf_size * sark.virt_cpu);
+        sark.vcpu = sv_vcpu + sark.virt_cpu;
+        sark.sdram_buf = (void *)
+                (sv->sdram_bufs + sv->sysbuf_size * sark.virt_cpu);
 
-	sark_word_set(sark.vcpu, 0, sizeof(vcpu_t) - 4 * sizeof(uint));
-	sark.vcpu->cpu_state = CPU_STATE_WAIT;
-	sark.vcpu->phys_cpu = sark.phys_cpu;
+        sark_word_set(sark.vcpu, 0, sizeof(vcpu_t) - 4 * sizeof(uint));
+        sark.vcpu->cpu_state = CPU_STATE_WAIT;
+        sark.vcpu->phys_cpu = sark.phys_cpu;
 
-	sark.vcpu->app_id = sark_vec->app_id;
-	sark.vcpu->time = sv->unix_time;
-	sark.vcpu->sw_ver = SLLT_VER_NUM;
-	sark_str_cpy(sark.vcpu->app_name, build_name);
+        sark.vcpu->app_id = sark_vec->app_id;
+        sark.vcpu->time = sv->unix_time;
+        sark.vcpu->sw_ver = SLLT_VER_NUM;
+        sark_str_cpy(sark.vcpu->app_name, build_name);
 
-	// Check software version number
-	//   Major must match
-	//   Minor must be LE
-	//   Patch is ignored
+        // Check software version number
+        //   Major must match
+        //   Minor must be LE
+        //   Patch is ignored
 
-	if ((SLLT_VER_NUM & 0x00ff0000) != (sv->sw_ver & 0x00ff0000) ||
-		(SLLT_VER_NUM & 0x0000ff00) > (sv->sw_ver & 0x0000ff00)) {
-	    rt_error(RTE_VER);
-	}
+        if ((SLLT_VER_NUM & 0x00ff0000) != (sv->sw_ver & 0x00ff0000) ||
+                (SLLT_VER_NUM & 0x0000ff00) > (sv->sw_ver & 0x0000ff00)) {
+            rt_error(RTE_VER);
+        }
     }
 
     // Set up VIC - disable everything
@@ -497,7 +497,7 @@ uint sark_msg_send(sdp_msg_t *msg, uint timeout)
     sdp_msg_t *shm_msg = sark_shmsg_get();
 
     if (shm_msg == NULL) {
-	return 0;
+        return 0;
     }
 
     sark_msg_cpy(shm_msg, msg);
@@ -512,7 +512,7 @@ uint sark_msg_send(sdp_msg_t *msg, uint timeout)
     sv->mbox_flags = t | (1 << sark.virt_cpu);
 
     if (t == 0) {
-	sc[SC_SET_IRQ] = SC_CODE + (1 << sv->v2p_map[0]);
+        sc[SC_SET_IRQ] = SC_CODE + (1 << sv->v2p_map[0]);
     }
 
     sark_lock_free(cpsr, LOCK_MBOX);
@@ -523,14 +523,14 @@ uint sark_msg_send(sdp_msg_t *msg, uint timeout)
     uint start = *ms;
 
     while (sark.vcpu->mbox_mp_cmd != SHM_IDLE) {
-	if (*ms - start > timeout) {
-	    break;
-	}
+        if (*ms - start > timeout) {
+            break;
+        }
     }
 
     if (sark.vcpu->mbox_mp_cmd != SHM_IDLE) {
-	sark_shmsg_free(shm_msg);
-	return 0;
+        sark_shmsg_free(shm_msg);
+        return 0;
     }
 
     sark.msg_sent++;
@@ -560,34 +560,34 @@ uint sark_cmd_read(sdp_msg_t *msg) // arg1=addr, arg2=len, arg3=type
     uint type = msg->arg3;
 
     if (len > SDP_BUF_SIZE || type > TYPE_WORD) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint addr = msg->arg1;
     uchar *buffer = (uchar *) &msg->arg1;
 
     if (type == TYPE_BYTE) {
-	uchar *mem = (uchar *) addr;
-	uchar *buf = (uchar *) buffer;
+        uchar *mem = (uchar *) addr;
+        uchar *buf = (uchar *) buffer;
 
-	for (uint i = 0; i < len; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint i = 0; i < len; i++) {
+            buf[i] = mem[i];
+        }
     } else if (type == TYPE_HALF) {
-	ushort *mem = (ushort *) addr;
-	ushort *buf = (ushort *) buffer;
+        ushort *mem = (ushort *) addr;
+        ushort *buf = (ushort *) buffer;
 
-	for (uint i = 0; i < len / 2; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint i = 0; i < len / 2; i++) {
+            buf[i] = mem[i];
+        }
     } else {
-	uint *mem = (uint *) addr;
-	uint *buf = (uint *) buffer;
+        uint *mem = (uint *) addr;
+        uint *buf = (uint *) buffer;
 
-	for (uint i = 0; i < len / 4; i++) {
-	    buf[i] = mem[i];
-	}
+        for (uint i = 0; i < len / 4; i++) {
+            buf[i] = mem[i];
+        }
     }
 
     return len;
@@ -600,34 +600,34 @@ uint sark_cmd_write(sdp_msg_t *msg) // arg1=addr, arg2=len, arg3=type
     uint type = msg->arg3;
 
     if (len > SDP_BUF_SIZE || type > TYPE_WORD) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint addr = msg->arg1;
     uchar *buffer = msg->data;
 
     if (type == TYPE_BYTE) {
-	uchar *mem = (uchar*) addr;
-	uchar *buf = (uchar*) buffer;
+        uchar *mem = (uchar*) addr;
+        uchar *buf = (uchar*) buffer;
 
-	for (uint i = 0; i < len; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint i = 0; i < len; i++) {
+            mem[i] = buf[i];
+        }
     } else if (type == TYPE_HALF) {
-	ushort* mem = (ushort*) addr;
-	ushort* buf = (ushort*) buffer;
+        ushort* mem = (ushort*) addr;
+        ushort* buf = (ushort*) buffer;
 
-	for (uint i = 0; i < len / 2; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint i = 0; i < len / 2; i++) {
+            mem[i] = buf[i];
+        }
     } else {
-	uint *mem = (uint *) addr;
-	uint *buf = (uint *) buffer;
+        uint *mem = (uint *) addr;
+        uint *buf = (uint *) buffer;
 
-	for (uint i = 0; i < len / 4; i++) {
-	    mem[i] = buf[i];
-	}
+        for (uint i = 0; i < len / 4; i++) {
+            mem[i] = buf[i];
+        }
     }
 
     return 0;
@@ -648,22 +648,22 @@ static uint sark_debug(sdp_msg_t *msg)
 {
     uint len = msg->length;
 
-    if (len < 24) {		// !! const
-	msg->cmd_rc = RC_LEN;
-	return 0;
+    if (len < 24) {             // !! const
+        msg->cmd_rc = RC_LEN;
+        return 0;
     }
 
     uint t = msg->cmd_rc;
     msg->cmd_rc = RC_OK;
 
     if (t == CMD_VER) {
-	return sark_cmd_ver(msg);
+        return sark_cmd_ver(msg);
     } else if (t == CMD_READ) {
-	return sark_cmd_read(msg);
+        return sark_cmd_read(msg);
     } else if (t == CMD_WRITE) {
-	return sark_cmd_write(msg);
+        return sark_cmd_write(msg);
     } else if (t == CMD_FILL) {
-	return sark_cmd_fill(msg);
+        return sark_cmd_fill(msg);
     }
 
     msg->cmd_rc = RC_CMD;
@@ -691,7 +691,7 @@ static void swap_hdr(sdp_msg_t *msg)
 void sark_wait(void)
 {
     while (sark_vec->app_flags & (1 << APP_FLAG_WAIT)) {
-	cpu_wfi();
+        cpu_wfi();
     }
 }
 #endif
@@ -707,103 +707,103 @@ void sark_wait(void)
 
 void sark_int(void *pc)
 {
-    sc[SC_CLR_IRQ] = SC_CODE + (1 << sark.phys_cpu);	// Ack the interrupt
+    sc[SC_CLR_IRQ] = SC_CODE + (1 << sark.phys_cpu);    // Ack the interrupt
 
-    uint cmd = sark.vcpu->mbox_ap_cmd;			// Get command code
+    uint cmd = sark.vcpu->mbox_ap_cmd;                  // Get command code
 
     if (cmd == SHM_IDLE) {
-	return;
+        return;
     }
 
-    uint data = (uint) sark.vcpu->mbox_ap_msg;		// and data word
+    uint data = (uint) sark.vcpu->mbox_ap_msg;          // and data word
 
-    if (cmd == SHM_NOP) {				// Send back PC if NOP
-	sark.vcpu->mbox_ap_msg = pc;
+    if (cmd == SHM_NOP) {                               // Send back PC if NOP
+        sark.vcpu->mbox_ap_msg = pc;
     }
 
-    sark.vcpu->mbox_ap_cmd = SHM_IDLE;			// and go back to idle
+    sark.vcpu->mbox_ap_cmd = SHM_IDLE;                  // and go back to idle
 
 #ifdef SARK_EVENT
     if (cmd == SHM_SIGNAL) {
-	switch (data) {
-	case SIG_PAUSE:
-	    event_pause(1);
-	    return;
+        switch (data) {
+        case SIG_PAUSE:
+            event_pause(1);
+            return;
 
-	case SIG_CONT:
-	    event_pause(0);
-	    return;
+        case SIG_CONT:
+            event_pause(0);
+            return;
 
-	case SIG_EXIT:
-	    event_stop(255);	// !! const
-	    return;
+        case SIG_EXIT:
+            event_stop(255);    // !! const
+            return;
 
-	case SIG_START:
-	    sark_vec->app_flags &= ~(1 << APP_FLAG_WAIT);
-	    return;
+        case SIG_START:
+            sark_vec->app_flags &= ~(1 << APP_FLAG_WAIT);
+            return;
 
-	case SIG_USR0:
-	case SIG_USR1:
-	case SIG_USR2:
-	case SIG_USR3:
-	    event.signal = data;
-	    vic[VIC_SOFT_SET] = 1 << SARK_SIG_INT;
-	    return;
+        case SIG_USR0:
+        case SIG_USR1:
+        case SIG_USR2:
+        case SIG_USR3:
+            event.signal = data;
+            vic[VIC_SOFT_SET] = 1 << SARK_SIG_INT;
+            return;
 
-	case SIG_TIMER:
-	    vic[VIC_SOFT_SET] = 1 << TIMER1_INT;
-	    return;
+        case SIG_TIMER:
+            vic[VIC_SOFT_SET] = 1 << TIMER1_INT;
+            return;
 
-	default:
-	    return;
-	}
+        default:
+            return;
+        }
     }
 #endif
 
     if (cmd == SHM_MSG) {
-	sdp_msg_t *shm_msg = (sdp_msg_t *) data;
-	sdp_msg_t *msg = sark_msg_get();
+        sdp_msg_t *shm_msg = (sdp_msg_t *) data;
+        sdp_msg_t *msg = sark_msg_get();
 
-	if (msg != NULL) {
-	    sark_msg_cpy(msg, shm_msg);
-	    sark_shmsg_free(shm_msg);
+        if (msg != NULL) {
+            sark_msg_cpy(msg, shm_msg);
+            sark_shmsg_free(shm_msg);
 
-	    sark.msg_rcvd++;
+            sark.msg_rcvd++;
 
-	    uint dp = msg->dest_port;
+            uint dp = msg->dest_port;
 
-	    if ((dp & PORT_MASK) == 0) {	// Port 0 is for us
-		msg->length = 12 + sark_debug(msg);
-		swap_hdr(msg);
+            if ((dp & PORT_MASK) == 0) {        // Port 0 is for us
+                msg->length = 12 + sark_debug(msg);
+                swap_hdr(msg);
 
-		sark_msg_send(msg, 10);
-		sark_msg_free(msg);
-	    } else {				// else send msg to application...
-		if (sark_vec->api) {
+                sark_msg_send(msg, 10);
+                sark_msg_free(msg);
+            } else {                            // else send msg to application...
+                if (sark_vec->api) {
 #ifdef SARK_API
-		    if (callback[SDP_PACKET_RX].cback != NULL) {
-			uint cpsr = cpu_int_disable();
-			schedule_sysmode(SDP_PACKET_RX, (uint) msg,
-				dp >> PORT_SHIFT);
-			cpu_int_restore(cpsr);
-		    } else {
-			sark_msg_free(msg);
-		    }
+                    if (callback[SDP_PACKET_RX].cback != NULL) {
+                        uint cpsr = cpu_int_disable();
+                        schedule_sysmode(SDP_PACKET_RX, (uint) msg,
+                                dp >> PORT_SHIFT);
+                        cpu_int_restore(cpsr);
+                    } else {
+                        sark_msg_free(msg);
+                    }
 #endif // SARK_API
-		} else {
+                } else {
 #ifdef SARK_EVENT
-		    if (vic[VIC_ENABLE] & (1 << SARK_MSG_INT)) {
-			event.msg = msg;
-			vic[VIC_SOFT_SET] = 1 << SARK_MSG_INT;
-		    } else {
-			sark_msg_free(msg);
-		    }
+                    if (vic[VIC_ENABLE] & (1 << SARK_MSG_INT)) {
+                        event.msg = msg;
+                        vic[VIC_SOFT_SET] = 1 << SARK_MSG_INT;
+                    } else {
+                        sark_msg_free(msg);
+                    }
 #endif // SARK_EVENT
-		}
-	    }
-	} else {
-	    sark_shmsg_free(shm_msg);
-	}
+                }
+            }
+        } else {
+            sark_shmsg_free(shm_msg);
+        }
     }
 }
 

--- a/sark/sark_event.c
+++ b/sark/sark_event.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_event.c	    Event handling routines for SARK
+// sark_event.c     Event handling routines for SARK
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -21,12 +21,12 @@ extern int_handler null_events[];
 
 
 static const uchar vic_bit[] = {
-    TIMER1_INT,		// Timer 1
-    CC_MC_INT,		// MC pkt
-    SARK_MSG_INT,	// SDP msg
-    SOFTWARE_INT,	// User event
-    SARK_SIG_INT,	// Signal
-    DMA_DONE_INT	// DMA done
+    TIMER1_INT,         // Timer 1
+    CC_MC_INT,          // MC pkt
+    SARK_MSG_INT,       // SDP msg
+    SOFTWARE_INT,       // User event
+    SARK_SIG_INT,       // Signal
+    DMA_DONE_INT        // DMA done
 };
 
 
@@ -44,7 +44,7 @@ event_data_t event;
 uint event_user(uint arg1, uint arg2)
 {
     if (event.user) {
-	return 0;
+        return 0;
     }
 
     event.arg1 = arg1;
@@ -65,55 +65,55 @@ void event_register_int(event_proc proc, event_type event_num, vic_slot slot)
     uint bit = 1 << vic_bit[event_num];
 
     if (slot == SLOT_FIQ) {
-	if (event_num > EVENT_MAX ||
-		event.vic_select != 0 ||
-		event.vic_enable & bit) {
-	    event.rc |= EFAIL(EFAIL_FIQ);
-	    return;
-	}
+        if (event_num > EVENT_MAX ||
+                event.vic_select != 0 ||
+                event.vic_enable & bit) {
+            event.rc |= EFAIL(EFAIL_FIQ);
+            return;
+        }
 
-	event.fiq_vector = fiq_events[event_num];
+        event.fiq_vector = fiq_events[event_num];
 
-	sark_vec->event[event_num].proc = (uint) proc;
-	sark_vec->event[event_num].slot = SLOT_FIQ;
-	sark_vec->event[event_num].priority = 0;	// 0 for FIQ
+        sark_vec->event[event_num].proc = (uint) proc;
+        sark_vec->event[event_num].slot = SLOT_FIQ;
+        sark_vec->event[event_num].priority = 0;        // 0 for FIQ
 
-	event.vic_select = bit;
-	event.vic_enable |= bit;
+        event.vic_select = bit;
+        event.vic_enable |= bit;
     } else {
-	if (event_num > EVENT_MAX ||
-		slot > SLOT_MAX ||
-		event.vic_enable & bit ||
-		vic[VIC_CNTL + slot] != 0) {
-	    event.rc |= EFAIL(EFAIL_IRQ);
-	    return;
-	}
+        if (event_num > EVENT_MAX ||
+                slot > SLOT_MAX ||
+                event.vic_enable & bit ||
+                vic[VIC_CNTL + slot] != 0) {
+            event.rc |= EFAIL(EFAIL_IRQ);
+            return;
+        }
 
-	vic[VIC_ADDR + slot] = (uint) irq_events[event_num];
-	vic[VIC_CNTL + slot] = 0x20 | vic_bit[event_num];
+        vic[VIC_ADDR + slot] = (uint) irq_events[event_num];
+        vic[VIC_CNTL + slot] = 0x20 | vic_bit[event_num];
 
-	sark_vec->event[event_num].proc = (uint) proc;
-	sark_vec->event[event_num].slot = slot;
-	sark_vec->event[event_num].priority = 1;	// 1 for IRQ
+        sark_vec->event[event_num].proc = (uint) proc;
+        sark_vec->event[event_num].slot = slot;
+        sark_vec->event[event_num].priority = 1;        // 1 for IRQ
 
-	event.vic_addr[event_num] = irq_events[event_num];
-	event.vic_enable |= bit;
+        event.vic_addr[event_num] = irq_events[event_num];
+        event.vic_enable |= bit;
     }
 }
 
 
 void event_register_queue(event_proc proc, event_type event_num,
-			  vic_slot slot, event_priority priority)
+                          vic_slot slot, event_priority priority)
 {
     uint bit = 1 << vic_bit[event_num];
 
     if (event_num > EVENT_MAX ||
-	    slot > SLOT_MAX ||
-	    priority > PRIO_MAX ||
-	    event.vic_enable & bit ||
-	    vic[VIC_CNTL + slot] != 0) {
-	event.rc |= EFAIL(EFAIL_QUEUE);
-	return;
+            slot > SLOT_MAX ||
+            priority > PRIO_MAX ||
+            event.vic_enable & bit ||
+            vic[VIC_CNTL + slot] != 0) {
+        event.rc |= EFAIL(EFAIL_QUEUE);
+        return;
     }
 
     vic[VIC_ADDR + slot] = (uint) queue_events[event_num];
@@ -133,25 +133,25 @@ void event_enable(event_type event_num, uint enable)
     uint slot = sark_vec->event[event_num].slot;
 
     if (enable) {
-	if (slot == SLOT_FIQ) {
-	    if (event.fiq_vector == NULL) {
-		rt_error(RTE_ENABLE);
-	    }
+        if (slot == SLOT_FIQ) {
+            if (event.fiq_vector == NULL) {
+                rt_error(RTE_ENABLE);
+            }
 
-	    sark_vec->fiq_vec = event.fiq_vector;
-	} else {
-	    if (event.vic_addr[event_num] == NULL) {
-		rt_error(RTE_ENABLE);
-	    }
+            sark_vec->fiq_vec = event.fiq_vector;
+        } else {
+            if (event.vic_addr[event_num] == NULL) {
+                rt_error(RTE_ENABLE);
+            }
 
-	    vic[VIC_ADDR + slot] = (uint) event.vic_addr[event_num];
-	}
+            vic[VIC_ADDR + slot] = (uint) event.vic_addr[event_num];
+        }
     } else {
-	if (slot == SLOT_FIQ) {
-	    sark_vec->fiq_vec = null_events[event_num];
-	} else {
-	    vic[VIC_ADDR + slot] = (uint) null_events[event_num];
-	}
+        if (slot == SLOT_FIQ) {
+            sark_vec->fiq_vec = null_events[event_num];
+        } else {
+            vic[VIC_ADDR + slot] = (uint) null_events[event_num];
+        }
     }
 }
 
@@ -171,17 +171,17 @@ void event_wait(void)
     uint bit = 1 << sark.virt_cpu;
 
     if (event.wait) {
-	sark_cpu_state(CPU_STATE_SYNC1);
+        sark_cpu_state(CPU_STATE_SYNC1);
 
-	while (~sc[SC_FLAG] & bit) { 	// Wait 1
-	    cpu_wfi();
-	}
+        while (~sc[SC_FLAG] & bit) {    // Wait 1
+            cpu_wfi();
+        }
     } else {
-	sark_cpu_state(CPU_STATE_SYNC0);
+        sark_cpu_state(CPU_STATE_SYNC0);
 
-	while (sc[SC_FLAG] & bit) { 	// Wait 0
-	    cpu_wfi();
-	}
+        while (sc[SC_FLAG] & bit) {     // Wait 0
+            cpu_wfi();
+        }
     }
 
     event.wait ^= 1;
@@ -196,24 +196,24 @@ uint event_start(uint period, uint events, sync_bool wait)
     // Allocate required number of events
 
     if (events != 0) {
-	event_alloc(events);
+        event_alloc(events);
     }
 
     // Die if any errors so far
     if (event.rc != 0) {
-	rt_error(RTE_EVENT, event.rc);
+        rt_error(RTE_EVENT, event.rc);
     }
 
     // Wait for go...
     if (wait) {
-	event_wait();
+        event_wait();
     }
 
     // Set up timer1 if needed
 
     if (period) {
-	tc[T1_CONTROL] = 0xe2;
-	tc[T1_LOAD] = sark.cpu_clk * period;
+        tc[T1_CONTROL] = 0xe2;
+        tc[T1_LOAD] = sark.cpu_clk * period;
     }
 
     // Set up VIC enables and FIQ vector for this app.
@@ -241,11 +241,11 @@ uint event_start(uint period, uint events, sync_bool wait)
     // Run the event loop until asked to stop
 
     while (event.state != EVENT_STOP) {
-	event_run2(1);
+        event_run2(1);
 
-	do {
-	    cpu_wfi();
-	} while (event.state == EVENT_PAUSE);
+        do {
+            cpu_wfi();
+        } while (event.state == EVENT_PAUSE);
     }
 
     // Notify new CPU state
@@ -272,15 +272,15 @@ uint event_start(uint period, uint events, sync_bool wait)
 void event_pause(uint pause)
 {
     if (pause) {
-	event.state = EVENT_PAUSE;
-	sark_cpu_state(CPU_STATE_PAUSE);
+        event.state = EVENT_PAUSE;
+        sark_cpu_state(CPU_STATE_PAUSE);
     } else {
-	event.state = EVENT_RUN;
-	sark_cpu_state(CPU_STATE_RUN);
+        event.state = EVENT_RUN;
+        sark_cpu_state(CPU_STATE_RUN);
     }
 
     if (event.pause_proc != NULL) {
-	event.pause_proc(pause, event.pause_arg2);
+        event.pause_proc(pause, event.pause_arg2);
     }
 }
 
@@ -303,7 +303,7 @@ void event_stop(uint rc)
 uint event_queue(event_t *e, event_priority priority)
 {
     if (priority > PRIO_MAX) {
-	return 0;
+        return 0;
     }
 
     proc_queue_t *queue = event.proc_queue + priority;
@@ -311,10 +311,10 @@ uint event_queue(event_t *e, event_priority priority)
     uint cpsr = cpu_int_disable();
 
     if (queue->proc_head == NULL) {
-	queue->proc_head = queue->proc_tail = e;
+        queue->proc_head = queue->proc_tail = e;
     } else {
-	queue->proc_tail->next = e;
-	queue->proc_tail = e;
+        queue->proc_tail->next = e;
+        queue->proc_tail = e;
     }
 
     cpu_int_restore(cpsr);
@@ -328,11 +328,11 @@ uint event_queue(event_t *e, event_priority priority)
 // Adds an "event_proc" with args to the event_queue.
 
 uint event_queue_proc(event_proc proc, uint arg1, uint arg2,
-		      event_priority priority)
+                      event_priority priority)
 {
     event_t *e = event_new(proc, arg1, arg2);
     if (e == NULL) {
-	return 0;
+        return 0;
     }
 
     return event_queue(e, priority);
@@ -349,39 +349,39 @@ void event_run(uint restart)
     uint priority = PRIO_0;
 
     while (priority <= PRIO_MAX && event.state == EVENT_RUN) {
-	proc_queue_t *queue = event.proc_queue + priority;
+        proc_queue_t *queue = event.proc_queue + priority;
 
-	uint cpsr = cpu_int_disable();
+        uint cpsr = cpu_int_disable();
 
-	event_t* e = queue->proc_head;	// Get list of events and
-	queue->proc_head = NULL;	// update list head
+        event_t* e = queue->proc_head;  // Get list of events and
+        queue->proc_head = NULL;        // update list head
 
-	cpu_int_restore(cpsr);
+        cpu_int_restore(cpsr);
 
-	event_t *x = e;			// Non-NULL if any events run
+        event_t *x = e;                 // Non-NULL if any events run
 
-	while (e != NULL) {
-	    event_t* next = e->next;
+        while (e != NULL) {
+            event_t* next = e->next;
 
-	    e->proc(e->arg1, e->arg2);	// No need to check for NULL here
+            e->proc(e->arg1, e->arg2);  // No need to check for NULL here
 
-	    uint cpsr = cpu_int_disable();
+            uint cpsr = cpu_int_disable();
 
-	    e->next = event.free;	// Return to free queue
-	    event.free = e;
-	    e->ID = 0;
-	    event.count--;
+            e->next = event.free;       // Return to free queue
+            event.free = e;
+            e->ID = 0;
+            event.count--;
 
-	    cpu_int_restore(cpsr);
+            cpu_int_restore(cpsr);
 
-	    e = next;
-	}
+            e = next;
+        }
 
-	if ((x != NULL) && restart) {
-	    priority = PRIO_0;
-	} else {
-	    priority++;
-	}
+        if ((x != NULL) && restart) {
+            priority = PRIO_0;
+        } else {
+            priority++;
+        }
     }
 }
 
@@ -391,36 +391,36 @@ void event_run2(uint restart)
     event_priority priority = PRIO_0;
 
     while (priority <= PRIO_MAX && event.state == EVENT_RUN) {
-	proc_queue_t *queue = event.proc_queue + priority;
+        proc_queue_t *queue = event.proc_queue + priority;
 
-	uint cpsr = cpu_int_disable();	// Interrupts off to manipulate queue
+        uint cpsr = cpu_int_disable();  // Interrupts off to manipulate queue
 
-	event_t* e = queue->proc_head;	// Get head of queue
+        event_t* e = queue->proc_head;  // Get head of queue
 
-	if (e == NULL) {		// If no item on queue...
-	    cpu_int_restore(cpsr);
-	    priority++;
-	    continue;
-	}
+        if (e == NULL) {                // If no item on queue...
+            cpu_int_restore(cpsr);
+            priority++;
+            continue;
+        }
 
-	queue->proc_head = e->next;	// Remove from queue
+        queue->proc_head = e->next;     // Remove from queue
 
-	cpu_int_restore(cpsr);		// Interrupts on again
+        cpu_int_restore(cpsr);          // Interrupts on again
 
-	e->proc(e->arg1, e->arg2);	// Execute the "proc"
+        e->proc(e->arg1, e->arg2);      // Execute the "proc"
 
-	cpsr = cpu_int_disable();	// Return to free queue
+        cpsr = cpu_int_disable();       // Return to free queue
 
-	e->next = event.free;
-	event.free = e;
-	e->ID = 0;
-	event.count--;
+        e->next = event.free;
+        event.free = e;
+        e->ID = 0;
+        event.count--;
 
-	cpu_int_restore(cpsr);
+        cpu_int_restore(cpsr);
 
-	if (restart) {			// Back to priority 0 if anything
-	    priority = PRIO_0;		// executed
-	}
+        if (restart) {                  // Back to priority 0 if anything
+            priority = PRIO_0;          // executed
+        }
     }
 }
 
@@ -438,29 +438,29 @@ event_t* event_new(event_proc proc, uint arg1, uint arg2)
     event_t *e = event.free;
 
     if (e != NULL) {
-	uint next_id = event.id + 1;
+        uint next_id = event.id + 1;
 
-	if (next_id == 0) {
-	    next_id = 1;
-	}
+        if (next_id == 0) {
+            next_id = 1;
+        }
 
-	event.free = e->next;
-	e->next = NULL;
+        event.free = e->next;
+        e->next = NULL;
 
-	e->ID = event.id = next_id;
+        e->ID = event.id = next_id;
 
-	e->proc = proc;
-	e->arg1 = arg1;
-	e->arg2 = arg2;
-	e->time = 0;
+        e->proc = proc;
+        e->arg1 = arg1;
+        e->arg2 = arg2;
+        e->time = 0;
 
-	event.count++;
-	if (event.count > event.max) {
-	    event.max = event.count;
-	}
+        event.count++;
+        if (event.count > event.max) {
+            event.max = event.count;
+        }
     } else {
-	event.failed++;
-	event.rc |= EFAIL(EFAIL_NEW);
+        event.failed++;
+        event.rc |= EFAIL(EFAIL_NEW);
     }
 
     cpu_int_restore(cpsr);
@@ -480,16 +480,16 @@ uint event_alloc(uint events)
     event_t *head = (event_t *) sark_alloc(events, sizeof(event_t));
 
     if (head != NULL) {
-	event_t *tail = sark_block_init(head, events, sizeof(event_t));
+        event_t *tail = sark_block_init(head, events, sizeof(event_t));
 
-	uint cpsr = cpu_int_disable();
+        uint cpsr = cpu_int_disable();
 
-	tail->next = event.free;
-	event.free = head;
+        tail->next = event.free;
+        event.free = head;
 
-	cpu_int_restore(cpsr);
+        cpu_int_restore(cpsr);
 
-	return 1;
+        return 1;
     }
 
     event.rc |= EFAIL(EFAIL_ALLOC);

--- a/sark/sark_hw.c
+++ b/sark/sark_hw.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_hw.c	    Spinnaker hardware/peripheral support routines
+// sark_hw.c        Spinnaker hardware/peripheral support routines
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -19,13 +19,13 @@ extern void vic_error(void);
 
 void sark_vic_init(void)
 {
-    vic[VIC_DISABLE] = 0xffffffff;		// Disable all
-    vic[VIC_SELECT] = 0;			// All use IRQ
-    vic[VIC_VADDR] = 0;				// Ack just in case...
+    vic[VIC_DISABLE] = 0xffffffff;              // Disable all
+    vic[VIC_SELECT] = 0;                        // All use IRQ
+    vic[VIC_VADDR] = 0;                         // Ack just in case...
 
-    for (uint i = 0; i < 16; i++) {		// Clear all entries
-	vic[VIC_CNTL + i] = 0;
-	vic[VIC_ADDR + i] = (uint) vic_error;
+    for (uint i = 0; i < 16; i++) {             // Clear all entries
+        vic[VIC_CNTL + i] = 0;
+        vic[VIC_ADDR + i] = (uint) vic_error;
     }
 
     // Default handler (fixes VIC 'feature'!)
@@ -34,18 +34,18 @@ void sark_vic_init(void)
 
 
 void sark_vic_set(vic_slot slot, uint interrupt, uint enable,
-		  int_handler handler)
+                  int_handler handler)
 {
     if (slot == SLOT_FIQ) {
-	sark_vec->fiq_vec = handler;
-	vic[VIC_SELECT] = 1 << interrupt;
+        sark_vec->fiq_vec = handler;
+        vic[VIC_SELECT] = 1 << interrupt;
     } else {
-	vic[VIC_ADDR + slot] = (uint) handler;
-	vic[VIC_CNTL + slot] = 0x20 | interrupt;
+        vic[VIC_ADDR + slot] = (uint) handler;
+        vic[VIC_CNTL + slot] = 0x20 | interrupt;
     }
 
     if (enable) {
-	vic[VIC_ENABLE] = 1 << interrupt;
+        vic[VIC_ENABLE] = 1 << interrupt;
     }
 }
 
@@ -58,9 +58,9 @@ uint v2p_mask(uint virt_mask)
     uint phys_mask = 0;
 
     for (uint i = 0; i < NUM_CPUS; i++) {
-	if (virt_mask & (1 << i)) {
-	    phys_mask |= 1 << sv->v2p_map[i];
-	}
+        if (virt_mask & (1 << i)) {
+            phys_mask |= 1 << sv->v2p_map[i];
+        }
     }
 
     return phys_mask;
@@ -71,7 +71,7 @@ uint v2p_mask(uint virt_mask)
 
 // Set up GPIO port for LED driving
 
-#if 0	// Superseded...
+#if 0   // Superseded...
 
 const uchar s0_leds[] = {0}; // Dummy
 const uchar s1_leds[] = {4, 0x01, 0x02, 0x40, 0x80};
@@ -80,7 +80,7 @@ const uchar s3_leds[] = {2, 0x01, 0x20};
 const uchar s4_leds[] = {1, 0x01};
 
 const uchar * const led_list[] = {
-	s0_leds, s1_leds, s2_leds, s3_leds, s4_leds};
+        s0_leds, s1_leds, s2_leds, s3_leds, s4_leds};
 const uchar led_bits[] = {0x00, 0xc3, 0x43, 0x21, 0x01};
 
 void led_init(void)
@@ -88,12 +88,12 @@ void led_init(void)
     uint hw_ver = sv->hw_ver;
 
     if (hw_ver < HW_VER_MIN || hw_ver > HW_VER_MAX) {
-	hw_ver = 0;
+        hw_ver = 0;
     }
 
-    sark_memcpy(sv->leds, led_list[hw_ver], 8);	// Point to appropriate table
-    sc[GPIO_SET] = led_bits[hw_ver];		// Turn LEDs off
-    sc[GPIO_DIR] &= ~led_bits[hw_ver];		// Clear bits in GPIO_DIR
+    sark_memcpy(sv->leds, led_list[hw_ver], 8); // Point to appropriate table
+    sc[GPIO_SET] = led_bits[hw_ver];            // Turn LEDs off
+    sc[GPIO_DIR] &= ~led_bits[hw_ver];          // Clear bits in GPIO_DIR
 }
 #endif
 
@@ -112,11 +112,11 @@ void sark_led_init(void)
     uint mask = 0;
 
     for (uint i = 1; i <= count; i++) {
-	mask |= 1 << get4(&sv->led0, i);
+        mask |= 1 << get4(&sv->led0, i);
     }
 
-    sc[GPIO_SET] = mask;		// Turn LEDs off
-    sc[GPIO_DIR] &= ~mask;		// Clear bits in GPIO_DIR
+    sc[GPIO_SET] = mask;                // Turn LEDs off
+    sc[GPIO_DIR] &= ~mask;              // Clear bits in GPIO_DIR
 }
 
 
@@ -127,25 +127,25 @@ void sark_led_set(uint leds)
     uint count = get4(&sv->led0, 0);
 
     for (uint i = 1; i <= count; i++) {
-	uint led = 1 << get4(&sv->led0, i);
-	uint v = leds & 1;
-	uint c = leds & 2;
+        uint led = 1 << get4(&sv->led0, i);
+        uint v = leds & 1;
+        uint c = leds & 2;
 
-	leds = leds >> 2;
+        leds = leds >> 2;
 
-	if (c == 0) {
-	    if (v != 0) {
-		v = sc[GPIO_PORT] & led;
-	    } else {
-		continue;
-	    }
-	}
+        if (c == 0) {
+            if (v != 0) {
+                v = sc[GPIO_PORT] & led;
+            } else {
+                continue;
+            }
+        }
 
-	if (v) {
-	    sc[GPIO_CLR] = led;
-	} else {
-	    sc[GPIO_SET] = led;
-	}
+        if (v) {
+            sc[GPIO_CLR] = led;
+        } else {
+            sc[GPIO_SET] = led;
+        }
     }
 }
 
@@ -159,20 +159,20 @@ void sark_led_set(uint leds)
 // Refresh period 7.8us
 
 const ushort pl340_data[] = {
-    0x0006,  	// [0]  MC_CASL CAS latency =3
-    0x0001,  	// [1]  MC_DQSS T_dqss
-    0x0002,  	// [2]  MC_MRD  T_mrd
-    0x0007,  	// [3]  MC_RAS  T_ras
-    0x000A,  	// [4]  MC_RC   T_rc
-    0x0003,  	// [5]  MC_RCD  T_rcd
-    0x0275,  	// [6]  MC_RFC  T_rfc
-    0x0003,  	// [7]  MC_RP   T_rp
-    0x0002,  	// [8]  MC_RRD  T_rrd
-    0x0003,  	// [9]  MC_WR   T_wr
-    0x0001,  	// [10] MC_WTR  T_wtr
-    0x0005,  	// [11] MC_XP   T_xp
-    0x0017,  	// [12] MC_XSR  T_xsr
-    0x0014  	// [13] MC_ESR  T_esr
+    0x0006,     // [0]  MC_CASL CAS latency =3
+    0x0001,     // [1]  MC_DQSS T_dqss
+    0x0002,     // [2]  MC_MRD  T_mrd
+    0x0007,     // [3]  MC_RAS  T_ras
+    0x000A,     // [4]  MC_RC   T_rc
+    0x0003,     // [5]  MC_RCD  T_rcd
+    0x0275,     // [6]  MC_RFC  T_rfc
+    0x0003,     // [7]  MC_RP   T_rp
+    0x0002,     // [8]  MC_RRD  T_rrd
+    0x0003,     // [9]  MC_WR   T_wr
+    0x0001,     // [10] MC_WTR  T_wtr
+    0x0005,     // [11] MC_XP   T_xp
+    0x0017,     // [12] MC_XSR  T_xsr
+    0x0014      // [13] MC_ESR  T_esr
 };
 
 
@@ -185,39 +185,39 @@ uint pl340_init(uint mem_clk)
 
     // Next 3 lines only really needed if re-initialising
 
-    mc[MC_CMD] = 0x00000003;		// -> Pause
-    mc[MC_CMD] = 0x00000004;		// -> Configure
-    mc[DLL_CONFIG0] = 0;		// Disable DLL
+    mc[MC_CMD] = 0x00000003;            // -> Pause
+    mc[MC_CMD] = 0x00000004;            // -> Configure
+    mc[DLL_CONFIG0] = 0;                // Disable DLL
 
     for (uint i = 0; i < 14; i++) {
-	mc[MC_CASL + i] = pl340_data[i];
+        mc[MC_CASL + i] = pl340_data[i];
     }
 
-    mc[MC_MCFG] = 0x00018012;		// Init Memory_Cfg
+    mc[MC_MCFG] = 0x00018012;           // Init Memory_Cfg
 
-    mc[MC_REFP] = refresh;		// Init refresh_prd reg
+    mc[MC_REFP] = refresh;              // Init refresh_prd reg
 
-    mc[MC_CCFG0] = 0x000060e0;		// Set config reg
+    mc[MC_CCFG0] = 0x000060e0;          // Set config reg
 
-    mc[MC_DIRC] = 0x000c0000;		// NOP
-    mc[MC_DIRC] = 0x00000000;		// PRECHARGEALL
-    mc[MC_DIRC] = 0x00040000;		// AUTOREFRESH
-    mc[MC_DIRC] = 0x00040000;		// AUTOREFRESH
+    mc[MC_DIRC] = 0x000c0000;           // NOP
+    mc[MC_DIRC] = 0x00000000;           // PRECHARGEALL
+    mc[MC_DIRC] = 0x00040000;           // AUTOREFRESH
+    mc[MC_DIRC] = 0x00040000;           // AUTOREFRESH
 
-    mc[MC_DIRC] = 0x00080033;		// MODEREG (burst=8)
+    mc[MC_DIRC] = 0x00080033;           // MODEREG (burst=8)
 
-    mc[MC_DIRC] = 0x000a0000;		// EXTMODEREG
+    mc[MC_DIRC] = 0x000a0000;           // EXTMODEREG
 
-    mc[MC_CMD] = 0x00000000;		// Enable memory
+    mc[MC_CMD] = 0x00000000;            // Enable memory
 
-    mc[DLL_CONFIG1] = 0x00000000;	// Clear fine-tune
-    mc[DLL_CONFIG0] = 0x01000000;	// Enable DLL
+    mc[DLL_CONFIG1] = 0x00000000;       // Clear fine-tune
+    mc[DLL_CONFIG0] = 0x01000000;       // Enable DLL
 
-    uint t = 100;	// Wait for lock with 100us timeout
+    uint t = 100;       // Wait for lock with 100us timeout
 
     while ((mc[DLL_STATUS] & (1 << 18)) == 0 && t != 0) {
-	sark_delay_us(1);
-	t--;
+        sark_delay_us(1);
+        t--;
     }
 
     return t;
@@ -233,15 +233,15 @@ uint pl340_init(uint mem_clk)
 uint rtr_mc_clear(uint start, uint count)
 {
     if (start + count > MC_TABLE_SIZE) {
-	return 0;
+        return 0;
     }
 
     rtr_entry_t *router = sv->rtr_copy;
 
     for (uint i = start; i < start + count; i++) {
-	router[i].route  = rtr_ram[i]  = 0xff000000;
-	router[i].mask   = rtr_mask[i] = 0;
-	router[i].key    = rtr_key[i] =  0xffffffff;
+        router[i].route  = rtr_ram[i]  = 0xff000000;
+        router[i].mask   = rtr_mask[i] = 0;
+        router[i].key    = rtr_key[i] =  0xffffffff;
     }
 
     return 1;
@@ -283,24 +283,24 @@ void rtr_mc_init(uint start)
 uint rtr_mc_load(rtr_entry_t *e, uint count, uint offset, uint app_id)
 {
     if (count == 0) {
-	count = e->free;
+        count = e->free;
     }
 
     if (count > MC_TABLE_SIZE) {
-	return 0;
+        return 0;
     }
 
     app_id <<= 24;
 
     for (uint i = 0; i < count; i++) {
-	uint entry = e->next + offset;
+        uint entry = e->next + offset;
 
-	if (entry >= MC_TABLE_SIZE) {
-	    return 0;
-	}
+        if (entry >= MC_TABLE_SIZE) {
+            return 0;
+        }
 
-	rtr_mc_set(entry, e->key, e->mask, app_id + e->route);
-	e++;
+        rtr_mc_set(entry, e->key, e->mask, app_id + e->route);
+        e++;
     }
 
     return 1;
@@ -312,14 +312,14 @@ uint rtr_mc_load(rtr_entry_t *e, uint count, uint offset, uint app_id)
 uint rtr_mc_set(uint entry, uint key, uint mask, uint route)
 {
     if (entry >= MC_TABLE_SIZE) {
-	return 0;
+        return 0;
     }
 
     rtr_entry_t *copy = sv->rtr_copy + entry;
     uint app_id = route >> 24;
 
     if (app_id == 0) {
-	app_id = sark_vec->app_id;
+        app_id = sark_vec->app_id;
     }
 
     route &= 0x00ffffff;
@@ -346,7 +346,7 @@ uint rtr_mc_set(uint entry, uint key, uint mask, uint route)
 uint rtr_mc_get(uint entry, rtr_entry_t *r)
 {
     if (entry >= MC_TABLE_SIZE) {
-	return 0;
+        return 0;
     }
 
     rtr_entry_t *copy = sv->rtr_copy + entry;
@@ -387,7 +387,7 @@ uint rtr_fr_get(void)
 void rtr_p2p_init()
 {
     for (uint i = 0; i < P2P_TABLE_SIZE; i++) {
-	rtr_p2p[i] = P2P_INIT;
+        rtr_p2p[i] = P2P_INIT;
     }
 }
 
@@ -399,7 +399,7 @@ void rtr_p2p_set(uint entry, uint value)
     uint word = entry >> P2P_LOG_EPW;
 
     if (word >= P2P_TABLE_SIZE) {
-	return;
+        return;
     }
 
     uint offset = P2P_BPE * (entry & P2P_EMASK);
@@ -419,7 +419,7 @@ uint rtr_p2p_get(uint entry)
     uint word = entry >> P2P_LOG_EPW;
 
     if (word >= P2P_TABLE_SIZE) {
-	return 6;
+        return 6;
     }
 
     uint offset = P2P_BPE * (entry & P2P_EMASK);
@@ -430,44 +430,44 @@ uint rtr_p2p_get(uint entry)
 
 
 static const uint dgf_init[] = {
-    0x01fe7cf1,		// 0  local MC packets
-    0x01febcf1,		// 1  non-local MC packets
-    0x01fe7cf2,		// 2  local P2P packets
-    0x01febcf2,		// 3  non-local P2P packets
-    0x01fe7cf4,		// 4  local NN packets
-    0x01febcf4,		// 5  non-local NN packets
-    0x01fe7cf8,		// 6  local FR packets
-    0x01febcf8,		// 7  non-local FR packets
-    0x0001fcf1,		// 8  dumped MC packets
-    0x0001fcf2,		// 9  dumped P2P packets
-    0x0001fcf4,		// 10 dumped NN packets
-    0x0001fcf8,		// 11 dumped FR packets
-    0x00000000,		// 12
-    0x00000000,		// 13
-    0x00000000,		// 14
-    0x00000000		// 15
+    0x01fe7cf1,         // 0  local MC packets
+    0x01febcf1,         // 1  non-local MC packets
+    0x01fe7cf2,         // 2  local P2P packets
+    0x01febcf2,         // 3  non-local P2P packets
+    0x01fe7cf4,         // 4  local NN packets
+    0x01febcf4,         // 5  non-local NN packets
+    0x01fe7cf8,         // 6  local FR packets
+    0x01febcf8,         // 7  non-local FR packets
+    0x0001fcf1,         // 8  dumped MC packets
+    0x0001fcf2,         // 9  dumped P2P packets
+    0x0001fcf4,         // 10 dumped NN packets
+    0x0001fcf8,         // 11 dumped FR packets
+    0x00000000,         // 12
+    0x00000000,         // 13
+    0x00000000,         // 14
+    0x00000000          // 15
 };
 
 
 void rtr_diag_init(const uint *table)
 {
-    rtr[RTR_DGEN] = 0xffff0000;		// Disable and clear all 16 counters
+    rtr[RTR_DGEN] = 0xffff0000;         // Disable and clear all 16 counters
 
     volatile uint *rtr_dgf = &rtr[RTR_DGF0];
 
-    for (uint i = 0; i < 16; i++) {	// Copy filter registers
-	rtr_dgf[i] = table[i];
+    for (uint i = 0; i < 16; i++) {     // Copy filter registers
+        rtr_dgf[i] = table[i];
     }
 
-    rtr[RTR_DGEN] = 0x0000ffff;		// Enable 16 counters
+    rtr[RTR_DGEN] = 0x0000ffff;         // Enable 16 counters
 }
 
 
 void rtr_init(uint monitor)
 {
-    rtr_p2p_init();		// Clear P2P table
-    rtr_mc_init(0);		// and MC tables
-    rtr_diag_init(dgf_init);	// Set up diagnostic regs
+    rtr_p2p_init();             // Clear P2P table
+    rtr_mc_init(0);             // and MC tables
+    rtr_diag_init(dgf_init);    // Set up diagnostic regs
 
     // Enable, MP=0, Wait1=256
     rtr[RTR_CONTROL] = 0x00400001 | (monitor << 8);

--- a/sark/sark_io.c
+++ b/sark/sark_io.c
@@ -1,11 +1,11 @@
 //------------------------------------------------------------------------------
 //
-// sark_io.c	    Simple character I/O library for Spinnaker
+// sark_io.c        Simple character I/O library for Spinnaker
 //
 // Copyright (C)    The University of Manchester - 2009, 2010, 2011
 //
 // Author           Steve Temple, APT Group, School of Computer Science
-//		    Fixed point formats by Paul Richmond (Univ. of Sheffield)
+//                  Fixed point formats by Paul Richmond (Univ. of Sheffield)
 //                                     and Dave Lester (APT Group)
 //
 // Email            temples@cs.man.ac.uk
@@ -35,11 +35,11 @@ typedef struct iobuf {
 } iobuf_t;
 
 
-static uint sp_ptr;		// Buffer pointer for 'sprintf'
-static uint buf_ptr;		// Buffer pointer for IO_BUF
+static uint sp_ptr;             // Buffer pointer for 'sprintf'
+static uint buf_ptr;            // Buffer pointer for IO_BUF
 
-static sdp_msg_t *io_msg;	// Points to SDP buffer
-static iobuf_t   *io_buf;	// Points to SDRAM buffer
+static sdp_msg_t *io_msg;       // Points to SDP buffer
+static iobuf_t   *io_buf;       // Points to SDRAM buffer
 
 static const char hex[] = "0123456789abcdef";
 
@@ -53,20 +53,20 @@ static sdp_msg_t *io_std_init()
 {
     sdp_msg_t *msg = sark_alloc(1, sizeof(sdp_msg_t));
     if (msg == NULL) {
-	rt_error(RTE_IOBUF);
+        rt_error(RTE_IOBUF);
     }
 
     msg->flags = 0x07;
     msg->tag = TAG_HOST;
 
-    msg->dest_port = PORT_ETH;	// Take from dbg_addr?
+    msg->dest_port = PORT_ETH;  // Take from dbg_addr?
     msg->dest_addr = sv->dbg_addr;
 
     msg->srce_port = sark.virt_cpu;
     msg->srce_addr = sv->p2p_addr;
 
     msg->cmd_rc = CMD_TUBE;
-    msg->length = 12;		// !! const (SDP header + command word)
+    msg->length = 12;           // !! const (SDP header + command word)
 
     return msg;
 }
@@ -75,9 +75,9 @@ static sdp_msg_t *io_std_init()
 static iobuf_t *io_buf_init()
 {
     iobuf_t *iobuf = sark_xalloc(sv->sys_heap,
-	    sizeof(iobuf_t) + sv->iobuf_size, 0, 1);
+            sizeof(iobuf_t) + sv->iobuf_size, 0, 1);
     if (iobuf == NULL) {
-	rt_error(RTE_IOBUF);
+        rt_error(RTE_IOBUF);
     }
 
     iobuf->unix_time = sv->unix_time;
@@ -112,14 +112,14 @@ void sark_io_buf_reset(void)
 
     // if there are other iobuf blocks, cycle and free
     while (io_buf_to_free != NULL) {
-	// record location of next iobuf block
-	iobuf_t *next_io_buf = io_buf_to_free->next;
+        // record location of next iobuf block
+        iobuf_t *next_io_buf = io_buf_to_free->next;
 
-	// free the current iobuf block
-	sark_xfree(sv->sys_heap, (void *) io_buf_to_free, 1);
+        // free the current iobuf block
+        sark_xfree(sv->sys_heap, (void *) io_buf_to_free, 1);
 
-	// update current pointer to next iobuf block
-	io_buf_to_free = next_io_buf;
+        // update current pointer to next iobuf block
+        io_buf_to_free = next_io_buf;
     }
 }
 
@@ -134,35 +134,35 @@ void sark_io_buf_reset(void)
 void io_put_char(char *stream, uint c)
 {
     if (stream > IO_NULL) {
-	stream[sp_ptr++] = c;
-	stream[sp_ptr] = 0;
+        stream[sp_ptr++] = c;
+        stream[sp_ptr] = 0;
     } else if (stream == IO_STD) {
-	if (io_msg == NULL) {
-	    io_msg = io_std_init();
-	}
+        if (io_msg == NULL) {
+            io_msg = io_std_init();
+        }
 
-	uchar *buf = (uchar *) &io_msg->flags;	// Point at start of msg
+        uchar *buf = (uchar *) &io_msg->flags;  // Point at start of msg
 
-	buf[io_msg->length++] = c;		// Insert char at end
+        buf[io_msg->length++] = c;              // Insert char at end
 
-	if (c == '\n' || c == 0 || io_msg->length == SDP_BUF_SIZE + 12) { // !! const
-	    sark_msg_send(io_msg, 10);	// !! const
-	    io_msg->length = 12;	// !! const
-	}
+        if (c == '\n' || c == 0 || io_msg->length == SDP_BUF_SIZE + 12) { // !! const
+            sark_msg_send(io_msg, 10);  // !! const
+            io_msg->length = 12;        // !! const
+        }
     } else if (stream == IO_BUF) {
-	if (io_buf == NULL) {
-	    io_buf = sark.vcpu->iobuf = io_buf_init();
-	}
+        if (io_buf == NULL) {
+            io_buf = sark.vcpu->iobuf = io_buf_init();
+        }
 
-	io_buf->buf[buf_ptr++] = c;
+        io_buf->buf[buf_ptr++] = c;
 
-	if (buf_ptr == sv->iobuf_size) {
-	    io_buf->ptr = buf_ptr;
-	    io_buf->next = io_buf_init();
-	    io_buf = io_buf->next;
-	} else if (c == '\n' || c == 0) {
-	    io_buf->ptr = buf_ptr;
-	}
+        if (buf_ptr == sv->iobuf_size) {
+            io_buf->ptr = buf_ptr;
+            io_buf->next = io_buf_init();
+            io_buf = io_buf->next;
+        } else if (c == '\n' || c == 0) {
+            io_buf->ptr = buf_ptr;
+        }
     }
 }
 
@@ -180,13 +180,13 @@ static void io_put_str(char *stream, char *s, int d)
     int n = 0;
 
     while (*t++) {
-	n++;
+        n++;
     }
     while (d-- > n) {
-	io_put_char(stream, ' ');
+        io_put_char(stream, ' ');
     }
     while (*s) {
-	io_put_char(stream, *s++);
+        io_put_char(stream, *s++);
     }
 }
 
@@ -201,28 +201,28 @@ static void io_put_int(char *stream, int n, uint d, uint pad) // pad not used!
     uint neg = 0;
 
     if (n < 0) {
-	n = -n;
-	neg = '-';
+        n = -n;
+        neg = '-';
     }
 
     do {
-	divmod_t r = sark_div10(n);
+        divmod_t r = sark_div10(n);
 
-	s[i++] = r.mod + '0';
-	n = r.div;
+        s[i++] = r.mod + '0';
+        n = r.div;
     } while (n != 0);
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
     if (neg) {
-	s[++i] = neg;
+        s[++i] = neg;
     }
     while (d-- > i + 1) {
-	io_put_char(stream, ' ');
+        io_put_char(stream, ' ');
     }
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
@@ -236,20 +236,20 @@ static void io_put_uint(char *stream, uint n, uint d, uint pad)
     int i = 0;
 
     do {
-	divmod_t r = sark_div10(n);
+        divmod_t r = sark_div10(n);
 
-	s[i++] = r.mod + '0';
-	n = r.div;
+        s[i++] = r.mod + '0';
+        n = r.div;
     } while (n != 0);
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
     while (d-- > i + 1) {
-	io_put_char(stream, pad);
+        io_put_char(stream, pad);
     }
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
@@ -260,7 +260,7 @@ static void io_put_uint(char *stream, uint n, uint d, uint pad)
 static void io_put_zhex(char *stream, uint n, uint d)
 {
     for (int i = d - 1; i >= 0; i--) {
-	io_put_char(stream, hex[(n >> (4 * i)) & 15]);
+        io_put_char(stream, hex[(n >> (4 * i)) & 15]);
     }
 }
 
@@ -274,18 +274,18 @@ static void io_put_hex(char *stream, uint n, uint d, uint pad)
     int i = 0;
 
     do {
-	s[i++] = hex[n & 15];
-	n = n >> 4;
+        s[i++] = hex[n & 15];
+        n = n >> 4;
     } while (n != 0);
 
     while (i > 0 && s[--i] == '0') {
-	continue;
+        continue;
     }
     while (d-- > i + 1) {
-	io_put_char(stream, pad);
+        io_put_char(stream, pad);
     }
     while (i >= 0) {
-	io_put_char(stream, s[i--]);
+        io_put_char(stream, s[i--]);
     }
 }
 
@@ -298,10 +298,10 @@ static void io_put_hex(char *stream, uint n, uint d, uint pad)
 static void io_put_mac(char *stream, uchar *s)
 {
     for (uint i = 0; i < 6; i++) {
-	io_put_zhex(stream, s[i], 2);
-	if (i != 5) {
-	    io_put_char(stream, ':');
-	}
+        io_put_zhex(stream, s[i], 2);
+        if (i != 5) {
+            io_put_char(stream, ':');
+        }
     }
 }
 
@@ -309,10 +309,10 @@ static void io_put_mac(char *stream, uchar *s)
 static void io_put_ip(char *stream, uchar *s)
 {
     for (uint i = 0; i < 4; i++) {
-	io_put_int(stream, s[i], 0, 0);
-	if (i != 3) {
-	    io_put_char(stream, '.');
-	}
+        io_put_int(stream, s[i], 0, 0);
+        if (i != 3) {
+            io_put_char(stream, '.');
+        }
     }
 }
 #endif
@@ -334,14 +334,14 @@ void io_put_fixed(char *stream, uint n, uint d, uint a, uint pad, int neg)
     // fractional part
 
     f = n;
-    if (a > 12) {	// maximum precision of 12 to prevent overflow
-	a = 12;
+    if (a > 12) {       // maximum precision of 12 to prevent overflow
+        a = 12;
     }
 
     while (i < a) {
-	f &= 0x0000ffff;
-	f *= 10;
-	s[a - ++i] = (f >> 16) + '0';
+        f &= 0x0000ffff;
+        f *= 10;
+        s[a - ++i] = (f >> 16) + '0';
     }
 
     //set carry for rounding
@@ -354,40 +354,40 @@ void io_put_fixed(char *stream, uint n, uint d, uint a, uint pad, int neg)
 
     f = 0;
     while ((c) && (f < a)) {
-	if (s[f] >= '9') {
-	    s[f++] = '0';
-	} else {
-	    s[f++]++;
-	    c=0;
-	}
+        if (s[f] >= '9') {
+            s[f++] = '0';
+        } else {
+            s[f++]++;
+            c=0;
+        }
     }
 
     // add decimal
 
     if (a) {
-	s[i++] = '.';
+        s[i++] = '.';
     }
 
     // integer part
 
-    n = (n >> 16) + c;	// add the carry
+    n = (n >> 16) + c;  // add the carry
 
     do {
-	divmod_t r = sark_div10(n);
+        divmod_t r = sark_div10(n);
 
-	s[i++] = r.mod + '0';
-	n = r.div;
+        s[i++] = r.mod + '0';
+        n = r.div;
     } while (n != 0);
 
-    if (neg) {		// <drl add>
-	s[i++] = '-';
+    if (neg) {          // <drl add>
+        s[i++] = '-';
     }
 
     while (d-- > (i+1)) {
-	io_put_char(stream, pad);
+        io_put_char(stream, pad);
     }
     while (i > 0) {
-	io_put_char(stream, s[--i]);
+        io_put_char(stream, s[--i]);
     }
 }
 
@@ -429,87 +429,87 @@ void io_printf(char *stream, char *f, ...)
     va_list ap;
 
     if (stream == IO_NULL) {
-	return;
+        return;
     } else if (stream > IO_NULL) {
-	sp_ptr = stream[0] = 0;
+        sp_ptr = stream[0] = 0;
     }
 
     va_start(ap, f);
 
     while (1) {
-	char c = *f++;
+        char c = *f++;
 
-	if (c == 0) {
-	    return;
-	}
+        if (c == 0) {
+            return;
+        }
 
-	if (c != '%') {
-	    io_put_char(stream, c);
-	    continue;
-	}
+        if (c != '%') {
+            io_put_char(stream, c);
+            continue;
+        }
 
-	c = *f++;
+        c = *f++;
 
-	if (c == 0) {
-	    return;
-	}
+        if (c == 0) {
+            return;
+        }
 
-	char pad = ' ';
+        char pad = ' ';
 
-	if (c == '0') {
-	    pad = c;
-	}
+        if (c == '0') {
+            pad = c;
+        }
 
-	uint size = 0;
+        uint size = 0;
 
-	while (c >= '0' && c <= '9') {
-	    size = 10 * size + c - '0';
-	    c = *f++;
-	    if (c == 0) {
-		return;
-	    }
-	}
+        while (c >= '0' && c <= '9') {
+            size = 10 * size + c - '0';
+            c = *f++;
+            if (c == 0) {
+                return;
+            }
+        }
 
 #ifdef SPINN_IO_FIX
-	uint precision = 6;
+        uint precision = 6;
 
-	if (c == '.') {
-	    precision = 0;
-	    c = *f++;
+        if (c == '.') {
+            precision = 0;
+            c = *f++;
 
-	    while (c >= '0' && c <= '9') {
-		precision = 10 * precision + c - '0';
-		c = *f++;
-	    }
+            while (c >= '0' && c <= '9') {
+                precision = 10 * precision + c - '0';
+                c = *f++;
+            }
 
-	    if (c == 0) {
-		return;
-	    }
-	}
+            if (c == 0) {
+                return;
+            }
+        }
 #endif // SPINN_IO_FIX
 
 #ifdef SPINN_IO_NET
-	uint t;
+        uint t;
 #endif // SPINN_IO_NET
 
-	switch (c) {
-	case 'c':
-	    io_put_char(stream, va_arg(ap, uint));
-	    break;
+        switch (c) {
+        case 'c':
+            io_put_char(stream, va_arg(ap, uint));
+            break;
 
-	case 's':
-	    io_put_str(stream, va_arg(ap, char *), size);
-	    break;
+        case 's':
+            io_put_str(stream, va_arg(ap, char *), size);
+            break;
 
-	case 'd':
-	    io_put_int(stream, va_arg(ap, int), size, pad);
-	    break;
+        case 'd':
+            io_put_int(stream, va_arg(ap, int), size, pad);
+            break;
 
-	case 'u':
-	    io_put_uint(stream, va_arg(ap, uint), size, pad);
-	    break;
+        case 'u':
+            io_put_uint(stream, va_arg(ap, uint), size, pad);
+            break;
 #ifdef SPINN_IO_FIX
-	case 'f': // Paul Richmond's FP format (u1616)
+        case 'f': // Paul Richmond's FP format (u1616)
 // <drl add>
         case 'K': // ISO unsigned accum (u1616)
             io_put_ufixed(stream, va_arg(ap, uint), size, precision, pad);
@@ -525,37 +525,37 @@ void io_printf(char *stream, char *f, ...)
             break;
 // </drl add>
 #endif // SPINN_IO_FIX
-	case 'x': // hex, digits as needed
-	    io_put_hex(stream, va_arg(ap, uint), size, pad);
-	    break;
+        case 'x': // hex, digits as needed
+            io_put_hex(stream, va_arg(ap, uint), size, pad);
+            break;
 
-	case 'z': // zero prefixed hex, exactly "size" digits
-	    io_put_zhex(stream, va_arg(ap, uint), size);
-	    break;
+        case 'z': // zero prefixed hex, exactly "size" digits
+            io_put_zhex(stream, va_arg(ap, uint), size);
+            break;
 #ifdef SPINN_IO_NET
-	case 'h': // pointer to network short (hex)
-	    t = va_arg(ap, uint);
-	    t = * (ushort *) t;
-	    io_put_zhex(stream, ntohs(t), size);
-	    break;
+        case 'h': // pointer to network short (hex)
+            t = va_arg(ap, uint);
+            t = * (ushort *) t;
+            io_put_zhex(stream, ntohs(t), size);
+            break;
 
-	case 'i': // pointer to network short (decimal)
-	    t = va_arg(ap, uint);
-	    t = * (ushort *) t;
-	    io_put_uint(stream, ntohs(t), size, pad);
-	    break;
+        case 'i': // pointer to network short (decimal)
+            t = va_arg(ap, uint);
+            t = * (ushort *) t;
+            io_put_uint(stream, ntohs(t), size, pad);
+            break;
 
-	case 'p': // pointer to IP address
-	    io_put_ip(stream, va_arg(ap, uchar *));
-	    break;
+        case 'p': // pointer to IP address
+            io_put_ip(stream, va_arg(ap, uchar *));
+            break;
 
-	case 'm': // pointer to MAC address
-	    io_put_mac(stream, va_arg(ap, uchar *));
-	    break;
+        case 'm': // pointer to MAC address
+            io_put_mac(stream, va_arg(ap, uchar *));
+            break;
 #endif // SPINN_IO_NET
-	default:
-	    io_put_char(stream, c);
-	}
+        default:
+            io_put_char(stream, c);
+        }
     }
     //  va_end(ap);
 }

--- a/sark/sark_isr.c
+++ b/sark/sark_isr.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_isr.c	    Interrupt handlers for SARK
+// sark_isr.c       Interrupt handlers for SARK
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -39,17 +39,17 @@ INT_HANDLER txpkt_int_han()
     pkt_t *pkt = event.pkt_queue + event.pkt_remove;
 
     if (pkt->ctrl & 1) {
-	cc[CC_TCR] = pkt->ctrl;
+        cc[CC_TCR] = pkt->ctrl;
     }
     if (pkt->ctrl & 2) {
-	cc[CC_TXDATA] = pkt->data;
+        cc[CC_TXDATA] = pkt->data;
     }
 
     cc[CC_TXKEY] = pkt->key;
 
     event.pkt_count--;
     if (event.pkt_count == 0) {
-	vic[VIC_DISABLE] = 1 << CC_TNF_INT;
+        vic[VIC_DISABLE] = 1 << CC_TNF_INT;
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -66,7 +66,7 @@ INT_HANDLER user_null(void)
     uint slot = sark_vec->event[EVENT_USER].slot;
 
     if (slot != SLOT_FIQ) {
-	vic[VIC_VADDR] = (uint) vic;
+        vic[VIC_VADDR] = (uint) vic;
     }
 }
 
@@ -119,7 +119,7 @@ INT_HANDLER sdp_null(void)
     uint slot = sark_vec->event[EVENT_USER].slot;
 
     if (slot != SLOT_FIQ) {
-	vic[VIC_VADDR] = (uint) vic;
+        vic[VIC_VADDR] = (uint) vic;
     }
 }
 
@@ -177,7 +177,7 @@ INT_HANDLER rxpkt_null(void)
     uint slot = sark_vec->event[EVENT_RXPKT].slot;
 
     if (slot != SLOT_FIQ) {
-	vic[VIC_VADDR] = (uint) vic;
+        vic[VIC_VADDR] = (uint) vic;
     }
 }
 
@@ -231,7 +231,7 @@ INT_HANDLER timer_null(void)
     uint slot = sark_vec->event[EVENT_TIMER].slot;
 
     if (slot != SLOT_FIQ) {
-	vic[VIC_VADDR] = (uint) vic;
+        vic[VIC_VADDR] = (uint) vic;
     }
 }
 
@@ -290,7 +290,7 @@ INT_HANDLER sig_null(void)
     uint slot = sark_vec->event[EVENT_SIG].slot;
 
     if (slot != SLOT_FIQ) {
-	vic[VIC_VADDR] = (uint) vic;
+        vic[VIC_VADDR] = (uint) vic;
     }
 }
 

--- a/sark/sark_pkt.c
+++ b/sark/sark_pkt.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_pkt.c	    Packet handling routines for SARK
+// sark_pkt.c       Packet handling routines for SARK
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -19,21 +19,21 @@ extern INT_HANDLER txpkt_int_han(void);
 void event_register_pkt(uint queue_size, vic_slot slot)
 {
     if (queue_size <= 256 &&
-	    (queue_size & (queue_size - 1)) == 0 &&
-	    slot <= SLOT_MAX &&
-	    vic[VIC_CNTL + slot] == 0) {
-	event.pkt_queue = sark_alloc(queue_size, sizeof(pkt_t));
+            (queue_size & (queue_size - 1)) == 0 &&
+            slot <= SLOT_MAX &&
+            vic[VIC_CNTL + slot] == 0) {
+        event.pkt_queue = sark_alloc(queue_size, sizeof(pkt_t));
 
-	if (event.pkt_queue != NULL) {
-	    event.pkt_insert = 1;
-	    event.pkt_size = queue_size;
+        if (event.pkt_queue != NULL) {
+            event.pkt_insert = 1;
+            event.pkt_size = queue_size;
 
-	    sark_vic_set(slot, CC_TNF_INT, 0, txpkt_int_han);
+            sark_vic_set(slot, CC_TNF_INT, 0, txpkt_int_han);
 
-	    cc[CC_TCR] = PKT_MC;
+            cc[CC_TCR] = PKT_MC;
 
-	    return;
-	}
+            return;
+        }
     }
 
     rt_error(RTE_PKT);
@@ -52,18 +52,18 @@ uint pkt_tx_kdc(uint key, uint data, uint ctrl)
     uint cpsr = cpu_int_disable();
 
     if (event.pkt_count >= event.pkt_size) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (event.pkt_count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TNF_INT;
+        vic[VIC_ENABLE] = 1 << CC_TNF_INT;
     }
 
     event.pkt_count++;
 
     if (event.pkt_count > event.pkt_max) {
-	event.pkt_max = event.pkt_count;
+        event.pkt_max = event.pkt_count;
     }
 
     event.pkt_queue[event.pkt_insert] = pkt;
@@ -82,18 +82,18 @@ uint pkt_tx_kd(uint key, uint data)
     uint cpsr = cpu_int_disable();
 
     if (event.pkt_count >= event.pkt_size) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (event.pkt_count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TNF_INT;
+        vic[VIC_ENABLE] = 1 << CC_TNF_INT;
     }
 
     event.pkt_count++;
 
     if (event.pkt_count > event.pkt_max) {
-	event.pkt_max = event.pkt_count;
+        event.pkt_max = event.pkt_count;
     }
 
     event.pkt_queue[event.pkt_insert] = pkt;
@@ -112,17 +112,17 @@ uint pkt_tx_k(uint key)
     uint cpsr = cpu_int_disable();
 
     if (event.pkt_count >= event.pkt_size) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (event.pkt_count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TNF_INT;
+        vic[VIC_ENABLE] = 1 << CC_TNF_INT;
     }
 
     event.pkt_count++;
     if (event.pkt_count > event.pkt_max) {
-	event.pkt_max = event.pkt_count;
+        event.pkt_max = event.pkt_count;
     }
 
     event.pkt_queue[event.pkt_insert] = pkt;
@@ -141,17 +141,17 @@ uint pkt_tx_kc(uint key, uint ctrl)
     uint cpsr = cpu_int_disable();
 
     if (event.pkt_count >= event.pkt_size) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (event.pkt_count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TNF_INT;
+        vic[VIC_ENABLE] = 1 << CC_TNF_INT;
     }
 
     event.pkt_count++;
     if (event.pkt_count > event.pkt_max) {
-	event.pkt_max = event.pkt_count;
+        event.pkt_max = event.pkt_count;
     }
 
     event.pkt_queue[event.pkt_insert] = pkt;

--- a/sark/sark_timer.c
+++ b/sark/sark_timer.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// sark_timer.c	    Timer routines for SARK
+// sark_timer.c     Timer routines for SARK
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -19,13 +19,13 @@ extern INT_HANDLER timer2_int_han(void);
 void event_register_timer(vic_slot slot)
 {
     if (vic[VIC_CNTL + slot] == 0) {
-	tc[T2_CONTROL] = 0;			// Disable timer
+        tc[T2_CONTROL] = 0;                     // Disable timer
 
-	event.vic_enable |= 1 << TIMER2_INT;	// Disabled by event_stop
+        event.vic_enable |= 1 << TIMER2_INT;    // Disabled by event_stop
 
-	sark_vic_set(slot, TIMER2_INT, 1, timer2_int_han);
+        sark_vic_set(slot, TIMER2_INT, 1, timer2_int_han);
     } else {
-	rt_error(RTE_TIMER);
+        rt_error(RTE_TIMER);
     }
 }
 
@@ -38,32 +38,32 @@ void event_register_timer(vic_slot slot)
 
 void timer_schedule(event_t *e, uint time)
 {
-    time *= sark.cpu_clk;			// Convert us to timer ticks
+    time *= sark.cpu_clk;                       // Convert us to timer ticks
 
     uint cpsr = cpu_int_disable();
 
-    if (event.timer_queue == NULL) {		// Queue empty - just insert
-	event.timer_queue = e;
+    if (event.timer_queue == NULL) {            // Queue empty - just insert
+        event.timer_queue = e;
 
-	tc[T2_LOAD] = time;
-	tc[T2_CONTROL] = 0xe3;
+        tc[T2_LOAD] = time;
+        tc[T2_CONTROL] = 0xe3;
 
-	cpu_int_restore(cpsr);
-	return;
+        cpu_int_restore(cpsr);
+        return;
     }
 
     uint t2c = tc[T2_COUNT];
 
-    if (time < t2c) {		 		// Earlier than current head - replace
-	tc[T2_LOAD] = time;			// Set counter to new time
+    if (time < t2c) {                           // Earlier than current head - replace
+        tc[T2_LOAD] = time;                     // Set counter to new time
 
-	event.timer_queue->time = t2c - time;	// Adjust old head time
+        event.timer_queue->time = t2c - time;   // Adjust old head time
 
-	e->next = event.timer_queue;		// and insert new timer at head
-	event.timer_queue = e;
+        e->next = event.timer_queue;            // and insert new timer at head
+        event.timer_queue = e;
 
-	cpu_int_restore(cpsr);
-	return;
+        cpu_int_restore(cpsr);
+        return;
     }
 
     // (time >= t2c) - Insert in correct place in queue (tricky!)
@@ -77,16 +77,16 @@ void timer_schedule(event_t *e, uint time)
     time -= t2c;
 
     while (q != NULL) {
-	total += q->time;
+        total += q->time;
 
-	if (total > time) {
-	    q->time = total - time;
-	    break;
-	}
+        if (total > time) {
+            q->time = total - time;
+            break;
+        }
 
-	pq = q;
-	ptotal += q->time;
-	q = q->next;
+        pq = q;
+        ptotal += q->time;
+        q = q->next;
     }
 
     e->time = time - ptotal;
@@ -109,7 +109,7 @@ uint timer_schedule_proc(event_proc proc, uint arg1, uint arg2, uint time)
 {
     event_t *e = event_new(proc, arg1, arg2);
     if (e == NULL) {
-	return 0;
+        return 0;
     }
 
     timer_schedule(e, time);
@@ -132,41 +132,41 @@ uint timer_schedule_proc(event_proc proc, uint arg1, uint arg2, uint time)
 void timer_cancel(event_t *e, uint ID)
 {
     if (e == NULL) {
-	rt_error(RTE_NULL);
+        rt_error(RTE_NULL);
     }
 
-    if (e->ID != ID) {		// Still active (return if not)
-	return;
+    if (e->ID != ID) {          // Still active (return if not)
+        return;
     }
 
     uint cpsr = cpu_int_disable();
     event_t* q = event.timer_queue;
 
-    if (q == e) { 		// At head of queue - nullify proc
-	e->proc = NULL;
-    } else {			// Further down queue - remove
-	event_t* pq = q;
-	q = q->next;
+    if (q == e) {               // At head of queue - nullify proc
+        e->proc = NULL;
+    } else {                    // Further down queue - remove
+        event_t* pq = q;
+        q = q->next;
 
-	while (q != NULL) {
-	    if (q == e) {
-		pq->next = e->next;
+        while (q != NULL) {
+            if (q == e) {
+                pq->next = e->next;
 
-		if (e->next != NULL) {	// Add our time to next in queue
-		    e->next->time += e->time;
-		}
+                if (e->next != NULL) {  // Add our time to next in queue
+                    e->next->time += e->time;
+                }
 
-		e->next = event.free;	// Return to free queue
-		event.free = e;
-		e->ID = 0;
-		event.count--;
+                e->next = event.free;   // Return to free queue
+                event.free = e;
+                e->ID = 0;
+                event.count--;
 
-		break;
-	    }
+                break;
+            }
 
-	    pq = q;
-	    q = q->next;
-	}
+            pq = q;
+            q = q->next;
+        }
     }
 
     cpu_int_restore(cpsr);
@@ -180,42 +180,42 @@ void timer_cancel(event_t *e, uint ID)
 
 void timer2_int(void)
 {
-    tc[T2_INT_CLR] = (uint) tc;		// Clear interrupt in timer
+    tc[T2_INT_CLR] = (uint) tc;         // Clear interrupt in timer
 
-    event_t *e = event.timer_queue;	// Pointer to timer queue
-    event_t *eq = NULL;			// Accumulates list of events to execute
+    event_t *e = event.timer_queue;     // Pointer to timer queue
+    event_t *eq = NULL;                 // Accumulates list of events to execute
 
-    while (e != NULL && e->time == 0) {	// Process all in queue with time=0
-	event_t* next = e->next;	// Remove head of event queue
-	event.timer_queue = next;
+    while (e != NULL && e->time == 0) { // Process all in queue with time=0
+        event_t* next = e->next;        // Remove head of event queue
+        event.timer_queue = next;
 
-	e->next = eq;			// Move to exec queue
-	eq = e;
+        e->next = eq;                   // Move to exec queue
+        eq = e;
 
-	e = next;			// Move to next entry
+        e = next;                       // Move to next entry
     }
 
-    if (e != NULL) {			// If entries remain in queue
-	tc[T2_LOAD] = e->time;		// Put first one into timer
-	e->time = 0;			// and set its time to zero
+    if (e != NULL) {                    // If entries remain in queue
+        tc[T2_LOAD] = e->time;          // Put first one into timer
+        e->time = 0;                    // and set its time to zero
     }
 
-    while (eq != NULL) {		// Run the execute queue
-	if (eq->proc != NULL) {		// Execute proc if non-NULL
-	    eq->proc(eq->arg1, eq->arg2);
-	}
+    while (eq != NULL) {                // Run the execute queue
+        if (eq->proc != NULL) {         // Execute proc if non-NULL
+            eq->proc(eq->arg1, eq->arg2);
+        }
 
-	event_t* next = eq->next;
+        event_t* next = eq->next;
 
-	eq->next = event.free;		// Return to free queue
-	event.free = eq;
-	eq->ID = 0;
-	event.count--;
+        eq->next = event.free;          // Return to free queue
+        event.free = eq;
+        eq->ID = 0;
+        event.count--;
 
-	eq = next;
+        eq = next;
     }
 
-    vic[VIC_VADDR] = (uint) vic;	// Ack the VIC
+    vic[VIC_VADDR] = (uint) vic;        // Ack the VIC
 }
 
 

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp.c	    SC&MP - Spinnaker Control & Monitor Program
+// scamp.c          SC&MP - Spinnaker Control & Monitor Program
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -86,9 +86,9 @@ uint p2p_up = 0;
 
 uint ltpc_timer;
 
-uint link_en = 0x3f;	// Bitmap of enabled links
+uint link_en = 0x3f;    // Bitmap of enabled links
 
-srom_data_t srom;	// Copy of SROM struct
+srom_data_t srom;       // Copy of SROM struct
 
 pkt_queue_t tx_pkt_queue;
 
@@ -96,7 +96,7 @@ uchar watchdog[20]; // !! const - needs to be multiple of 4?
 
 iptag_t tag_table[TAG_TABLE_SIZE];
 
-uint tag_tto = 9;	// 2.56s = 10ms * (1 << (9-1))
+uint tag_tto = 9;       // 2.56s = 10ms * (1 << (9-1))
 
 //------------------------------------------------------------------------------
 
@@ -171,13 +171,13 @@ void iptag_timer()
     iptag_t *tag = tag_table;
 
     for (uint i = 0; i < TAG_TABLE_SIZE; i++) {
-	if ((tag->flags & IPFLAG_VALID) && (tag->timeout > 0)) {
-	    tag->timeout--;
-	    if (tag->timeout == 0) {
-		tag->flags = 0;
-	    }
-	}
-	tag++;
+        if ((tag->flags & IPFLAG_VALID) && (tag->timeout > 0)) {
+            tag->timeout--;
+            if (tag->timeout == 0) {
+                tag->flags = 0;
+            }
+        }
+        tag++;
     }
 }
 
@@ -185,8 +185,8 @@ void iptag_timer()
 uint iptag_new()
 {
     for (uint i = FIRST_POOL_TAG; i <= LAST_POOL_TAG; i++) {
-	if (tag_table[i].flags == 0) {
-	    return i;
+        if (tag_table[i].flags == 0) {
+            return i;
         }
     }
 
@@ -198,17 +198,17 @@ uint transient_tag(uchar *ip, uchar *mac, uint port, uint timeout)
     uint tag = iptag_new();
 
     if (tag != TAG_NONE) {
-	iptag_t *tt = tag_table+tag;
+        iptag_t *tt = tag_table+tag;
 
-	tt->flags = IPFLAG_VALID + IPFLAG_TRANS + timeout;
-	tt->tx_port = port;
-	tt->rx_port = 0;
-	copy_ip(ip, tt->ip);
-	copy_mac(mac, tt->mac);
-	if (timeout != 0) {
-	    timeout = 1 << (timeout - 1);
-	}
-	tt->timeout = timeout;
+        tt->flags = IPFLAG_VALID + IPFLAG_TRANS + timeout;
+        tt->tx_port = port;
+        tt->rx_port = 0;
+        copy_ip(ip, tt->ip);
+        copy_mac(mac, tt->mac);
+        if (timeout != 0) {
+            timeout = 1 << (timeout - 1);
+        }
+        tt->timeout = timeout;
     }
 
     return tag;
@@ -234,8 +234,8 @@ void proc_route_msg(uint arg1, uint arg2);
 void msg_queue_insert(sdp_msg_t *msg, uint srce_ip)
 {
     if (event_queue_proc(proc_route_msg, (uint) msg, srce_ip, PRIO_0) == 0) {
-	// if no event is queued free SDP msg buffer
-	sark_msg_free(msg);
+        // if no event is queued free SDP msg buffer
+        sark_msg_free(msg);
     }
 }
 
@@ -253,17 +253,17 @@ uint pkt_tx(uint tcr, uint data, uint key)
     uint cpsr = cpu_irq_disable();
 
     if (txq->count >= PKT_QUEUE_SIZE) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (txq->count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TMT_INT;
+        vic[VIC_ENABLE] = 1 << CC_TMT_INT;
     }
 
     txq->count++;
     if (txq->count > txq->max) {
-	txq->max = txq->count;
+        txq->max = txq->count;
     }
 
     txq->queue[txq->insert] = pkt;
@@ -281,8 +281,8 @@ uint pkt_tx(uint tcr, uint data, uint key)
 
 static void timer1_init(uint count)
 {
-    tc[T1_CONTROL] = 0x000000e2; 	// En, Per, IntEn, Pre=1, 32bit, Wrap
-    tc[T1_LOAD] = count;    	 	// Reload value
+    tc[T1_CONTROL] = 0x000000e2;        // En, Per, IntEn, Pre=1, 32bit, Wrap
+    tc[T1_LOAD] = count;                // Reload value
 }
 
 
@@ -301,8 +301,8 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (rx_pkt + IP_HDR_OFFSET);
 
     if (!cmp_ip(ip_hdr->dest, srom.ip_addr)) {
-	eth_discard();
-	return;
+        eth_discard();
+        return;
     }
 
     uint ip_len = (ip_hdr->ver_len & 15) * 4;
@@ -312,92 +312,92 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
     int len = ntohs(udp_hdr->length);
 
     if (udp_dest == srom.udp_port) {
-	len -= 10;			//const UDP_HDR + UDP_PAD
+        len -= 10;                      //const UDP_HDR + UDP_PAD
 
-	if (len > 24 + SDP_BUF_SIZE) {	// SDP=8, CMD=16
-	    eth_discard();
-	    return;
-	}
+        if (len > 24 + SDP_BUF_SIZE) {  // SDP=8, CMD=16
+            eth_discard();
+            return;
+        }
 
-	sdp_msg_t *msg = sark_msg_get();
+        sdp_msg_t *msg = sark_msg_get();
 
-	if (msg == NULL) {		// !! fix this - reply somehow?
-	    sw_error(SW_OPT);
-	    eth_discard();
-	    return;
-	}
+        if (msg == NULL) {              // !! fix this - reply somehow?
+            sw_error(SW_OPT);
+            eth_discard();
+            return;
+        }
 
-	sark_word_cpy(&msg->flags, (uchar *) udp_hdr+10, len); //const
+        sark_word_cpy(&msg->flags, (uchar *) udp_hdr+10, len); //const
 
-	msg->length = len;
-	msg->srce_addr = p2p_addr;
+        msg->length = len;
+        msg->srce_addr = p2p_addr;
 
-	uint flags = msg->flags;
-	uint tag = msg->tag;
-	uint srce_ip;
+        uint flags = msg->flags;
+        uint tag = msg->tag;
+        uint srce_ip;
 
-	copy_ip(ip_hdr->srce, (uchar *) &srce_ip);
+        copy_ip(ip_hdr->srce, (uchar *) &srce_ip);
 
-	if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
-	    tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
-	}
+        if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
+            tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
+        }
 
-	eth_discard();
+        eth_discard();
 
-	if ((flags & SDPF_REPLY) == 0 ||
-		(tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
-	    msg_queue_insert(msg, srce_ip);
-	} else {
-	    sark_msg_free(msg);
-	}
-    } else {				// Reverse IPTag...
-	len -= 8;			//const UDP_HDR
+        if ((flags & SDPF_REPLY) == 0 ||
+                (tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
+            msg_queue_insert(msg, srce_ip);
+        } else {
+            sark_msg_free(msg);
+        }
+    } else {                            // Reverse IPTag...
+        len -= 8;                       //const UDP_HDR
 
-	if (len > 16 + SDP_BUF_SIZE) {	// CMD=16
-	    eth_discard();
-	    return;
-	}
+        if (len > 16 + SDP_BUF_SIZE) {  // CMD=16
+            eth_discard();
+            return;
+        }
 
-	uint i = 0;
+        uint i = 0;
 
-	while (i < TAG_FIXED_SIZE) {
-	    if (tag_table[i].flags != 0 && tag_table[i].rx_port == udp_dest) {
-		break;
-	    }
-	    i++;
-	}
+        while (i < TAG_FIXED_SIZE) {
+            if (tag_table[i].flags != 0 && tag_table[i].rx_port == udp_dest) {
+                break;
+            }
+            i++;
+        }
 
-	if (i == TAG_FIXED_SIZE) {
-	    eth_discard();
-	    return;
-	}
+        if (i == TAG_FIXED_SIZE) {
+            eth_discard();
+            return;
+        }
 
-	sdp_msg_t *msg = sark_msg_get();
-	if (msg == NULL) {
-	    sw_error(SW_OPT);
-	    eth_discard();
-	    return;
-	}
+        sdp_msg_t *msg = sark_msg_get();
+        if (msg == NULL) {
+            sw_error(SW_OPT);
+            eth_discard();
+            return;
+        }
 
-	// Set up reply path
+        // Set up reply path
 
-	tag_table[i].tx_port = udp_srce;
-	copy_ip(ip_hdr->srce, tag_table[i].ip);
-	copy_mac(rx_pkt+6, tag_table[i].mac);
+        tag_table[i].tx_port = udp_srce;
+        copy_ip(ip_hdr->srce, tag_table[i].ip);
+        copy_mac(rx_pkt+6, tag_table[i].mac);
 
-	memcpy(&msg->cmd_rc, (uchar *) udp_hdr+8, len); //const
+        memcpy(&msg->cmd_rc, (uchar *) udp_hdr+8, len); //const
 
-	eth_discard();
+        eth_discard();
 
-	msg->flags = 0x07;
-	msg->tag = i;
-	msg->srce_addr = p2p_addr;
-	msg->srce_port = PORT_ETH;
-	msg->length = len + 8;
-	msg->dest_addr = tag_table[i].dest_addr;
-	msg->dest_port = tag_table[i].dest_port;
+        msg->flags = 0x07;
+        msg->tag = i;
+        msg->srce_addr = p2p_addr;
+        msg->srce_port = PORT_ETH;
+        msg->length = len + 8;
+        msg->dest_addr = tag_table[i].dest_addr;
+        msg->dest_port = tag_table[i].dest_port;
 
-	msg_queue_insert(msg, 0);
+        msg_queue_insert(msg, 0);
     }
 }
 
@@ -405,30 +405,30 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
 void eth_receive()
 {
     while (1) {
-	uint count = (er[ETH_STATUS] >> 1) & 63;
-	if (count == 0) {
-	    er[ETH_INT_CLR] = ETH_RX_CLR;
-	    return;
-	}
+        uint count = (er[ETH_STATUS] >> 1) & 63;
+        if (count == 0) {
+            er[ETH_INT_CLR] = ETH_RX_CLR;
+            return;
+        }
 
-	uint rx_desc = er[ETH_RX_DESC_RP] & 0x3f;	// Descriptor table index
-	uint rx_len = eth_rx_desc[rx_desc] & 0x7ff;	// Frame size
-	uchar *rx_pkt = eth_rx_ram + (er[ETH_RX_BUF_RP] & 0xfff);
+        uint rx_desc = er[ETH_RX_DESC_RP] & 0x3f;       // Descriptor table index
+        uint rx_len = eth_rx_desc[rx_desc] & 0x7ff;     // Frame size
+        uchar *rx_pkt = eth_rx_ram + (er[ETH_RX_BUF_RP] & 0xfff);
 
-	uint etype = (rx_pkt[12] << 8) + rx_pkt[13];
+        uint etype = (rx_pkt[12] << 8) + rx_pkt[13];
 
-	if (etype == ETYPE_IP) {
-	    uint ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
+        if (etype == ETYPE_IP) {
+            uint ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
 
-	    if (ip_prot == PROT_UDP) {
-		udp_pkt(rx_pkt, rx_len);
-	    } else if (ip_prot == PROT_ICMP) {
-		icmp_pkt(rx_pkt, rx_len);
-	    } else {
-		eth_discard();
-	    }
-	} else if (etype == ETYPE_ARP) {
-	    arp_pkt(rx_pkt, rx_len, TAG_TABLE_SIZE);
+            if (ip_prot == PROT_UDP) {
+                udp_pkt(rx_pkt, rx_len);
+            } else if (ip_prot == PROT_ICMP) {
+                icmp_pkt(rx_pkt, rx_len);
+            } else {
+                eth_discard();
+            }
+        } else if (etype == ETYPE_ARP) {
+            arp_pkt(rx_pkt, rx_len, TAG_TABLE_SIZE);
         } else {
             eth_discard();
         }
@@ -444,7 +444,7 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
     iptag_t *iptag = tag_table + tag;
 
     if ((iptag->flags & IPFLAG_VALID) == 0) {
-	return;
+        return;
     }
 
     uchar hdr[44];
@@ -456,33 +456,33 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
     uint pad;
 
     if (iptag->flags & IPFLAG_STRIP) {
-	buf = (uchar *) &msg->cmd_rc;
-	len -= 8;
-	pad = 0;
+        buf = (uchar *) &msg->cmd_rc;
+        len -= 8;
+        pad = 0;
     } else {
-	buf = (uchar *) &msg->flags;
-	pad = 2;
+        buf = (uchar *) &msg->flags;
+        pad = 2;
     }
 
     if (iptag->flags & IPFLAG_REV) {
-	udp_hdr->srce = htons(iptag->rx_port);
+        udp_hdr->srce = htons(iptag->rx_port);
     } else {
-	udp_hdr->srce = htons(srom.udp_port);
+        udp_hdr->srce = htons(srom.udp_port);
     }
 
     copy_ip_hdr(iptag->ip, PROT_UDP, ip_hdr,
-	    len + pad + IP_HDR_SIZE + UDP_HDR_SIZE);
+            len + pad + IP_HDR_SIZE + UDP_HDR_SIZE);
 
     udp_hdr->length = htons(len + pad + UDP_HDR_SIZE);
     udp_hdr->dest = htons(iptag->tx_port);
-    udp_hdr->checksum = 0;		// Zero checksum
+    udp_hdr->checksum = 0;              // Zero checksum
 
     uint t;
-    t = ipsum(hdr + IP_HDR_OFFSET + 12, 8, 0);	// Sum IP hdr addresses
-    t += len + pad + UDP_HDR_SIZE;		// add in UDP data length
-    t += PROT_UDP;				// and UDP protocol number
-    t = ipsum((uchar *) udp_hdr, 8 + pad, t);	// and UDP header and pad
-    t = ipsum(buf, len, t);			// and finally the data
+    t = ipsum(hdr + IP_HDR_OFFSET + 12, 8, 0);  // Sum IP hdr addresses
+    t += len + pad + UDP_HDR_SIZE;              // add in UDP data length
+    t += PROT_UDP;                              // and UDP protocol number
+    t = ipsum((uchar *) udp_hdr, 8 + pad, t);   // and UDP header and pad
+    t = ipsum(buf, len, t);                     // and finally the data
 
     udp_hdr->checksum = htons(~t);
 
@@ -494,12 +494,12 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
 
     eth_transmit2(hdr, buf, 42 + pad, len);
 
-    sark_delay_us(5);		//## !! Trouble with back-to-back packets??
+    sark_delay_us(5);           //## !! Trouble with back-to-back packets??
 
-    if (iptag->flags & IPFLAG_TRANS) {		//transient tag
-	iptag->flags = 0;
+    if (iptag->flags & IPFLAG_TRANS) {          //transient tag
+        iptag->flags = 0;
     } else {
-	iptag->count++;
+        iptag->count++;
     }
 }
 
@@ -516,19 +516,19 @@ uint shm_ping(uint dest)
     volatile uchar flag = 0;
     event_t *e = event_new(proc_byte_set, (uint) &flag, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	return 1;
+        sw_error(SW_OPT);
+        return 1;
     }
 
     uint id = e->ID;
     timer_schedule(e, 1000); // !! const??
 
     while (vcpu->mbox_ap_cmd != SHM_IDLE && flag == 0) {
-	continue;
+        continue;
     }
 
     if (flag != 0) {
-	return 0;
+        return 0;
     }
 
     timer_cancel(e, id);
@@ -543,7 +543,7 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
 
     sdp_msg_t *shm_msg = sark_shmsg_get();
     if (shm_msg == NULL) {
-	return RC_BUF;
+        return RC_BUF;
     }
 
     sark_msg_cpy(shm_msg, msg);
@@ -556,21 +556,21 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
     volatile uchar flag = 0;
     event_t *e = event_new(proc_byte_set, (uint) &flag, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	sark_shmsg_free(shm_msg);
-	return RC_BUF;		// !! not the right RC
+        sw_error(SW_OPT);
+        sark_shmsg_free(shm_msg);
+        return RC_BUF;          // !! not the right RC
     }
 
     uint id = e->ID;
-    timer_schedule(e, 1000);	// !! const??
+    timer_schedule(e, 1000);    // !! const??
 
     while (vcpu->mbox_ap_cmd != SHM_IDLE && flag == 0) {
-	continue;
+        continue;
     }
 
     if (flag != 0) {
-	sark_shmsg_free(shm_msg);
-	return RC_TIMEOUT;
+        sark_shmsg_free(shm_msg);
+        return RC_TIMEOUT;
     }
 
     timer_cancel(e, id);
@@ -596,17 +596,17 @@ void return_msg(sdp_msg_t *msg, uint rc) // Zero "rc" skips updating cmd_hdr
     uint f = msg->flags;
 
     if (f & SDPF_REPLY) {
-	msg->flags = f & ~SDPF_REPLY;
-	swap_sdp_hdr(msg);
+        msg->flags = f & ~SDPF_REPLY;
+        swap_sdp_hdr(msg);
 
-	if (rc != 0) {
-	    msg->cmd_rc = rc;
-	    msg->length = 12;
-	}
+        if (rc != 0) {
+            msg->cmd_rc = rc;
+            msg->length = 12;
+        }
 
-	msg_queue_insert(msg, 0);
+        msg_queue_insert(msg, 0);
     } else {
-	sark_msg_free(msg);
+        sark_msg_free(msg);
     }
 }
 
@@ -618,69 +618,69 @@ void proc_route_msg(uint arg1, uint srce_ip)
 
     if (flags & SDPF_SUM) {
 /*
-	uint sum = ipsum((uchar *) &msg->length, msg->length+4, 0);
-	if (sum != 0xffff) { // !! fix this
-	  //	  msg_free(msg);
-	  //	  return;
-	}
+        uint sum = ipsum((uchar *) &msg->length, msg->length+4, 0);
+        if (sum != 0xffff) { // !! fix this
+          //      msg_free(msg);
+          //      return;
+        }
 */
-	msg->flags = flags &= ~SDPF_SUM;
+        msg->flags = flags &= ~SDPF_SUM;
     }
 
     // Map (255, 255) to the root chip's coordinates
     if (msg->dest_addr == 0xFFFF) {
-	msg->dest_addr = p2p_root;
+        msg->dest_addr = p2p_root;
     }
     if (msg->srce_addr == 0xFFFF) {
-	msg->srce_addr = p2p_root;
+        msg->srce_addr = p2p_root;
     }
 
     // Off-chip via P2P
 
     if (msg->dest_addr != msg->srce_addr && msg->dest_addr != p2p_addr &&
-	    (flags & SDPF_NR) == 0) {
-	if (p2p_up == 0 || rtr_p2p_get(msg->dest_addr) == 6) {
-	    return_msg(msg, RC_ROUTE);
-	    return;
-	}
+            (flags & SDPF_NR) == 0) {
+        if (p2p_up == 0 || rtr_p2p_get(msg->dest_addr) == 6) {
+            return_msg(msg, RC_ROUTE);
+            return;
+        }
 
-	uint rc = p2p_send_msg(msg->dest_addr, msg);
-	if (rc == RC_OK) {
-	    sark_msg_free(msg);
+        uint rc = p2p_send_msg(msg->dest_addr, msg);
+        if (rc == RC_OK) {
+            sark_msg_free(msg);
         } else {
             return_msg(msg, rc);
         }
-	return;
+        return;
     }
 
     if (msg->dest_port == PORT_ETH) {
-	eth_send_msg(msg->tag, msg);
-	sark_msg_free(msg);
-	return;
+        eth_send_msg(msg->tag, msg);
+        sark_msg_free(msg);
+        return;
     }
 
     uint dest_cpu = msg->dest_port & CPU_MASK;
     if (dest_cpu >= num_cpus) {
-	return_msg(msg, RC_CPU);
-	return;
+        return_msg(msg, RC_CPU);
+        return;
     }
 
-    if (dest_cpu != sark.virt_cpu) {	// !! virt_cpu always zero
-	uint rc = shm_send_msg(dest_cpu, msg);
-	if (rc == RC_OK) {
-	    sark_msg_free(msg);
+    if (dest_cpu != sark.virt_cpu) {    // !! virt_cpu always zero
+        uint rc = shm_send_msg(dest_cpu, msg);
+        if (rc == RC_OK) {
+            sark_msg_free(msg);
         } else {
             return_msg(msg, rc);
         }
-	return;
+        return;
     }
 
     uint dest_port = msg->dest_port >> PORT_SHIFT;
     if (dest_port == 0) {
-	msg->length = 12 + scamp_debug(msg, srce_ip);
-	return_msg(msg, 0);
+        msg->length = 12 + scamp_debug(msg, srce_ip);
+        return_msg(msg, 0);
     } else {
-	return_msg(msg, RC_PORT);	// APs should not do this!!
+        return_msg(msg, RC_PORT);       // APs should not do this!!
     }
 }
 
@@ -694,7 +694,7 @@ void proc_route_msg(uint arg1, uint srce_ip)
 void assign_virt_cpu(uint phys_cpu)
 {
     for (uint phys = 0; phys < MAX_CPUS; phys++) {
-	sv->p2v_map[phys] = 255;
+        sv->p2v_map[phys] = 255;
     }
 
     sv->p2v_map[phys_cpu] = sark.virt_cpu = 0;
@@ -704,28 +704,28 @@ void assign_virt_cpu(uint phys_cpu)
     uint virt = 1;
 
     for (uint phys = 0; phys < NUM_CPUS; phys++) {
-	if (phys == phys_cpu) {
-	    continue;
+        if (phys == phys_cpu) {
+            continue;
         }
 
-	if (sc[SC_CPU_OK] & (1 << phys)) {
-	    sv->p2v_map[phys] = virt;
-	    sv->v2p_map[virt] = phys;
-	    virt++;
-	}
+        if (sc[SC_CPU_OK] & (1 << phys)) {
+            sv->p2v_map[phys] = virt;
+            sv->v2p_map[virt] = phys;
+            virt++;
+        }
     }
 
     sv->num_cpus = num_cpus = virt;
 
     while (virt < MAX_CPUS) {
-	sv->v2p_map[virt++] = 255;
+        sv->v2p_map[virt++] = 255;
     }
 
     // Turn off clocks of dead cores. If the monitor (this core) is marked as
     // dead, turn off the LED to make deadness more obvious.
     uint cpsr = cpu_int_disable();
     if (!(sc[SC_CPU_OK] & (1 << phys_cpu))) {
-	sark_led_set(LED_OFF(0));
+        sark_led_set(LED_OFF(0));
     }
     sc[SC_CPU_DIS] = SC_CODE + (~sc[SC_CPU_OK] & ((1 << NUM_CPUS) - 1));
     cpu_int_restore(cpsr);
@@ -772,20 +772,20 @@ uint ram_size(void *mem)
 
     uint v, z;
     do {
-	uint a = 1 << i++;
-	uint s = ram[a];
+        uint a = 1 << i++;
+        uint s = ram[a];
 
-	ram[a] = i;
+        ram[a] = i;
 
-	z = ram[0];
-	v = ram[a];
-	ram[a] = s;
+        z = ram[0];
+        v = ram[a];
+        ram[a] = s;
     } while ((v == i) && (z == zf));
 
     ram[0] = s;
 
     if (i == 1) {
-	return 0;
+        return 0;
     }
 
     return 1 << (i + 1);
@@ -796,48 +796,48 @@ uint ram_size(void *mem)
 
 
 const uint rst_init[] = {0x45206e49, 0x79726576, 0x65724420, 0x48206d61,
-			 0x20656d6f, 0x65482061, 0x61747261, 0x00656863};
+                         0x20656d6f, 0x65482061, 0x61747261, 0x00656863};
 
 
 void get_board_info(void)
 {
     sdp_msg_t msg;
 
-    msg.arg1 = (256 << 16) + 32;	// 256 bytes, send 32 bit command
-    msg.arg2 = (3 << 24) + 0x100;	// READ, address 0x100
+    msg.arg1 = (256 << 16) + 32;        // 256 bytes, send 32 bit command
+    msg.arg2 = (3 << 24) + 0x100;       // READ, address 0x100
 
     (void) cmd_srom(&msg);
 
     sark_word_cpy(sv_board_info, &msg.arg1, 256);
 
     if (sv_board_info[0] < 64) {
-	sv->board_info = sv_board_info;
+        sv->board_info = sv_board_info;
     }
 }
 
 
 void sv_init(void)
 {
-    sark_word_cpy(sv_vectors, rst_init, SV_VSIZE); 	// Copy Reset vectors
-    sark_word_cpy(&srom, sv_srom, sizeof(srom_data_t));	// Copy SROM block
+    sark_word_cpy(sv_vectors, rst_init, SV_VSIZE);      // Copy Reset vectors
+    sark_word_cpy(&srom, sv_srom, sizeof(srom_data_t)); // Copy SROM block
 
-    sark_word_set((void *) 0xf5007fc0, 0, 64);		// Kludge...
+    sark_word_set((void *) 0xf5007fc0, 0, 64);          // Kludge...
 
-    if (srom.flags & SRF_PRESENT) {			// Get board_info ??
-	get_board_info();
+    if (srom.flags & SRF_PRESENT) {                     // Get board_info ??
+        get_board_info();
     }
 
-    if (sv->hw_ver == 0 && srom.flags & SRF_PRESENT) {	// Set hardware version
-	sv->hw_ver = (srom.flags >> 4) & 15;
+    if (sv->hw_ver == 0 && srom.flags & SRF_PRESENT) {  // Set hardware version
+        sv->hw_ver = (srom.flags >> 4) & 15;
     }
 
-    sv->sw_ver = SLLT_VER_NUM;				// Set software version
+    sv->sw_ver = SLLT_VER_NUM;                          // Set software version
 
     sv->sysram_base = (uint *) SYS_USER_BASE;
     uint *sysram_top = sv->sysram_base + (uint) sv->sysram_heap;
     sv->sysram_heap = sark_heap_init(sysram_top, (uint *) SYS_USER_TOP);
 
-    sark_word_set(sv_vcpu, 0, NUM_CPUS * VCPU_SIZE);	// Set up VCPU blocks
+    sark_word_set(sv_vcpu, 0, NUM_CPUS * VCPU_SIZE);    // Set up VCPU blocks
     sv->vcpu_base = sv_vcpu;
 
     sv_vcpu[0].cpu_state = CPU_STATE_RUN;
@@ -848,15 +848,15 @@ void sv_init(void)
 
     // Set up SHM buffers
     sv->shm_buf = sark_xalloc(sv->sysram_heap,
-	    sv->num_buf * sizeof(sdp_msg_t), 0, 0);
+            sv->num_buf * sizeof(sdp_msg_t), 0, 0);
 
     sv->shm_root.free = (mem_link_t *) sv->shm_buf;
-    //sv->shm_root.count = sv->shm_root.max = 0;	//## Not needed now...
+    //sv->shm_root.count = sv->shm_root.max = 0;        //## Not needed now...
 
     sark_block_init(sv->shm_buf, sv->num_buf, sizeof(sdp_msg_t));
 
     if (sv->boot_delay == 0 && sv->rom_cpus == 0) {
-	sv->root_chip = 1;
+        sv->root_chip = 1;
     }
 }
 
@@ -868,8 +868,8 @@ void sdram_init(void)
 
     // Compute sizes
 
-    uint sdram_size = ram_size(sdram);		// SDRAM size (bytes)
-    uint sys_size = (uint) sv->sdram_bufs;	// System size (bytes)
+    uint sdram_size = ram_size(sdram);          // SDRAM size (bytes)
+    uint sys_size = (uint) sv->sdram_bufs;      // System size (bytes)
 
     // Fill in sv->sdram... vars
 
@@ -902,7 +902,7 @@ void sdram_init(void)
     // Router MC table copy (NB 1 extra entry in copy table)
 
     sv->rtr_copy = sark_xalloc(sv->sys_heap,
-	    (MC_TABLE_SIZE + 1) * sizeof(rtr_entry_t), 0, 0);
+            (MC_TABLE_SIZE + 1) * sizeof(rtr_entry_t), 0, 0);
 
     // Alloc ID table
 
@@ -920,22 +920,22 @@ void random_init(void)
 {
     /* Now done from SDRAM...
       if (sv->random == 0) {
-	  uint rand = 0xa5;				// Set up random seed
-	  for (uint i = 0; i < SV_RSIZE / 4; i++) {
-	      rand ^= (i & 1) ? sv_random[i] : ~sv_random[i];
-	  }
-	  sv->random = rand;
+          uint rand = 0xa5;                             // Set up random seed
+          for (uint i = 0; i < SV_RSIZE / 4; i++) {
+              rand ^= (i & 1) ? sv_random[i] : ~sv_random[i];
+          }
+          sv->random = rand;
       }
      */
     // Make random seed
 
     uint *rnd = sark_xalloc(sv->sys_heap, 256 * 4, 0, 0);
     if (sv->random == 0) {
-	uint rand = 0xa5;				// Set up random seed
-	for (uint i = 0; i < 256; i++) {
-	    rand ^= (i & 1) ? rnd[i] : ~rnd[i];
+        uint rand = 0xa5;                               // Set up random seed
+        for (uint i = 0; i < 256; i++) {
+            rand ^= (i & 1) ? rnd[i] : ~rnd[i];
         }
-	sv->random = rand;
+        sv->random = rand;
     }
 
     sark_srand(sv->random);
@@ -953,17 +953,17 @@ void update_load(uint arg1, uint arg2)
     uint sleeping_cpus = sc[SC_SLEEP];
 
     for (uint cpu = 1; cpu < NUM_CPUS; cpu++) {
-	vcpu_t *vcpu = sv_vcpu + cpu;
+        vcpu_t *vcpu = sv_vcpu + cpu;
 
-	if (vcpu->cpu_state != CPU_STATE_DEAD) {
-	    num_working++;
+        if (vcpu->cpu_state != CPU_STATE_DEAD) {
+            num_working++;
         }
 
-	// NB: Ignores cores not running apps
-	if (vcpu->app_id > 0) {
-	    num_with_apps++;
-	    if (!(sleeping_cpus & (1 << vcpu->phys_cpu))) {
-		num_awake++;
+        // NB: Ignores cores not running apps
+        if (vcpu->app_id > 0) {
+            num_with_apps++;
+            if (!(sleeping_cpus & (1 << vcpu->phys_cpu))) {
+                num_awake++;
             }
         }
     }
@@ -973,7 +973,7 @@ void update_load(uint arg1, uint arg2)
     // are loaded.
     uint new_load = (num_awake * 255) / (num_working);
     if (num_with_apps > 0 && new_load == 0) {
-	new_load = 1;
+        new_load = 1;
     }
     load = new_load;
 }
@@ -985,12 +985,12 @@ void update_load(uint arg1, uint arg2)
 void proc_1hz(uint a1, uint a2)
 {
     if (srom.flags & SRF_ETH) {
-	uint s = phy_read(PHY_STATUS);
-	sv->eth_up = (s & 4) >> 2;
+        uint s = phy_read(PHY_STATUS);
+        sv->eth_up = (s & 4) >> 2;
 
-	// If the Ethernet is up now, we are done
-	if (sv->eth_up) {
-	    ethinit_phase = ETHINIT_PHASE_DONE;
+        // If the Ethernet is up now, we are done
+        if (sv->eth_up) {
+            ethinit_phase = ETHINIT_PHASE_DONE;
         }
     }
 
@@ -1011,21 +1011,21 @@ void soft_wdog(uint max)
 {
     vcpu_t *vcpu = sv_vcpu + ping_cpu;
 
-    if (vcpu->cpu_state >= 4) {				// !! const
-	if (shm_ping(ping_cpu)) {
-	    watchdog[ping_cpu] = 0;
-	} else if (++watchdog[ping_cpu] == max) {
-	    clock_ap(1 << v2p_map[ping_cpu], 0);	// Disable clock
+    if (vcpu->cpu_state >= 4) {                         // !! const
+        if (shm_ping(ping_cpu)) {
+            watchdog[ping_cpu] = 0;
+        } else if (++watchdog[ping_cpu] == max) {
+            clock_ap(1 << v2p_map[ping_cpu], 0);        // Disable clock
 
-	    vcpu_t *vcpu = sv_vcpu + ping_cpu;
-	    vcpu->cpu_state = CPU_STATE_WDOG;
-	}
+            vcpu_t *vcpu = sv_vcpu + ping_cpu;
+            vcpu->cpu_state = CPU_STATE_WDOG;
+        }
     } else {
-	watchdog[ping_cpu] = 0;
+        watchdog[ping_cpu] = 0;
     }
 
     if (++ping_cpu >= num_cpus) {
-	ping_cpu = 1;
+        ping_cpu = 1;
     }
 }
 
@@ -1045,11 +1045,11 @@ void netinit_start(void)
 
     // Initial P2P address guess
     if (sv->root_chip) {
-	p2p_addr_guess_x = 0;
-	p2p_addr_guess_y = 0;
+        p2p_addr_guess_x = 0;
+        p2p_addr_guess_y = 0;
     } else {
-	p2p_addr_guess_x = NO_IDEA;
-	p2p_addr_guess_y = NO_IDEA;
+        p2p_addr_guess_x = NO_IDEA;
+        p2p_addr_guess_y = NO_IDEA;
     }
 
     // Initial P2P dimension range, initially empty
@@ -1081,28 +1081,28 @@ void compute_st(void)
     // and add them to the route, forming a spanning tree.
     uint timeout = sv->peek_time;
     for (uint link = 0; link < NUM_LINKS; link++) {
-	if (!((1 << link) & link_en)) {
-	    continue;
+        if (!((1 << link) & link_en)) {
+            continue;
         }
 
-	// Try to read multiple times if required
-	uint attempts_remaining = 2;
-	uint remote_rtr_p2p;
-	uint rc;
-	do {
-	    rc = link_read_word((uint)(rtr_p2p + word), link,
-		    &remote_rtr_p2p, timeout);
+        // Try to read multiple times if required
+        uint attempts_remaining = 2;
+        uint remote_rtr_p2p;
+        uint rc;
+        do {
+            rc = link_read_word((uint)(rtr_p2p + word), link,
+                    &remote_rtr_p2p, timeout);
         } while (rc != RC_OK && (--attempts_remaining));
 
-	// Flag an error if we could not get a p2p entry from a neighbour
-	if (rc != RC_OK) {
-	    sw_error(SW_OPT);
-	    continue;
+        // Flag an error if we could not get a p2p entry from a neighbour
+        if (rc != RC_OK) {
+            sw_error(SW_OPT);
+            continue;
         }
 
-	// Check if p2p_root route from neighbour points at this chip.
-	if (((remote_rtr_p2p >> offset) & 0x7) == ((link + 3) % 6)) {
-	    route |= MC_LINK_ROUTE(link);
+        // Check if p2p_root route from neighbour points at this chip.
+        if (((remote_rtr_p2p >> offset) & 0x7) == ((link + 3) % 6)) {
+            route |= MC_LINK_ROUTE(link);
         }
     }
 
@@ -1122,152 +1122,152 @@ void proc_100hz(uint a1, uint a2)
     // Boot-up related packet sending and boot-phase advancing
     switch (netinit_phase) {
     case NETINIT_PHASE_P2P_ADDR:
-	// Periodically re-send the neighbours their P2P address as
-	// neighbouring chips may take some time to come online.
-	p2pc_addr_nn_send(0, 0);
+        // Periodically re-send the neighbours their P2P address as
+        // neighbouring chips may take some time to come online.
+        p2pc_addr_nn_send(0, 0);
 
-	// If no new P2P addresses have been broadcast for a while we can
-	// assume all chips are have a valid P2P address so it is now time to
-	// determine the system's dimensions.
-	if (ticks_since_last_p2pc_new++ > (uint)sv->netinit_bc_wait) {
-	    netinit_phase = NETINIT_PHASE_P2P_DIMS;
+        // If no new P2P addresses have been broadcast for a while we can
+        // assume all chips are have a valid P2P address so it is now time to
+        // determine the system's dimensions.
+        if (ticks_since_last_p2pc_new++ > (uint)sv->netinit_bc_wait) {
+            netinit_phase = NETINIT_PHASE_P2P_DIMS;
 
-	    p2p_min_x = (p2p_addr_guess_x < 0) ? p2p_addr_guess_x : 0;
-	    p2p_min_y = (p2p_addr_guess_y < 0) ? p2p_addr_guess_y : 0;
-	    p2p_max_x = (p2p_addr_guess_x > 0) ? p2p_addr_guess_x : 0;
-	    p2p_max_y = (p2p_addr_guess_y > 0) ? p2p_addr_guess_y : 0;
+            p2p_min_x = (p2p_addr_guess_x < 0) ? p2p_addr_guess_x : 0;
+            p2p_min_y = (p2p_addr_guess_y < 0) ? p2p_addr_guess_y : 0;
+            p2p_max_x = (p2p_addr_guess_x > 0) ? p2p_addr_guess_x : 0;
+            p2p_max_y = (p2p_addr_guess_y > 0) ? p2p_addr_guess_y : 0;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_P2P_DIMS:
-	// Periodically re-broadcast the local best guess of system
-	// dimensions as a safety net in the event of packet loss.
-	p2pc_dims_nn_send(0, 0);
+        // Periodically re-broadcast the local best guess of system
+        // dimensions as a safety net in the event of packet loss.
+        p2pc_dims_nn_send(0, 0);
 
-	// If no new guesses have been broadcast for a while we can assume
-	// the current guess is accurate so its time to move onto the next
-	// phase
-	if (ticks_since_last_p2pc_dims++ > (uint)sv->netinit_bc_wait) {
-	    // If no coordinate discovered, just shut down this chip
-	    if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA) {
-		remap_phys_cores(0x3ffff);
+        // If no new guesses have been broadcast for a while we can assume
+        // the current guess is accurate so its time to move onto the next
+        // phase
+        if (ticks_since_last_p2pc_dims++ > (uint)sv->netinit_bc_wait) {
+            // If no coordinate discovered, just shut down this chip
+            if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA) {
+                remap_phys_cores(0x3ffff);
             }
 
-	    // Record the coordinates/dimensions discovered
-	    sv->p2p_addr = p2p_addr = ((p2p_addr_guess_x - p2p_min_x) << 8) |
-		    ((p2p_addr_guess_y - p2p_min_y) << 0);
-	    sv->p2p_dims = p2p_dims = ((1 + p2p_max_x - p2p_min_x) << 8) |
-		    ((1 + p2p_max_y - p2p_min_y) << 0);
-	    sv->p2p_root = p2p_root = (-p2p_min_x << 8) | -p2p_min_y;
+            // Record the coordinates/dimensions discovered
+            sv->p2p_addr = p2p_addr = ((p2p_addr_guess_x - p2p_min_x) << 8) |
+                    ((p2p_addr_guess_y - p2p_min_y) << 0);
+            sv->p2p_dims = p2p_dims = ((1 + p2p_max_x - p2p_min_x) << 8) |
+                    ((1 + p2p_max_y - p2p_min_y) << 0);
+            sv->p2p_root = p2p_root = (-p2p_min_x << 8) | -p2p_min_y;
 
-	    sv->p2p_active += 1;
+            sv->p2p_active += 1;
 
-	    // Reseed uniquely for each chip
-	    sark_srand(p2p_addr);
+            // Reseed uniquely for each chip
+            sark_srand(p2p_addr);
 
-	    // Set our P2P addr in the comms controller
-	    cc[CC_SAR] = 0x07000000 + p2p_addr;
+            // Set our P2P addr in the comms controller
+            cc[CC_SAR] = 0x07000000 + p2p_addr;
 
-	    // Work out the local Ethernet connected chip coordinates
-	    compute_eth();
+            // Work out the local Ethernet connected chip coordinates
+            compute_eth();
 
-	    netinit_biff_tick_counter = 0;
-	    netinit_phase = NETINIT_PHASE_BIFF;
+            netinit_biff_tick_counter = 0;
+            netinit_phase = NETINIT_PHASE_BIFF;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_BIFF:
-	// The board information floodfill is allowed three 100Hz ticks. In
-	// the first tick, the board information is actually broadcast. In
-	// the second tick, nothing happens and in the third the state
-	// advances to the P2P table generation phase.
-	//
-	// The reason for using more than one tick is that the 10ms ticks
-	// around the machine are not aligned. As a result, some chips may be
-	// *almost* 10ms ahead of others. Since it is important that
-	// blacklisting information is broadcast ahead of P2P generation,
-	// leaving an extra "tick" before moving to the next state should
-	// deal with the problem. A third tick is left to allow extra leeway
-	// accounting for the fact that the timers are not necessarily
-	// *perfectly* aligned to within 10ms...
+        // The board information floodfill is allowed three 100Hz ticks. In
+        // the first tick, the board information is actually broadcast. In
+        // the second tick, nothing happens and in the third the state
+        // advances to the P2P table generation phase.
+        //
+        // The reason for using more than one tick is that the 10ms ticks
+        // around the machine are not aligned. As a result, some chips may be
+        // *almost* 10ms ahead of others. Since it is important that
+        // blacklisting information is broadcast ahead of P2P generation,
+        // leaving an extra "tick" before moving to the next state should
+        // deal with the problem. A third tick is left to allow extra leeway
+        // accounting for the fact that the timers are not necessarily
+        // *perfectly* aligned to within 10ms...
 
-	netinit_biff_tick_counter++;
+        netinit_biff_tick_counter++;
 
-	if (netinit_biff_tick_counter == 1) {
-	    if (sv->board_info) {
-		uint num_info_words = sv->board_info[0];
-		uint *info_word = sv->board_info + 1;
-		while (num_info_words--) {
-		    // Handle command on this chip
-		    nn_cmd_biff(0, 0, *(info_word));
-		    // Also flood to other chips on this board
-		    biff_nn_send(*(info_word++));
+        if (netinit_biff_tick_counter == 1) {
+            if (sv->board_info) {
+                uint num_info_words = sv->board_info[0];
+                uint *info_word = sv->board_info + 1;
+                while (num_info_words--) {
+                    // Handle command on this chip
+                    nn_cmd_biff(0, 0, *(info_word));
+                    // Also flood to other chips on this board
+                    biff_nn_send(*(info_word++));
                 }
             }
         } else if (netinit_biff_tick_counter >= 3) {
             netinit_p2p_tick_counter = 0;
             netinit_phase = NETINIT_PHASE_P2P_TABLE;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_P2P_TABLE: {
-	// Broadcast P2P table generation packets, staggered by chip to
-	// reduce network load.
-	uint p2pb_period = ((p2p_dims >> 8) * (p2p_dims & 0xFF)) * P2PB_OFFSET_USEC;
-	if (netinit_p2p_tick_counter == 0) {
-	    hop_table[p2p_addr] = 0;
-	    rtr_p2p_set(p2p_addr, 7);
-	    timer_schedule_proc(p2pb_nn_send, 0, 0,
-		    (sark_rand() % p2pb_period) + 1);
-	}
+        // Broadcast P2P table generation packets, staggered by chip to
+        // reduce network load.
+        uint p2pb_period = ((p2p_dims >> 8) * (p2p_dims & 0xFF)) * P2PB_OFFSET_USEC;
+        if (netinit_p2p_tick_counter == 0) {
+            hop_table[p2p_addr] = 0;
+            rtr_p2p_set(p2p_addr, 7);
+            timer_schedule_proc(p2pb_nn_send, 0, 0,
+                    (sark_rand() % p2pb_period) + 1);
+        }
 
-	// Once all P2P messages have had ample time to send (and the
-	// required number of repeats have occurred), compute the level
-	// config and signalling broadcast spanning tree.
-	if (netinit_p2p_tick_counter++ >= (p2pb_period / 10000) + 2) {
-	    netinit_p2p_tick_counter = 0;
+        // Once all P2P messages have had ample time to send (and the
+        // required number of repeats have occurred), compute the level
+        // config and signalling broadcast spanning tree.
+        if (netinit_p2p_tick_counter++ >= (p2pb_period / 10000) + 2) {
+            netinit_p2p_tick_counter = 0;
 
-	    if (sv->p2pb_repeats-- == 0) {
-		netinit_phase = NETINIT_PHASE_DONE;
+            if (sv->p2pb_repeats-- == 0) {
+                netinit_phase = NETINIT_PHASE_DONE;
 
-		level_config();
-		compute_st();
-		sv->p2p_up = p2p_up = 1;
+                level_config();
+                compute_st();
+                sv->p2p_up = p2p_up = 1;
 
-		if (srom.flags & SRF_ETH) {
-		    uint s = phy_read(PHY_STATUS);
-		    sv->eth_up = (s & 4) >> 2;
-		    if (sv->eth_up) {
-			ethinit_phase = ETHINIT_PHASE_DONE;
-		    }
-		}
-	    }
-	}
-	break;
+                if (srom.flags & SRF_ETH) {
+                    uint s = phy_read(PHY_STATUS);
+                    sv->eth_up = (s & 4) >> 2;
+                    if (sv->eth_up) {
+                        ethinit_phase = ETHINIT_PHASE_DONE;
+                    }
+                }
+            }
+        }
+        break;
     }
 
     case NETINIT_PHASE_DONE:
     default:
-	// Unrecognised or finished state? Do nothing.
-	break;
+        // Unrecognised or finished state? Do nothing.
+        break;
     }
     sv->netinit_phase = netinit_phase;
 
     // Light the LED every-so-often to make it clear that this chip is alive
     if (netinit_phase == NETINIT_PHASE_DONE) {
-	static uint ticks = 0;
+        static uint ticks = 0;
 
-	uint p2p_x = p2p_addr >> 8;
-	uint p2p_y = p2p_addr & 0xFF;
-	uint p2p_dist = p2p_x + p2p_y;
-	uint flash_time = (p2p_dist * LIVENESS_FLASH_SPACING)
-		% LIVENESS_FLASH_INTERVAL;
-	if (ticks == flash_time) {
-	    disp_load = ((load < 128) ? 255 : 0) << LOAD_FRAC_BITS;
+        uint p2p_x = p2p_addr >> 8;
+        uint p2p_y = p2p_addr & 0xFF;
+        uint p2p_dist = p2p_x + p2p_y;
+        uint flash_time = (p2p_dist * LIVENESS_FLASH_SPACING)
+                % LIVENESS_FLASH_INTERVAL;
+        if (ticks == flash_time) {
+            disp_load = ((load < 128) ? 255 : 0) << LOAD_FRAC_BITS;
         }
 
-	if (++ticks >= LIVENESS_FLASH_INTERVAL) {
-	    ticks = 0;
+        if (++ticks >= LIVENESS_FLASH_INTERVAL) {
+            ticks = 0;
         }
     }
 
@@ -1279,15 +1279,15 @@ void proc_100hz(uint a1, uint a2)
 
     // Ping application CPUs to check on status
     if (sv->soft_wdog) {
-	soft_wdog(sv->soft_wdog);
+        soft_wdog(sv->soft_wdog);
     }
 
     // Send LTPC packet (untested!)
     if (sv->ltpc_period > 0 && ++ltpc_timer >= sv->ltpc_period) {
-	ltpc_timer = 0;
+        ltpc_timer = 0;
 
-	ff_nn_send((NN_CMD_LTPC << 24) + (0x3e00 << 8),
-		sv->tp_timer, 0x3f00, 0);
+        ff_nn_send((NN_CMD_LTPC << 24) + (0x3e00 << 8),
+                sv->tp_timer, 0x3f00, 0);
     }
 }
 
@@ -1300,43 +1300,43 @@ void proc_1khz(uint a1, uint a2)
 {
     // Display status on LED0 except when booting
     if (netinit_phase >= NETINIT_PHASE_DONE) {
-	if (sv->led_period == 1) {
-	    // sv->led_period == 1: Display current load using PWM
+        if (sv->led_period == 1) {
+            // sv->led_period == 1: Display current load using PWM
 
-	    // Slowly track the actual load value
-	    uint fractional_load = ((uint)load) << LOAD_FRAC_BITS;
-	    if (disp_load < fractional_load) {
-		disp_load++;
+            // Slowly track the actual load value
+            uint fractional_load = ((uint)load) << LOAD_FRAC_BITS;
+            if (disp_load < fractional_load) {
+                disp_load++;
             } else if (disp_load > fractional_load) {
-        	disp_load--;
+                disp_load--;
             }
 
-	    // PWM generation
-	    static uint period = 0;
-	    uint duty = disp_load >> (LOAD_FRAC_BITS + PWM_BITS);
+            // PWM generation
+            static uint period = 0;
+            uint duty = disp_load >> (LOAD_FRAC_BITS + PWM_BITS);
 
-	    // If there is *any* load, keep the LED on a little bit.
-	    if (disp_load > 0 && duty == 0) {
-		duty = 1;
-	    }
+            // If there is *any* load, keep the LED on a little bit.
+            if (disp_load > 0 && duty == 0) {
+                duty = 1;
+            }
 
-	    if (period >= duty) {
-		sark_led_set(LED_OFF(0));
-	    } else {
-		sark_led_set(LED_ON(0));
-	    }
+            if (period >= duty) {
+                sark_led_set(LED_OFF(0));
+            } else {
+                sark_led_set(LED_ON(0));
+            }
 
-	    if (++period >= (1 << PWM_BITS)) {
-		period = 0;
-	    }
-	} else if (sv->led_period >= 2) {
-	    // sv->led_period >= 2: Blink at a given frequency
-	    static uint last_toggle = 0;
-	    if (last_toggle++ > (sv->led_period * 10)) {
-		last_toggle = 0;
-		sark_led_set(LED_INV(0));	// !! assumes LED_0 always there
-	    }
-	}
+            if (++period >= (1 << PWM_BITS)) {
+                period = 0;
+            }
+        } else if (sv->led_period >= 2) {
+            // sv->led_period >= 2: Blink at a given frequency
+            static uint last_toggle = 0;
+            if (last_toggle++ > (sv->led_period * 10)) {
+                last_toggle = 0;
+                sark_led_set(LED_INV(0));       // !! assumes LED_0 always there
+            }
+        }
     }
 }
 
@@ -1349,13 +1349,13 @@ static uint pll_mult(uint freq)
     uint f = 0;
 
     if (freq >= 50) {
-	f = 1;
+        f = 1;
     }
     if (freq >= 100) {
-	f = 2;
+        f = 2;
     }
     if (freq >= 200) {
-	f = 3;
+        f = 3;
     }
 
     return f << 16;
@@ -1374,23 +1374,23 @@ static uint pll_mult(uint freq)
 //
 void pll_init()
 {
-    sark.cpu_clk = 10;			// Set for delay_us
-    sc[SC_CLKMUX] = 0;			// Switch to 10MHz everywhere
+    sark.cpu_clk = 10;                  // Set for delay_us
+    sc[SC_CLKMUX] = 0;                  // Switch to 10MHz everywhere
 
-    sark_delay_us(2);			// and wait a while
+    sark_delay_us(2);                   // and wait a while
 
-    uint cpu_freq = sv->cpu_clk * 2;	// Set local values
+    uint cpu_freq = sv->cpu_clk * 2;    // Set local values
     uint mem_freq = sv->mem_clk * 2;
 
-    divmod_t r;				// Divide by 10 and set PLLs
+    divmod_t r;                         // Divide by 10 and set PLLs
 
-    r = sark_div10(cpu_freq);		// CPUs on PLL1
+    r = sark_div10(cpu_freq);           // CPUs on PLL1
     sc[SC_PLL1] = 0x00040100 + pll_mult(cpu_freq) + r.div;
 
-    r = sark_div10(mem_freq);		// SDRAM on PLL2
+    r = sark_div10(mem_freq);           // SDRAM on PLL2
     sc[SC_PLL2] = 0x00040100 + pll_mult(mem_freq) + r.div;
 
-    sark_delay_us(PLL_LOCK_TIME);	// Wait for PLLs to lock
+    sark_delay_us(PLL_LOCK_TIME);       // Wait for PLLs to lock
 
     uint sys_div = ((sv->clk_div >> 4) - 1) & 3;
     uint rtr_div = (sv->clk_div - 1) & 3;
@@ -1404,29 +1404,29 @@ void pll_init()
 
 void eth_setup()
 {
-    if (srom.flags & SRF_ETH) {			// Ethernet present (possibly)
-	eth_init(srom.mac_addr);
-	sark_word_cpy(sv->ip_addr, srom.ip_addr, 4);
+    if (srom.flags & SRF_ETH) {                 // Ethernet present (possibly)
+        eth_init(srom.mac_addr);
+        sark_word_cpy(sv->ip_addr, srom.ip_addr, 4);
 
-	if (srom.flags & SRF_PHY_RST) {		// Hardware reset PHY
-	    phy_reset();
-	}
+        if (srom.flags & SRF_PHY_RST) {         // Hardware reset PHY
+            phy_reset();
+        }
 
-	if (srom.flags & SRF_PHY_INIT) {	// (Re-)initialise PHY
-	    phy_write(PHY_AUTO_ADV, 0x01e1);	// Allow 100/10 meg
-	    phy_write(PHY_CONTROL, 0x1200);	// Enable & restart auto-neg
-	}
+        if (srom.flags & SRF_PHY_INIT) {        // (Re-)initialise PHY
+            phy_write(PHY_AUTO_ADV, 0x01e1);    // Allow 100/10 meg
+            phy_write(PHY_CONTROL, 0x1200);     // Enable & restart auto-neg
+        }
 
-	while (srom.flags & SRF_PHY_WAIT) {	// Wait (without timeout)
-	    uint s = phy_read(PHY_STATUS);	// Read PHY status
-	    sv->eth_up = (s & 4) >> 2;		// Bit 2 says link up
-	    if (sv->eth_up) {
-		ethinit_phase = ETHINIT_PHASE_DONE;
-		break;
-	    }
-	    ethinit_phase = ETHINIT_PHASE_WAIT_1;
-	    event_run(1);
-	}
+        while (srom.flags & SRF_PHY_WAIT) {     // Wait (without timeout)
+            uint s = phy_read(PHY_STATUS);      // Read PHY status
+            sv->eth_up = (s & 4) >> 2;          // Bit 2 says link up
+            if (sv->eth_up) {
+                ethinit_phase = ETHINIT_PHASE_DONE;
+                break;
+            }
+            ethinit_phase = ETHINIT_PHASE_WAIT_1;
+            event_run(1);
+        }
     }
 }
 
@@ -1436,63 +1436,63 @@ void eth_setup()
 
 void jtag_init(void)
 {
-    sc[GPIO_CLR] = JTAG_NTRST;		// Ensure NTRST is low
-    sc[SC_MISC_CTRL] |= JTAG_INT; 	// Drive JTAG internally
-    sark_delay_us(1);			// Wait a short while
-    sc[SC_MISC_CTRL] &= ~JTAG_INT; 	// Drive JTAG externally
+    sc[GPIO_CLR] = JTAG_NTRST;          // Ensure NTRST is low
+    sc[SC_MISC_CTRL] |= JTAG_INT;       // Drive JTAG internally
+    sark_delay_us(1);                   // Wait a short while
+    sc[SC_MISC_CTRL] &= ~JTAG_INT;      // Drive JTAG externally
 }
 
 
 void sark_config(void)
 {
-    sark_vec->num_msgs = 16;		// Allocate 16 SDP messages
-    sark_vec->num_events = 64;		// and 64 events
-    sark_vec->app_id = 0;		// Just to be sure...
+    sark_vec->num_msgs = 16;            // Allocate 16 SDP messages
+    sark_vec->num_events = 64;          // and 64 events
+    sark_vec->app_id = 0;               // Just to be sure...
     sark_vec->app_flags &= ~(1 << APP_FLAG_WAIT); // Don't wait in SARK start-up
 }
 
 
 void c_main(void)
 {
-    sark.cpu_clk = 160;			// BootROM uses 160 MHz
+    sark.cpu_clk = 160;                 // BootROM uses 160 MHz
 
-    jtag_init();			// Reset JTAG internals
+    jtag_init();                        // Reset JTAG internals
 
-    wd[WD_LOCK] = WD_CODE;		// Disable watchdog!
+    wd[WD_LOCK] = WD_CODE;              // Disable watchdog!
     wd[WD_CTRL] = 0;
 
-    sc[SC_MISC_CTRL] |= 1;  		// Swap RAM/ROM
+    sc[SC_MISC_CTRL] |= 1;              // Swap RAM/ROM
 
-    assign_virt_cpu(sark.phys_cpu);	// Assign virtual CPUs
+    assign_virt_cpu(sark.phys_cpu);     // Assign virtual CPUs
 
-    sv_init();				// Initialise system RAM
-    sark_led_init();			// Initialise LED drivers
-    pll_init();				// Restart PLLs
-    sdram_init();			// Initialise SDRAM
-    random_init();			// Initialise random
-    rtr_init(sark.phys_cpu);		// Initialise router
+    sv_init();                          // Initialise system RAM
+    sark_led_init();                    // Initialise LED drivers
+    pll_init();                         // Restart PLLs
+    sdram_init();                       // Initialise SDRAM
+    random_init();                      // Initialise random
+    rtr_init(sark.phys_cpu);            // Initialise router
 
-    if (sv->boot_delay) {		// If bootROM boot
-	boot_nn(sv->hw_ver);		// Flood fill neighbours
+    if (sv->boot_delay) {               // If bootROM boot
+        boot_nn(sv->hw_ver);            // Flood fill neighbours
     }
-    boot_ap();				// Start local APs
+    boot_ap();                          // Start local APs
 
-    timer1_init(sark.cpu_clk * 1000);	// Initialise 1ms timer
+    timer1_init(sark.cpu_clk * 1000);   // Initialise 1ms timer
 
-    queue_init();			// Initialise various queues
-    nn_init();				// Initialise NN package
-    netinit_start();			// Initialise late-stage boot process datastructures
-    vic_setup();			// Set VIC, interrupts on
+    queue_init();                       // Initialise various queues
+    nn_init();                          // Initialise NN package
+    netinit_start();                    // Initialise late-stage boot process datastructures
+    vic_setup();                        // Set VIC, interrupts on
 
     if (sv->boot_delay) {
-	eth_setup();		        // Set up Ethernet if present
+        eth_setup();                    // Set up Ethernet if present
     }
 
-    while (1) {				// Run event loop (forever...)
-	event_run(0);
-	if (event.proc_queue->proc_head == NULL) {
-	    cpu_wfi();
-	}
+    while (1) {                         // Run event loop (forever...)
+        event_run(0);
+        if (event.proc_queue->proc_head == NULL) {
+            cpu_wfi();
+        }
     }
 }
 

--- a/scamp/scamp-app.c
+++ b/scamp/scamp-app.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-app.c	    Application support for SC&MP
+// scamp-app.c      Application support for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2012
 //
@@ -24,9 +24,9 @@ void clock_ap(uint phys_mask, uint enable)
     uint state = sc[SC_CPU_DIS];
 
     if (enable) {
-	state &= ~phys_mask;
+        state &= ~phys_mask;
     } else {
-	state |= phys_mask;
+        state |= phys_mask;
     }
 
     sc[SC_CPU_DIS] = SC_CODE + state;
@@ -68,11 +68,11 @@ void boot_ap(void)
 void signal_sark(uint cmd, uint data, uint virt_mask, uint phys_mask)
 {
     for (uint cpu = 1; cpu < num_cpus; cpu++) {
-	if (virt_mask & (1 << cpu)) {
-	    vcpu_t *vcpu = sv_vcpu + cpu;
-	    vcpu->mbox_ap_cmd = cmd;
-	    vcpu->mbox_ap_msg = (void *) data;
-	}
+        if (virt_mask & (1 << cpu)) {
+            vcpu_t *vcpu = sv_vcpu + cpu;
+            vcpu->mbox_ap_cmd = cmd;
+            vcpu->mbox_ap_msg = (void *) data;
+        }
     }
 
     sc[SC_SET_IRQ] = SC_CODE + phys_mask;
@@ -84,15 +84,15 @@ void signal_sark(uint cmd, uint data, uint virt_mask, uint phys_mask)
 void set_cpu_info(uint virt_mask, uint state, uint app_id)
 {
     for (uint cpu = 1; cpu < num_cpus; cpu++) {
-	if (virt_mask & (1 << cpu)) {
-	    vcpu_t *vcpu = sv_vcpu + cpu;
+        if (virt_mask & (1 << cpu)) {
+            vcpu_t *vcpu = sv_vcpu + cpu;
 
-	    vcpu->cpu_state = state;
-	    vcpu->time = sv->unix_time;
+            vcpu->cpu_state = state;
+            vcpu->time = sv->unix_time;
 
-	    vcpu->app_id = app_id;
-	    core_app[cpu] = app_id;
-	}
+            vcpu->app_id = app_id;
+            core_app[cpu] = app_id;
+        }
     }
 }
 
@@ -106,7 +106,7 @@ uint find_lead(uint mask)
     uint count = 0;
 
     while ((mask != 0) && ((mask & (1 << count)) == 0)) {
-	count++;
+        count++;
     }
 
     return count;
@@ -119,7 +119,7 @@ void proc_start_app(uint aplx_addr, uint id_op_mask)
     uint virt_mask = id_op_mask & 0x0003ffff;
 
     if (virt_mask == 0) {
-	return;
+        return;
     }
 
     uint app_id = id_op_mask >> 24;
@@ -128,10 +128,10 @@ void proc_start_app(uint aplx_addr, uint id_op_mask)
     app_data_t *app = sv->app_data + app_id;
 
     if (app->cores == 0) {
-	app->clean = 0;
-	app->sema = 0;
-	app->mask = 0;
-	app->lead = find_lead(virt_mask);
+        app->clean = 0;
+        app->sema = 0;
+        app->mask = 0;
+        app->lead = find_lead(virt_mask);
     }
 
     app->cores += sark_count_bits(virt_mask);
@@ -155,7 +155,7 @@ void clean_app_id(uint app_id)
     app_data_t *app = sv->app_data + app_id;
 
     if (app->clean) {
-	return;
+        return;
     }
 
     sark_xfree_id(sv->sdram_heap,  app_id, 1);
@@ -196,8 +196,8 @@ void proc_stop_app(uint app_id_and_virt_mask, uint app_mask_and_phys_mask)
 
     uint candidate_app_id = app_id;
     while ((candidate_app_id & app_mask) == app_id) {
-	clean_app_id(candidate_app_id);
-	candidate_app_id++;
+        clean_app_id(candidate_app_id);
+        candidate_app_id++;
     }
 
     proc_init_cores(virt_mask, phys_mask);
@@ -226,34 +226,34 @@ void signal_app(uint data)
     uint phys_mask = 0;
 
     for (uint i = 1; i < num_cpus; i++) {
-	uint b = (core_app[i] & app_mask) == app_id;
-	virt_mask |= b << i;
-	phys_mask |= b << v2p_map[i];
+        uint b = (core_app[i] & app_mask) == app_id;
+        virt_mask |= b << i;
+        phys_mask |= b << v2p_map[i];
     }
 
     switch (sig) {
     case SIG_INIT:
-	event_queue_proc(proc_init_cores, virt_mask, phys_mask, PRIO_0);
-	break;
+        event_queue_proc(proc_init_cores, virt_mask, phys_mask, PRIO_0);
+        break;
 
     case SIG_PWRDN:
-	event_queue_proc(proc_power_down, virt_mask, phys_mask, PRIO_0);
-	break;
+        event_queue_proc(proc_power_down, virt_mask, phys_mask, PRIO_0);
+        break;
 
     case SIG_STOP:
-	event_queue_proc(proc_stop_app, (app_id << 24) | virt_mask,
-		(app_mask << 24) | phys_mask, PRIO_0);
-	break;
+        event_queue_proc(proc_stop_app, (app_id << 24) | virt_mask,
+                (app_mask << 24) | phys_mask, PRIO_0);
+        break;
 
     case SIG_SYNC0:
-	sc[SC_CLRFLAG] = virt_mask;
-	sc[SC_SET_IRQ] = SC_CODE + phys_mask;
-	break;
+        sc[SC_CLRFLAG] = virt_mask;
+        sc[SC_SET_IRQ] = SC_CODE + phys_mask;
+        break;
 
     case SIG_SYNC1:
-	sc[SC_SETFLAG] = virt_mask;
-	sc[SC_SET_IRQ] = SC_CODE + phys_mask;
-	break;
+        sc[SC_SETFLAG] = virt_mask;
+        sc[SC_SET_IRQ] = SC_CODE + phys_mask;
+        break;
 
     case SIG_TIMER:
     case SIG_USR0:
@@ -264,7 +264,7 @@ void signal_app(uint data)
     case SIG_CONT:
     case SIG_EXIT:
     case SIG_START:
-	signal_sark(SHM_SIGNAL, sig, virt_mask, phys_mask);
-	break;
+        signal_sark(SHM_SIGNAL, sig, virt_mask, phys_mask);
+        break;
     }
 }

--- a/scamp/scamp-boot.c
+++ b/scamp/scamp-boot.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-boot.c	    BootROM support for SC&MP
+// scamp-boot.c     BootROM support for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2012
 //
@@ -21,18 +21,18 @@
 
 #define BOOT_BUF (DTCM_BASE + 0x8000)
 
-#define BLOCK_COUNT	28	// From 1-256,
-#define WORD_COUNT	256	// From 1-256, BLOCK_COUNT * WORD_COUNT must be < 32kB
-#define BYTE_COUNT	(WORD_COUNT * sizeof(uint))
+#define BLOCK_COUNT     28      // From 1-256,
+#define WORD_COUNT      256     // From 1-256, BLOCK_COUNT * WORD_COUNT must be < 32kB
+#define BYTE_COUNT      (WORD_COUNT * sizeof(uint))
 
 
-#define FF_START_PHASE_1		0x01000003
-#define FF_BLOCK_START_PHASE_1		0x02000003
-#define FF_BLOCK_DATA_PHASE_1		0x03000003
-#define FF_BLOCK_END_PHASE_1		0x04000003
-#define FF_CONTROL_PHASE_1		0x05000103
+#define FF_START_PHASE_1                0x01000003
+#define FF_BLOCK_START_PHASE_1          0x02000003
+#define FF_BLOCK_DATA_PHASE_1           0x03000003
+#define FF_BLOCK_END_PHASE_1            0x04000003
+#define FF_CONTROL_PHASE_1              0x05000103
 
-#define FF_TARGET_MONITOR		0x0
+#define FF_TARGET_MONITOR               0x0
 
 
 const uint crc_table[] = {
@@ -87,7 +87,7 @@ uint crc32(uchar *buf, uint len)
     uint crc = 0xffffffff;
 
     while (len--) {
-	crc = crc_table[(crc ^ (*buf++)) & 0xff] ^ (crc >> 8);
+        crc = crc_table[(crc ^ (*buf++)) & 0xff] ^ (crc >> 8);
     }
     return crc ^ 0xffffffff;
 }
@@ -98,16 +98,16 @@ void nn_tx(uint key, uint data)
     key |= chksum_64(key, data);
 
     for (uint link = 0; link < NUM_LINKS; link++) {
-	while ((cc[CC_TCR] & BIT_31) == 0) {
-	    continue;
+        while ((cc[CC_TCR] & BIT_31) == 0) {
+            continue;
         }
 
-	cc[CC_TCR] = 0x00820000 | link << 18;
-	cc[CC_TXDATA] = data;
-	cc[CC_TXKEY] = key;
+        cc[CC_TCR] = 0x00820000 | link << 18;
+        cc[CC_TXDATA] = data;
+        cc[CC_TXKEY] = key;
     }
 
-    sark_delay_us(sv->boot_delay);	// ST - 05jul12 - allow time to propagate...
+    sark_delay_us(sv->boot_delay);      // ST - 05jul12 - allow time to propagate...
 }
 
 
@@ -127,22 +127,22 @@ void boot_nn(uint hw_ver)
     nn_tx(key, data);
 
     for (uint j = 0; j < BLOCK_COUNT; j++) {
-	key = FF_BLOCK_START_PHASE_1 | (j << 16) | ((WORD_COUNT - 1) << 8);
-	data = j * BYTE_COUNT;
+        key = FF_BLOCK_START_PHASE_1 | (j << 16) | ((WORD_COUNT - 1) << 8);
+        data = j * BYTE_COUNT;
 
-	nn_tx(key, data);
+        nn_tx(key, data);
 
-	for (uint k = 0; k < WORD_COUNT; k++) {
-	    key = FF_BLOCK_DATA_PHASE_1 | (j << 16) | (k << 0x8);
-	    data = image[j * WORD_COUNT + k];
+        for (uint k = 0; k < WORD_COUNT; k++) {
+            key = FF_BLOCK_DATA_PHASE_1 | (j << 16) | (k << 0x8);
+            data = image[j * WORD_COUNT + k];
 
-	    nn_tx(key, data);
-	}
+            nn_tx(key, data);
+        }
 
-	key = FF_BLOCK_END_PHASE_1 | (j << 16);
-	data = crc32((uchar *) (image + j * WORD_COUNT), BYTE_COUNT);
+        key = FF_BLOCK_END_PHASE_1 | (j << 16);
+        data = crc32((uchar *) (image + j * WORD_COUNT), BYTE_COUNT);
 
-	nn_tx(key, data);
+        nn_tx(key, data);
     }
 
     key = FF_CONTROL_PHASE_1;

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-cmd.c	    Command handling for SC&MP
+// scamp-cmd.c      Command handling for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2011
 //
@@ -19,7 +19,7 @@
 
 // Version command string for SC&MP
 
-#define SCAMP_ID_STR  		"SC&MP/SpiNNaker"
+#define SCAMP_ID_STR            "SC&MP/SpiNNaker"
 
 //------------------------------------------------------------------------------
 
@@ -52,7 +52,7 @@ uint cmd_ffd(sdp_msg_t *msg)
 
     uint key = (NN_CMD_FBS << 24) + (msg->arg2 & 0x00ffff00) + ID;
 
-    ff_nn_send(key, sum, fwd_rty, 0);	//## Changed log 1->0 10may13
+    ff_nn_send(key, sum, fwd_rty, 0);   //## Changed log 1->0 10may13
 
     uint words = ((msg->arg2 >> 8) & 255) + 1;
 
@@ -61,9 +61,9 @@ uint cmd_ffd(sdp_msg_t *msg)
     uint *ptr = (uint *) msg->data;
 
     for (uint w = 0; w < words; w++) {
-	uint data = *ptr++;
-	sum += data;
-	ff_nn_send(key + (w << 8), data, fwd_rty, 0);
+        uint data = *ptr++;
+        sum += data;
+        ff_nn_send(key + (w << 8), data, fwd_rty, 0);
     }
 
     key = (NN_CMD_FBE << 24) + (msg->arg2 & 0x00ff0000) + ID;
@@ -85,79 +85,79 @@ uint cmd_iptag(sdp_msg_t *msg, uint srce_ip)
     uint tag = msg->arg1 & 255;
 
     if (op > IPTAG_MAX || tag >= TAG_TABLE_SIZE) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     if (op == IPTAG_NEW || op == IPTAG_SET) {
-	if (op == IPTAG_NEW) {
-	    tag = iptag_new();
-	}
+        if (op == IPTAG_NEW) {
+            tag = iptag_new();
+        }
 
-	if (tag != TAG_NONE) {
-	    iptag_t *tt = tag_table + tag;
+        if (tag != TAG_NONE) {
+            iptag_t *tt = tag_table + tag;
 
-	    sark_word_set(tt, 0, sizeof(iptag_t));
+            sark_word_set(tt, 0, sizeof(iptag_t));
 
-	    uint timeout = (msg->arg1 >> 24) & 15;
-	    uint flags = (msg->arg1 >> 20) & 0x0f00;
+            uint timeout = (msg->arg1 >> 24) & 15;
+            uint flags = (msg->arg1 >> 20) & 0x0f00;
 
-	    if (timeout != 0) {
-		timeout = 1 << (timeout - 1);
-	    }
+            if (timeout != 0) {
+                timeout = 1 << (timeout - 1);
+            }
 
-	    tt->timeout = timeout;
-	    tt->flags = flags |= timeout;
+            tt->timeout = timeout;
+            tt->flags = flags |= timeout;
 
-	    tt->dest_addr = msg->arg2 >> 16;
-	    tt->dest_port = (msg->arg1 >> 8) & 255;
+            tt->dest_addr = msg->arg2 >> 16;
+            tt->dest_port = (msg->arg1 >> 8) & 255;
 
-	    if (msg->arg3 != 0) {
-		uchar *ip_addr = (uchar *) &msg->arg3;
-		copy_ip(ip_addr, tt->ip);
-	    } else if (! (flags & IPFLAG_REV)) {
-		copy_ip((uchar *) &srce_ip, tt->ip);
-	    }
+            if (msg->arg3 != 0) {
+                uchar *ip_addr = (uchar *) &msg->arg3;
+                copy_ip(ip_addr, tt->ip);
+            } else if (! (flags & IPFLAG_REV)) {
+                copy_ip((uchar *) &srce_ip, tt->ip);
+            }
 
-	    if (flags & IPFLAG_REV) {
-		tt->rx_port = msg->arg2 & 0xffff;
+            if (flags & IPFLAG_REV) {
+                tt->rx_port = msg->arg2 & 0xffff;
 
-		tt->flags |= IPFLAG_VALID;
-	    } else {
-		tt->tx_port = msg->arg2 & 0xffff;
+                tt->flags |= IPFLAG_VALID;
+            } else {
+                tt->tx_port = msg->arg2 & 0xffff;
 
-		tt->flags |= IPFLAG_ARP;
-		arp_lookup(tt);
-	    }
-	}
+                tt->flags |= IPFLAG_ARP;
+                arp_lookup(tt);
+            }
+        }
 
-	msg->arg1 = tag;
+        msg->arg1 = tag;
 
-	return 4;
+        return 4;
     } else if (op == IPTAG_GET) {
-	iptag_t *tt = tag_table + tag;
-	uint size = msg->arg2 * sizeof(iptag_t);
+        iptag_t *tt = tag_table + tag;
+        uint size = msg->arg2 * sizeof(iptag_t);
 
-	if (size > SDP_BUF_SIZE) {
-	    msg->cmd_rc = RC_ARG;
-	    return 0;
-	}
+        if (size > SDP_BUF_SIZE) {
+            msg->cmd_rc = RC_ARG;
+            return 0;
+        }
 
-	sark_mem_cpy(&msg->arg1, tt, size);
+        sark_mem_cpy(&msg->arg1, tt, size);
 
-	return size;
+        return size;
     } else if (op == IPTAG_TTO) {
-	msg->arg1 = (TAG_FIXED_SIZE << 24) +
-		(TAG_POOL_SIZE << 16) +
-		(sizeof(iptag_t) << 8) +
-		tag_tto;
+        msg->arg1 = (TAG_FIXED_SIZE << 24) +
+                (TAG_POOL_SIZE << 16) +
+                (sizeof(iptag_t) << 8) +
+                tag_tto;
 
-	if (msg->arg2 < 16) {
-	    tag_tto = msg->arg2;
-	}
-	return 4;
-    } else {	// IPTAG_CLR
-	tag_table[tag].flags = 0;
+        if (msg->arg2 < 16) {
+            tag_tto = msg->arg2;
+        }
+        return 4;
+    } else {    // IPTAG_CLR
+        tag_table[tag].flags = 0;
     }
 
     return 0;
@@ -170,9 +170,9 @@ uint cmd_ver(sdp_msg_t *msg)
     // Report P2P address of 255,255 until boot completes (as an indication
     // of system readiness)
     uint p2p_addr =
-	    ((netinit_phase == NETINIT_PHASE_DONE) &&
-		    (ethinit_phase == ETHINIT_PHASE_DONE))
-	    ? sv->p2p_addr : 0xFFFF;
+            ((netinit_phase == NETINIT_PHASE_DONE) &&
+                    (ethinit_phase == ETHINIT_PHASE_DONE))
+            ? sv->p2p_addr : 0xFFFF;
 
     msg->arg1 = (p2p_addr << 16) + (sark.phys_cpu << 8) + sark.virt_cpu;
     msg->arg2 = 0xffff0000 + SDP_BUF_SIZE;
@@ -196,8 +196,8 @@ uint cmd_link_read(sdp_msg_t *msg)
     uint link = msg->arg3;
 
     if (len > SDP_BUF_SIZE || link > NUM_LINKS - 1) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint addr = msg->arg1;
@@ -206,14 +206,14 @@ uint cmd_link_read(sdp_msg_t *msg)
     uint timeout = sv->peek_time;
 
     for (uint i = 0; i < len / 4; i++) {
-	uint rc = link_read_word(addr, link, buf, timeout);
-	if (rc != RC_OK) {
-	    msg->cmd_rc = rc;
-	    return 0;
-	}
+        uint rc = link_read_word(addr, link, buf, timeout);
+        if (rc != RC_OK) {
+            msg->cmd_rc = rc;
+            return 0;
+        }
 
-	addr += 4;
-	buf += 1;
+        addr += 4;
+        buf += 1;
     }
 
     return len;
@@ -231,8 +231,8 @@ uint cmd_link_write(sdp_msg_t *msg)
     uint link = msg->arg3;
 
     if (len > SDP_BUF_SIZE || link > NUM_LINKS - 1) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     uint addr = msg->arg1;
@@ -241,14 +241,14 @@ uint cmd_link_write(sdp_msg_t *msg)
     uint timeout = sv->peek_time;
 
     for (uint i = 0; i < len / 4; i++) {
-	uint rc = link_write_word(addr, link, buf, timeout);
-	if (rc != RC_OK) {
-	    msg->cmd_rc = rc;
-	    return 0;
-	}
+        uint rc = link_write_word(addr, link, buf, timeout);
+        if (rc != RC_OK) {
+            msg->cmd_rc = rc;
+            return 0;
+        }
 
-	addr += 4;
-	buf += 1;
+        addr += 4;
+        buf += 1;
     }
 
     return 0;
@@ -272,9 +272,9 @@ uint cmd_ar(sdp_msg_t *msg)
 {
     uint id_op_mask = msg->arg1;
 
-    if (id_op_mask & 1) {		// Can't reset monitor
-	msg->cmd_rc = RC_ARG;
-	return 0;
+    if (id_op_mask & 1) {               // Can't reset monitor
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     proc_start_app((uint) sv->sdram_sys, id_op_mask);
@@ -300,26 +300,26 @@ uint cmd_rtr(sdp_msg_t *msg)
     uint count = msg->arg1 >> 16;
 
     if (op == 0) {
-	rtr_mc_init(1);
+        rtr_mc_init(1);
     } else if (op == 1) {
-	if (! rtr_mc_clear(msg->arg2, count)) {
-	    msg->cmd_rc = RC_ARG;
-	}
+        if (! rtr_mc_clear(msg->arg2, count)) {
+            msg->cmd_rc = RC_ARG;
+        }
     } else if (op == 2) {
-	rtr_entry_t *table = (rtr_entry_t *) msg->arg2;
-	uint offset = msg->arg3;
+        rtr_entry_t *table = (rtr_entry_t *) msg->arg2;
+        uint offset = msg->arg3;
 
-	if (! rtr_mc_load(table, count, offset, app_id)) {
-	    msg->cmd_rc = RC_ARG;
-	}
+        if (! rtr_mc_load(table, count, offset, app_id)) {
+            msg->cmd_rc = RC_ARG;
+        }
     } else if (op == 3) {
-	if (msg->arg2 & BIT_31) {
-	    msg->arg1 = rtr_fr_get();
-	    return 4;
-	}
-	rtr_fr_set(msg->arg2);
+        if (msg->arg2 & BIT_31) {
+            msg->arg1 = rtr_fr_get();
+            return 4;
+        }
+        rtr_fr_set(msg->arg2);
     } else {
-	msg->cmd_rc = RC_ARG;
+        msg->cmd_rc = RC_ARG;
     }
 
   return 0;
@@ -373,18 +373,18 @@ uint cmd_info(sdp_msg_t *msg)
     uint timeout = sv->peek_time;
     uint local_chip_id = sc[SC_CHIP_ID];
     for (uint link = 0; link < NUM_LINKS; link++) {
-	// A link is determined working if: a link read of the remote system
-	// controller's chip ID returns and the chip ID matches this chip's
-	// ID (i.e. the remote chip is the same type of chip as this one!).
-	// Mark "disabled" links as not working.
-	if (link_en & (1 << link)) {
-	    uint remote_chip_id;
-	    uint rc = link_read_word((uint) (sc + SC_CHIP_ID), link,
-		    &remote_chip_id, timeout);
-	    if (rc == RC_OK && remote_chip_id == local_chip_id) {
-		msg->arg1 |= 1 << (link + 8);
-	    }
-	}
+        // A link is determined working if: a link read of the remote system
+        // controller's chip ID returns and the chip ID matches this chip's
+        // ID (i.e. the remote chip is the same type of chip as this one!).
+        // Mark "disabled" links as not working.
+        if (link_en & (1 << link)) {
+            uint remote_chip_id;
+            uint rc = link_read_word((uint) (sc + SC_CHIP_ID), link,
+                    &remote_chip_id, timeout);
+            if (rc == RC_OK && remote_chip_id == local_chip_id) {
+                msg->arg1 |= 1 << (link + 8);
+            }
+        }
     }
 
     // Get largest free block in SDRAM
@@ -396,7 +396,7 @@ uint cmd_info(sdp_msg_t *msg)
     // Add core states to the message
     uchar *buf = (uchar*) &(msg->data);
     for (uint core = 0; core < NUM_CPUS; core++) {
-	*(buf++) = sv_vcpu[core].cpu_state;
+        *(buf++) = sv_vcpu[core].cpu_state;
     }
 
     // Add the nearest Ethernet P2P id
@@ -418,15 +418,15 @@ uint cmd_info(sdp_msg_t *msg)
 extern level_t levels[4];
 extern uint pkt_tx(uint tcr, uint data, uint key);
 
-#define MODE_OR  	0
-#define MODE_AND 	1
-#define MODE_SUM 	2
-#define MODE_3   	3
+#define MODE_OR         0
+#define MODE_AND        1
+#define MODE_SUM        2
+#define MODE_3          3
 
-#define APP_RET		0
-#define APP_STAT	1
-#define APP_SIG		2
-#define APP_3		3
+#define APP_RET         0
+#define APP_STAT        1
+#define APP_SIG         2
+#define APP_3           3
 
 void p2p_send_reg(uint ctrl, uint addr, uint data)
 {
@@ -451,16 +451,16 @@ void proc_send(uint data, uint mask)
     levels[level].result = (mode == MODE_AND) ? (1 << 16) : 0;
 
     for (uint i = 0; i < 16; i++) {
-	if (mask & (1 << i)) {
-	    uint valid = levels[level].valid[i];
+        if (mask & (1 << i)) {
+            uint valid = levels[level].valid[i];
 
-	    if (valid) {
-		uint addr = levels[level].addr[i];
+            if (valid) {
+                uint addr = levels[level].addr[i];
 
-		levels[level].sent++;
-		p2p_send_reg(data & (3 << 22), addr, data); //##
-	    }
-	}
+                levels[level].sent++;
+                p2p_send_reg(data & (3 << 22), addr, data); //##
+            }
+        }
     }
 }
 
@@ -481,7 +481,7 @@ void p2p_region(uint data, uint srce)
 {
     uint t = chksum_32(data);
     if (t != 0) {
-	return;
+        return;
     }
 
     uint cmd = (data >> 22) & 3;
@@ -489,30 +489,30 @@ void p2p_region(uint data, uint srce)
     uint mode = (data >> 20) & 3;
 
     if (cmd == APP_RET) {
-	data &= 0x000fffff;	// trim to 20 bits
+        data &= 0x000fffff;     // trim to 20 bits
 
-	if (mode == MODE_OR) {
-	    levels[level].result += data & 0xffff;
-	    levels[level].result |= data & (1 << 16);
-	} else if (mode == MODE_AND) {
-	    uint count = (levels[level].result + data) & 0xffff;
-	    uint bit = levels[level].result & data & (1 << 16);
-	    levels[level].result = bit | count;
-	} else {
-	    levels[level].result += data;
-	}
+        if (mode == MODE_OR) {
+            levels[level].result += data & 0xffff;
+            levels[level].result |= data & (1 << 16);
+        } else if (mode == MODE_AND) {
+            uint count = (levels[level].result + data) & 0xffff;
+            uint bit = levels[level].result & data & (1 << 16);
+            levels[level].result = bit | count;
+        } else {
+            levels[level].result += data;
+        }
 
-	levels[level].rcvd++;
-	return;
+        levels[level].rcvd++;
+        return;
     }
 
     if (level != 0) {
-	levels[level].parent = srce;
-	data &= 0x0fffffff;
-	timer_schedule_proc(proc_send, data, 0xffffffff, 5);
-	timer_schedule_proc(proc_gather, level, mode, 200 * (4 - level));
+        levels[level].parent = srce;
+        data &= 0x0fffffff;
+        timer_schedule_proc(proc_send, data, 0xffffffff, 5);
+        timer_schedule_proc(proc_gather, level, mode, 200 * (4 - level));
 
-	return;
+        return;
     }
 
     // Level == 0 - process packet
@@ -520,47 +520,47 @@ void p2p_region(uint data, uint srce)
     uint result = 1;
 
     if (cmd == APP_STAT) {
-	uint app_id = data & 255;
-	uint app_mask = (data >> 8) & 255;
-	uint state = (data >> 16) & 15;
-	uint mask = 0;
+        uint app_id = data & 255;
+        uint app_mask = (data >> 8) & 255;
+        uint state = (data >> 16) & 15;
+        uint mask = 0;
 
-	for (uint i = 1; i < num_cpus; i++) {
-	    uint b = (core_app[i] & app_mask) == app_id;
-	    mask |= b << i;
-	}
+        for (uint i = 1; i < num_cpus; i++) {
+            uint b = (core_app[i] & app_mask) == app_id;
+            mask |= b << i;
+        }
 
-	result = 0;
+        result = 0;
 
-	if (mode == MODE_SUM) {
-	    for (uint i = 1; i < num_cpus; i++) {
-		if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state == state)) {
-		    result++;
-		}
-	    }
-	} else if (mode == MODE_OR) {
-	    for (uint i = 1; i < num_cpus; i++) {
-		if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state == state)) {
-		    result = 1 << 16;
-		}
-	    }
+        if (mode == MODE_SUM) {
+            for (uint i = 1; i < num_cpus; i++) {
+                if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state == state)) {
+                    result++;
+                }
+            }
+        } else if (mode == MODE_OR) {
+            for (uint i = 1; i < num_cpus; i++) {
+                if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state == state)) {
+                    result = 1 << 16;
+                }
+            }
 
-	    result++;
-	} else {		// MODE_AND
-	    result = 1 << 16;
+            result++;
+        } else {                // MODE_AND
+            result = 1 << 16;
 
-	    for (uint i = 1; i < num_cpus; i++) {
-		if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state != state)) {
-		    result = 0;
-		}
-	    }
+            for (uint i = 1; i < num_cpus; i++) {
+                if ((mask & (1 << i)) && (sv_vcpu[i].cpu_state != state)) {
+                    result = 0;
+                }
+            }
 
-	    result++;
-	}
+            result++;
+        }
     } else if (cmd == APP_SIG) {
-	signal_app(data);
+        signal_app(data);
     }
-    // else	// APP_3
+    // else     // APP_3
 
     uint d = (mode << 20) + (3 << 26) + result;
     p2p_send_reg(APP_RET << 22, srce, d);
@@ -573,31 +573,31 @@ uint cmd_sig(sdp_msg_t *msg)
     uint data = msg->arg2;
 
     if (type == 0) {
-	if (p2p_addr != sv->p2p_root) {
-	    msg->cmd_rc = RC_ARG;
-	    return 0;
-	}
-	pkt_tx(PKT_MC_PL, data, 0xffff5555);
+        if (p2p_addr != sv->p2p_root) {
+            msg->cmd_rc = RC_ARG;
+            return 0;
+        }
+        pkt_tx(PKT_MC_PL, data, 0xffff5555);
     } else if (type == 1) {
-	uint mask = msg->arg3;
+        uint mask = msg->arg3;
 
-	if (mask == 0) {
-	    msg->cmd_rc = RC_ARG;
-	    return 0;
-	}
+        if (mask == 0) {
+            msg->cmd_rc = RC_ARG;
+            return 0;
+        }
 
-	uint level = (data >> 26) & 3;
+        uint level = (data >> 26) & 3;
 
-	proc_send(data, mask);
-	sark_delay_us(10000);
-	msg->arg1 = levels[level].result;
+        proc_send(data, mask);
+        sark_delay_us(10000);
+        msg->arg1 = levels[level].result;
 
-	return 4;
+        return 4;
     } else if (type == 2) {
-	ff_nn_send((NN_CMD_SIG0 << 24) + 0x3f0000,
-		(5 << 28) + data, 0x3f00, 1);
+        ff_nn_send((NN_CMD_SIG0 << 24) + 0x3f0000,
+                (5 << 28) + data, 0x3f00, 1);
     } else {
-	msg->cmd_rc = RC_ARG;
+        msg->cmd_rc = RC_ARG;
     }
 
     return 0;
@@ -622,48 +622,48 @@ uint cmd_alloc(sdp_msg_t *msg)
     uint op = msg->arg1 & 255;
     uint app_id = (msg->arg1 >> 8) & 255;
     if (op > ALLOC_MAX) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     switch (op) {
     case ALLOC_SDRAM:
-	msg->arg1 = (uint) sark_xalloc(sv->sdram_heap,
-		msg->arg2,
-		msg->arg3,
-		ALLOC_LOCK + ALLOC_ID + (app_id << 8));
-	sv->app_data[app_id].clean = 0;
-	break;
+        msg->arg1 = (uint) sark_xalloc(sv->sdram_heap,
+                msg->arg2,
+                msg->arg3,
+                ALLOC_LOCK + ALLOC_ID + (app_id << 8));
+        sv->app_data[app_id].clean = 0;
+        break;
 
     case FREE_SDRAM:
-	sark_xfree(sv->sdram_heap, (void *) msg->arg2, ALLOC_LOCK);
-	return 0;
+        sark_xfree(sv->sdram_heap, (void *) msg->arg2, ALLOC_LOCK);
+        return 0;
 
     case FREE_SDRAM_ID:
-	msg->arg1 = sark_xfree_id(sv->sdram_heap, app_id, ALLOC_LOCK);
-	break;
+        msg->arg1 = sark_xfree_id(sv->sdram_heap, app_id, ALLOC_LOCK);
+        break;
 
     case ALLOC_RTR:
-	msg->arg1 = rtr_alloc_id(msg->arg2, app_id);
-	sv->app_data[app_id].clean = 0;
-	break;
+        msg->arg1 = rtr_alloc_id(msg->arg2, app_id);
+        sv->app_data[app_id].clean = 0;
+        break;
 
     case FREE_RTR:
-	rtr_free(msg->arg2, msg->arg3);
-	return 0;
+        rtr_free(msg->arg2, msg->arg3);
+        return 0;
 
     case FREE_RTR_ID:
-	msg->arg1 = rtr_free_id(app_id, msg->arg2);
-	break;
+        msg->arg1 = rtr_free_id(app_id, msg->arg2);
+        break;
 
     case SDRAM_SPACE:
-	msg->arg1 = sv->sdram_heap->free_bytes;
-	msg->arg2 = sark_heap_max(sv->sdram_heap, ALLOC_LOCK);
-	return 8;
+        msg->arg1 = sv->sdram_heap->free_bytes;
+        msg->arg2 = sark_heap_max(sv->sdram_heap, ALLOC_LOCK);
+        return 8;
 
     case HEAP_TAG_PTR:
-	msg->arg1 = (uint) sark_tag_ptr(msg->arg2 & 255, app_id);
-	break;
+        msg->arg1 = (uint) sark_tag_ptr(msg->arg2 & 255, app_id);
+        break;
     }
 
     return 4;
@@ -682,21 +682,21 @@ uint cmd_remap(sdp_msg_t *msg)
     uint virt_core, phys_core;
 
     if (core > NUM_CPUS) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
-    if (flags & 1) {			// Arg is physical core
-	virt_core = sv->p2v_map[core];
-	phys_core = core;
-    } else {				// Arg is virtual core
-	virt_core = core;
-	phys_core = v2p_map[virt_core];
+    if (flags & 1) {                    // Arg is physical core
+        virt_core = sv->p2v_map[core];
+        phys_core = core;
+    } else {                            // Arg is virtual core
+        virt_core = core;
+        phys_core = v2p_map[virt_core];
     }
 
     if (virt_core == 0 || virt_core >= num_cpus) {
-	msg->cmd_rc = RC_ARG;
-	return 0;
+        msg->cmd_rc = RC_ARG;
+        return 0;
     }
 
     remap_phys_cores(1 << phys_core);
@@ -711,8 +711,8 @@ uint scamp_debug(sdp_msg_t *msg, uint srce_ip)
 {
     uint len = msg->length;
     if (len < 24) {
-	msg->cmd_rc = RC_LEN;
-	return 0;
+        msg->cmd_rc = RC_LEN;
+        return 0;
     }
 
     uint t = msg->cmd_rc;
@@ -720,45 +720,45 @@ uint scamp_debug(sdp_msg_t *msg, uint srce_ip)
 
     switch (t) {
     case CMD_VER:
-	return cmd_ver(msg);
+        return cmd_ver(msg);
     case CMD_READ:
-	return sark_cmd_read(msg);
+        return sark_cmd_read(msg);
     case CMD_WRITE:
-	return sark_cmd_write(msg);
+        return sark_cmd_write(msg);
     case CMD_FILL:
-	return sark_cmd_fill(msg);
+        return sark_cmd_fill(msg);
     case CMD_LED:
-	sark_led_set(msg->arg1);
-	return 0;
+        sark_led_set(msg->arg1);
+        return 0;
     case CMD_SROM:
-	return cmd_srom(msg);
+        return cmd_srom(msg);
     case CMD_LINK_READ:
-	return cmd_link_read(msg);
+        return cmd_link_read(msg);
     case CMD_LINK_WRITE:
-	return cmd_link_write(msg);
+        return cmd_link_write(msg);
     case CMD_FFD:
-	return cmd_ffd(msg);
+        return cmd_ffd(msg);
     case CMD_IPTAG:
-	return cmd_iptag(msg, srce_ip);
+        return cmd_iptag(msg, srce_ip);
     case CMD_NNP:
-	return cmd_nnp(msg);
+        return cmd_nnp(msg);
     case CMD_AS:
-	return cmd_as(msg);
+        return cmd_as(msg);
     case CMD_AR:
-	return cmd_ar(msg);
+        return cmd_ar(msg);
     case CMD_REMAP:
-	return cmd_remap(msg);
+        return cmd_remap(msg);
     case CMD_ALLOC:
-	return cmd_alloc(msg);
+        return cmd_alloc(msg);
     case CMD_SIG:
-	return cmd_sig(msg);
+        return cmd_sig(msg);
     case CMD_RTR:
-	return cmd_rtr(msg);
+        return cmd_rtr(msg);
     case CMD_INFO:
-	return cmd_info(msg);
+        return cmd_info(msg);
     default:
-	msg->cmd_rc = RC_CMD;
-	return 0;
+        msg->cmd_rc = RC_CMD;
+        return 0;
     }
 }
 

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-isr.c	    SC&MP interrupt routines
+// scamp-isr.c      SC&MP interrupt routines
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -39,7 +39,7 @@ extern void msg_queue_insert(sdp_msg_t *msg, uint srce_ip);
 extern uchar v2p_map[MAX_CPUS];
 extern uint num_cpus;
 
-static uint centi_ms;	// Counts 0 to 9 in ms
+static uint centi_ms;   // Counts 0 to 9 in ms
 
 //------------------------------------------------------------------------------
 
@@ -53,13 +53,13 @@ INT_HANDLER pkt_tx_int() // SPIN2 - optimise for register order??
 
     cc[CC_TCR] = pkt->ctrl;
     if (pkt->ctrl & PKT_PL) {
-	cc[CC_TXDATA] = pkt->data;
+        cc[CC_TXDATA] = pkt->data;
     }
     cc[CC_TXKEY] = pkt->key;
 
     txq->count--;
     if (txq->count == 0) {
-	vic[VIC_DISABLE] = 1 << CC_TMT_INT;
+        vic[VIC_DISABLE] = 1 << CC_TMT_INT;
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -73,59 +73,59 @@ INT_HANDLER pkt_tx_int() // SPIN2 - optimise for register order??
 void eth_rx_int(void)
 {
   asm volatile (
-  "	.arm \n\
-	.global	eth_receive \n\
-	.equ    MODE_SYS, 0x1f \n\
-	.equ    MODE_IRQ, 0x12 \n\
-	.equ	IMASK_IRQ, 0x80 \n\
-	.equ	VIC_BASE, 0x1f000000 \n\
-	.equ	VIC_VADDR, 0x30 \n\
-    	sub  	lr, lr, #4 \n\
-    	stmfd  	sp!, {r0, lr} \n\
-    	mrs    	lr, spsr \n\
-    	stmfd  	sp!, {r12, lr} \n\
-    	msr    	cpsr_c, #MODE_SYS \n\
-    	stmfd  	sp!, {r1-r3, lr} \n\
-    	bl     	eth_receive \n\
-    	ldmfd  	sp!, {r1-r3, lr} \n\
-    	msr    	cpsr_c, #MODE_IRQ+IMASK_IRQ \n\
-	mov    	r12, #VIC_BASE \n\
-	str    	r12, [r12, #VIC_VADDR] \n\
-    	ldmfd  	sp!, {r12, lr} \n\
-    	msr    	spsr_cxsf, lr \n\
-    	ldmfd  	sp!, {r0, pc}^ \n\
+  "     .arm \n\
+        .global eth_receive \n\
+        .equ    MODE_SYS, 0x1f \n\
+        .equ    MODE_IRQ, 0x12 \n\
+        .equ    IMASK_IRQ, 0x80 \n\
+        .equ    VIC_BASE, 0x1f000000 \n\
+        .equ    VIC_VADDR, 0x30 \n\
+        sub     lr, lr, #4 \n\
+        stmfd   sp!, {r0, lr} \n\
+        mrs     lr, spsr \n\
+        stmfd   sp!, {r12, lr} \n\
+        msr     cpsr_c, #MODE_SYS \n\
+        stmfd   sp!, {r1-r3, lr} \n\
+        bl      eth_receive \n\
+        ldmfd   sp!, {r1-r3, lr} \n\
+        msr     cpsr_c, #MODE_IRQ+IMASK_IRQ \n\
+        mov     r12, #VIC_BASE \n\
+        str     r12, [r12, #VIC_VADDR] \n\
+        ldmfd   sp!, {r12, lr} \n\
+        msr     spsr_cxsf, lr \n\
+        ldmfd   sp!, {r0, pc}^ \n\
   " :::);
 }
 #else
 __asm void eth_rx_int(void)
 {
-	code32
-	import	eth_receive
-	preserve8
+        code32
+        import  eth_receive
+        preserve8
 
-    	sub  	lr, lr, #4		;; Adjust LR_irq and save
-    	stmfd  	sp!, {r0, lr}		;; with r0
+        sub     lr, lr, #4              ;; Adjust LR_irq and save
+        stmfd   sp!, {r0, lr}           ;; with r0
 
-    	mrs    	lr, spsr		;; Get SPSR_irq to LR
-    	stmfd  	sp!, {r12, lr}  	;; Save SPSR & r12
+        mrs     lr, spsr                ;; Get SPSR_irq to LR
+        stmfd   sp!, {r12, lr}          ;; Save SPSR & r12
 
-    	msr    	cpsr_c, #MODE_SYS    	;; Go to SYS mode, interrupts enabled
+        msr     cpsr_c, #MODE_SYS       ;; Go to SYS mode, interrupts enabled
 
-    	stmfd  	sp!, {r1-r3, lr} 	;; Save working regs and LR_sys
+        stmfd   sp!, {r1-r3, lr}        ;; Save working regs and LR_sys
 
-    	bl     	eth_receive
+        bl      eth_receive
 
-    	ldmfd  	sp!, {r1-r3, lr} 	;; Restore working regs & LR_sys
+        ldmfd   sp!, {r1-r3, lr}        ;; Restore working regs & LR_sys
 
-    	msr    	cpsr_c, #MODE_IRQ+IMASK_IRQ ; Back to IRQ mode, IRQ disabled
+        msr     cpsr_c, #MODE_IRQ+IMASK_IRQ ; Back to IRQ mode, IRQ disabled
 
-	mov    	r12, #VIC_BASE		;; Tell VIC we are done
-	str    	r12, [r12, #VIC_VADDR * 4]
+        mov     r12, #VIC_BASE          ;; Tell VIC we are done
+        str     r12, [r12, #VIC_VADDR * 4]
 
-    	ldmfd  	sp!, {r12, lr} 	      	;; Restore r12 & SPSR_irq
-    	msr    	spsr_cxsf, lr
+        ldmfd   sp!, {r12, lr}          ;; Restore r12 & SPSR_irq
+        msr     spsr_cxsf, lr
 
-    	ldmfd  	sp!, {r0, pc}^       	;; and return restoring r0
+        ldmfd   sp!, {r0, pc}^          ;; and return restoring r0
 }
 #endif
 
@@ -141,7 +141,7 @@ INT_HANDLER pkt_mc_int()
     // Checksum ??
 
     if (key == 0xffff5555) {
-	signal_app(data);
+        signal_app(data);
     }
 
 #if MC_SLOT != SLOT_FIQ
@@ -157,18 +157,18 @@ INT_HANDLER pkt_nn_int()
     uint key = cc[CC_RXKEY];
     uint link = (ctrl >> 24) & 7;
 
-    if (ctrl & PKT_PL) {			// Has payload
-	if (key & 1) { 				// Reply to peek
-	    peek_ack_pkt(link, data, key);
-	} else {				// SNP protocol
-	    nn_rcv_pkt(link, data, key);
-	}
-    } else {					// No payload
-	if (key & 1) { 				// Reply to poke
-	    poke_ack_pkt(link, data, key);
-	} else {
-	    // not used
-	}
+    if (ctrl & PKT_PL) {                        // Has payload
+        if (key & 1) {                          // Reply to peek
+            peek_ack_pkt(link, data, key);
+        } else {                                // SNP protocol
+            nn_rcv_pkt(link, data, key);
+        }
+    } else {                                    // No payload
+        if (key & 1) {                          // Reply to poke
+            poke_ack_pkt(link, data, key);
+        } else {
+            // not used
+        }
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -183,11 +183,11 @@ INT_HANDLER pkt_p2p_int()
     key &= 0xffff;
 
     if (p2p_type == P2P_LEVEL) {
-	p2p_region(data, key);
+        p2p_region(data, key);
     } else if (p2p_type == P2P_DATA) {
-	p2p_rcv_data(data, key);
+        p2p_rcv_data(data, key);
     } else if (p2p_type == P2P_CTRL) {
-	p2p_rcv_ctrl(data, key);
+        p2p_rcv_ctrl(data, key);
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -199,39 +199,39 @@ INT_HANDLER pkt_p2p_int()
 
 INT_HANDLER ms_timer_int()
 {
-    tc[T1_INT_CLR] = (uint) tc;    	// Clear interrupt
+    tc[T1_INT_CLR] = (uint) tc;         // Clear interrupt
 
     sv->clock_ms++;
     uint ms = sv->time_ms + 1;
     if (ms == 1000) {
-	ms = 0;
-	sv->unix_time++;
+        ms = 0;
+        sv->unix_time++;
 
-	if (!event_queue_proc(proc_1hz, 0, 0, PRIO_2)) { // !!const
-	    sw_error(SW_OPT);
+        if (!event_queue_proc(proc_1hz, 0, 0, PRIO_2)) { // !!const
+            sw_error(SW_OPT);
         }
     }
 
     sv->time_ms = ms;
     uint cs = centi_ms + 1;
     if (cs == 10) {
-	cs = 0;
+        cs = 0;
 
-	if (!event_queue_proc(proc_100hz, 0, 0, PRIO_1)) { // !!const
-	    sw_error(SW_OPT);
+        if (!event_queue_proc(proc_100hz, 0, 0, PRIO_1)) { // !!const
+            sw_error(SW_OPT);
         }
     }
 
     if (!event_queue_proc(proc_1khz, 0, 0, PRIO_1)) {// !!const
-	sw_error(SW_OPT);
+        sw_error(SW_OPT);
     }
     centi_ms = cs;
 
     if (sv->tp_scale != 0) {
-	uint timer = ++sv->tp_timer;
-	uint tp = (timer >> sv->tp_scale) & 3;
+        uint timer = ++sv->tp_timer;
+        uint tp = (timer >> sv->tp_scale) & 3;
 
-	rtr[RTR_CONTROL] = (rtr[RTR_CONTROL] & ~0xc0) | (tp << 6);
+        rtr[RTR_CONTROL] = (rtr[RTR_CONTROL] & ~0xc0) | (tp << 6);
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -246,9 +246,9 @@ uint next_box;
 INT_HANDLER ap_int()
 {
     do {
-	next_box++;
-	if (next_box >= num_cpus) {
-	    next_box = 0;
+        next_box++;
+        if (next_box >= num_cpus) {
+            next_box = 0;
         }
     } while ((sv->mbox_flags & (1 << next_box)) == 0);
 
@@ -259,26 +259,26 @@ INT_HANDLER ap_int()
     uint cpsr = sark_lock_get(LOCK_MBOX);
     sv->mbox_flags &= ~(1 << next_box);
     if (sv->mbox_flags == 0) {
-	sc[SC_CLR_IRQ] = SC_CODE + (1 << sark.phys_cpu);
+        sc[SC_CLR_IRQ] = SC_CODE + (1 << sark.phys_cpu);
     }
     sark_lock_free(cpsr, LOCK_MBOX);
 
     if (cmd == SHM_MSG) {
-	vcpu->mbox_mp_cmd = SHM_IDLE;
+        vcpu->mbox_mp_cmd = SHM_IDLE;
 
-	sdp_msg_t *msg = sark_msg_get();
+        sdp_msg_t *msg = sark_msg_get();
 
-	if (msg != NULL) {
-	    sark_msg_cpy(msg, shm_msg);
-	    msg_queue_insert(msg, 0);
-	} else {
-	    sw_error(SW_OPT);
+        if (msg != NULL) {
+            sark_msg_cpy(msg, shm_msg);
+            msg_queue_insert(msg, 0);
+        } else {
+            sw_error(SW_OPT);
         }
 
-	sark_shmsg_free(shm_msg);
-    } else {	//## Hook for other commands...
-	vcpu->mbox_mp_cmd = SHM_IDLE;
-	sw_error(SW_OPT);
+        sark_shmsg_free(shm_msg);
+    } else {    //## Hook for other commands...
+        vcpu->mbox_mp_cmd = SHM_IDLE;
+        sw_error(SW_OPT);
     }
 
     vic[VIC_VADDR] = (uint) vic;
@@ -293,7 +293,7 @@ extern INT_HANDLER timer2_int_han(void);
 
 void vic_setup(void)
 {
-    tc[T2_CONTROL] = 0;	// Disable timer2
+    tc[T2_CONTROL] = 0; // Disable timer2
 
     sark_vic_set(MC_SLOT, CC_MC_INT, 1, pkt_mc_int);
 

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-nn.c	    NN packet handling for SC&MP
+// scamp-nn.c       NN packet handling for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2011
 //
@@ -18,11 +18,11 @@
 //------------------------------------------------------------------------------
 
 
-#define BC_TABLE_SIZE 		16
+#define BC_TABLE_SIZE           16
 
-#define FF_ST_IDLE  0		// Doing nothing
-#define FF_ST_EXBLK 1		// Rcvd FFS or FBE, awaiting FBS, FFE
-#define FF_ST_INBLK 2		// Rcvd FBS, awaiting FBD, FBE
+#define FF_ST_IDLE  0           // Doing nothing
+#define FF_ST_EXBLK 1           // Rcvd FFS or FBE, awaiting FBS, FFE
+#define FF_ST_INBLK 2           // Rcvd FBS, awaiting FBD, FBE
 
 #define PART_ID (CHIP_ID_CODE & 0xfff00000)
 
@@ -31,40 +31,40 @@
 //------------------------------------------------------------------------------
 
 typedef struct nn_desc_t {
-    uchar state;		// FF state
-    uchar error;		// Error flag
-    uchar forward;		// Rebroadcast code
-    uchar retry;		// Rebroadcast retry
+    uchar state;                // FF state
+    uchar error;                // Error flag
+    uchar forward;              // Rebroadcast code
+    uchar retry;                // Rebroadcast retry
 
-    uchar id;			// ID of current FF
-    uchar block_len;		// Block length
-    uchar block_count;		// Block count
-    uchar block_num;		// Block number
+    uchar id;                   // ID of current FF
+    uchar block_len;            // Block length
+    uchar block_count;          // Block count
+    uchar block_num;            // Block number
 
-    uchar app_id;		// AppID
-    uchar load;			// Set if for us
-    ushort srce_addr; 		// P2P of sender
+    uchar app_id;               // AppID
+    uchar load;                 // Set if for us
+    ushort srce_addr;           // P2P of sender
 
-    ushort word_len;		// Number of words in block
-    ushort word_count;		// Count of received words
+    ushort word_len;            // Number of words in block
+    ushort word_count;          // Count of received words
 
-    uint gidr_id;		// GIDR ID
+    uint gidr_id;               // GIDR ID
 
-    uint sum;			// Checksum
-    uint region;		// Region
-    uint cores;			// Selected cores to load
-    uint* aplx_addr;		// APLX block addr
-    uint load_addr;		// Block load base
-    uint id_set[4];		// ID bitmap (128 bits)
-    uint biff_id_set[4];	// Board-level flood-fill ID bitmap (128 bits)
-    uint fbs_set[8];		// Block bitmap for FBS (must be >= 8 words)
-    uint fbd_set[8];		// Word bitmap for FBD (must be >= 8 words)
-    uint fbe_set[8];		// Block bitmap for FBE (must be >= 8 words)
-    uint stats[16];		// Counters for each packet type
-    uint errors;		// Counter for bad checksums
-    uint buf[SDP_BUF_SIZE/4];	// Holding buffer
+    uint sum;                   // Checksum
+    uint region;                // Region
+    uint cores;                 // Selected cores to load
+    uint* aplx_addr;            // APLX block addr
+    uint load_addr;             // Block load base
+    uint id_set[4];             // ID bitmap (128 bits)
+    uint biff_id_set[4];        // Board-level flood-fill ID bitmap (128 bits)
+    uint fbs_set[8];            // Block bitmap for FBS (must be >= 8 words)
+    uint fbd_set[8];            // Word bitmap for FBD (must be >= 8 words)
+    uint fbe_set[8];            // Block bitmap for FBE (must be >= 8 words)
+    uint stats[16];             // Counters for each packet type
+    uint errors;                // Counter for bad checksums
+    uint buf[SDP_BUF_SIZE/4];   // Holding buffer
 
-    uint64 last_ffcs;		// Index of the last FFCS packet
+    uint64 last_ffcs;           // Index of the last FFCS packet
 } nn_desc_t;
 
 //------------------------------------------------------------------------------
@@ -103,8 +103,8 @@ void nn_init()
     pkt_buf_list = pkt;
 
     for (uint i = 0; i < BC_TABLE_SIZE; i++) {
-	pkt->next = (i != (BC_TABLE_SIZE - 1)) ? pkt + 1 : NULL;
-	pkt++;
+        pkt->next = (i != (BC_TABLE_SIZE - 1)) ? pkt + 1 : NULL;
+        pkt++;
     }
 }
 
@@ -150,18 +150,18 @@ void compute_eth(void)
 
     int xm = x - (p2p_root >> 8);
     while (xm < 0) {
-	xm += 12;
+        xm += 12;
     }
     while (xm >= 12) {
-	xm -= 12;
+        xm -= 12;
     }
 
     int ym = y - (p2p_root & 0xFF);
     while (ym < 0) {
-	ym += 12;
+        ym += 12;
     }
     while (ym >= 12) {
-	ym -= 12;
+        ym -= 12;
     }
 
     // Get table entry and split fields
@@ -174,12 +174,12 @@ void compute_eth(void)
 
     x -= xt;
     if (x < 0) {
-	x += x_size;
+        x += x_size;
     }
 
     y -= yt;
     if (y < 0) {
-	y += y_size;
+        y += y_size;
     }
 
     sv->board_addr = (xt << 8) + yt;
@@ -205,12 +205,12 @@ void compute_level(uint p2p_addr)
     uint y = p2p_addr & 255;
 
     for (uint lvl = 0; lvl < 4; lvl++) {
-	uint shift = 6 - 2 * lvl;
-	uint mask = ~((4 << shift) - 1);
-	uint bit = ((x >> shift) & 3) + 4 * ((y >> shift) & 3);
-	uint nx = x & mask;
-	uint ny = y & mask;
-	levels[lvl].level_addr = (nx << 24) + ((ny + lvl) << 16) + (1 << bit);
+        uint shift = 6 - 2 * lvl;
+        uint mask = ~((4 << shift) - 1);
+        uint bit = ((x >> shift) & 3) + 4 * ((y >> shift) & 3);
+        uint nx = x & mask;
+        uint ny = y & mask;
+        levels[lvl].level_addr = (nx << 24) + ((ny + lvl) << 16) + (1 << bit);
     }
 }
 
@@ -222,37 +222,37 @@ void level_config(void)
     compute_level(p2p_addr);
 
     for (uint level = 0; level < 4; level++) {
-	uint base = (levels[level].level_addr >> 16) & 0xfcfc;
-	uint shift = 6 - 2 * level;	// {6, 4, 2, 0};
-	uint width = (1 << shift);	// {64, 16, 4, 1};
+        uint base = (levels[level].level_addr >> 16) & 0xfcfc;
+        uint shift = 6 - 2 * level;     // {6, 4, 2, 0};
+        uint width = (1 << shift);      // {64, 16, 4, 1};
 
-	for (uint ix = 0; ix < 4; ix++) {
-	    for (uint iy = 0; iy < 4; iy++) {
-		uint num = ix + 4 * iy;
-		uint addr = ((ix << 8) + iy) << shift;
+        for (uint ix = 0; ix < 4; ix++) {
+            for (uint iy = 0; iy < 4; iy++) {
+                uint num = ix + 4 * iy;
+                uint addr = ((ix << 8) + iy) << shift;
 
-		// Now search for a working chip within the subregion.
+                // Now search for a working chip within the subregion.
 
-		for (uint i = 0; i < (width * width); i++) {
-		    uint wx = i & ((1 << shift) - 1);
-		    uint wy = i >> shift;
-		    uint a = base + addr + (wx << 8) + wy;
+                for (uint i = 0; i < (width * width); i++) {
+                    uint wx = i & ((1 << shift) - 1);
+                    uint wy = i >> shift;
+                    uint a = base + addr + (wx << 8) + wy;
 
-		    // Don't bother trying outside the scope of the system
-		    if (a >= p2p_dims || (a & 0xFF) >= (p2p_dims & 0xFF)) {
-			continue;
-		    }
+                    // Don't bother trying outside the scope of the system
+                    if (a >= p2p_dims || (a & 0xFF) >= (p2p_dims & 0xFF)) {
+                        continue;
+                    }
 
-		    uint link = rtr_p2p_get(a);
+                    uint link = rtr_p2p_get(a);
 
-		    if (link != 6) {
-			levels[level].addr[num] = a;
-			levels[level].valid[num] = 1;
-			break;
-		    }
-		}
-	    }
-	}
+                    if (link != 6) {
+                        levels[level].addr[num] = a;
+                        levels[level].valid[num] = 1;
+                        break;
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -263,9 +263,9 @@ void level_config(void)
 void peek_ack_pkt(uint link, uint data, uint key)
 {
     if (peek_pkt.flags != 1) {
-	pkt_t t = {link, data, key};
-	peek_pkt.pkt = t;
-	peek_pkt.flags = 1;
+        pkt_t t = {link, data, key};
+        peek_pkt.pkt = t;
+        peek_pkt.flags = 1;
     }
 }
 
@@ -273,9 +273,9 @@ void peek_ack_pkt(uint link, uint data, uint key)
 void poke_ack_pkt(uint link, uint data, uint key)
 {
     if (poke_pkt.flags != 1) {
-	pkt_t t = {link, data, key};
-	poke_pkt.pkt = t;
-	poke_pkt.flags = 1;
+        pkt_t t = {link, data, key};
+        poke_pkt.pkt = t;
+        poke_pkt.flags = 1;
     }
 }
 
@@ -288,30 +288,30 @@ uint link_read_word(uint addr, uint link, uint *buf, uint timeout)
     peek_pkt.flags = 0;
 
     if (! pkt_tx(PKT_NND + (link << 18), 0, addr)) {
-	return RC_PKT_TX;
+        return RC_PKT_TX;
     }
 
     event_t* e = event_new(proc_byte_set, (uint) &peek_pkt.flags, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	return RC_BUF;
+        sw_error(SW_OPT);
+        return RC_BUF;
     }
 
     uint id = e->ID;
     timer_schedule(e, timeout);
 
     while (peek_pkt.flags == 0) {
-	continue;
+        continue;
     }
 
     if (peek_pkt.flags == 2) {
-	return RC_TIMEOUT;
+        return RC_TIMEOUT;
     }
 
     timer_cancel(e, id);
 
     if (buf != NULL) {
-	*buf = peek_pkt.pkt.data;
+        *buf = peek_pkt.pkt.data;
     }
 
     return RC_OK;
@@ -323,24 +323,24 @@ uint link_write_word(uint addr, uint link, uint *buf, uint timeout)
     poke_pkt.flags = 0;
 
     if (! pkt_tx(PKT_NND + PKT_PL + (link << 18), *buf, addr)) {
-	return RC_PKT_TX;
+        return RC_PKT_TX;
     }
 
     event_t* e = event_new(proc_byte_set, (uint) &poke_pkt.flags, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	return RC_BUF;
+        sw_error(SW_OPT);
+        return RC_BUF;
     }
 
     uint id = e->ID;
     timer_schedule(e, timeout);
 
     while (poke_pkt.flags == 0) {
-	continue;
+        continue;
     }
 
     if (poke_pkt.flags == 2) {
-	return RC_TIMEOUT;
+        return RC_TIMEOUT;
     }
 
     timer_cancel(e, id);
@@ -356,10 +356,10 @@ pkt_buf_t* pkt_buf_get()
     pkt_buf_t *pkt = pkt_buf_list;
 
     if (pkt != NULL) {
-	pkt_buf_list = pkt->next;
-	pkt_buf_count++;
-	if (pkt_buf_count > pkt_buf_max) {
-	    pkt_buf_max = pkt_buf_count;
+        pkt_buf_list = pkt->next;
+        pkt_buf_count++;
+        if (pkt_buf_count > pkt_buf_max) {
+            pkt_buf_max = pkt_buf_count;
         }
     }
 
@@ -380,7 +380,7 @@ uint next_id(void)
 {
     uint t = sv->last_id + 1;
     if (t > 127) {
-	t = 1;
+        t = 1;
     }
     sv->last_id = t;
     return t << 1;
@@ -390,7 +390,7 @@ uint next_biff_id(void)
 {
     uint t = sv->last_biff_id + 1;
     if (t > 127) {
-	t = 1;
+        t = 1;
     }
     sv->last_biff_id = t;
     return t << 1;
@@ -401,9 +401,9 @@ void nn_mark(uint key)
 {
     uint id = (key >> 1) & 127;
 
-    uint w = id >> 5;			// Word in id_set
-    uint b = 1 << (id & 31);		// Bit in word
-    uint v = nn_desc.id_set[w];		// Get word from array
+    uint w = id >> 5;                   // Word in id_set
+    uint b = 1 << (id & 31);            // Bit in word
+    uint v = nn_desc.id_set[w];         // Get word from array
 
     nn_desc.id_set[w] = v | b;
     w = (w + 2) % 4;
@@ -414,22 +414,22 @@ void nn_mark(uint key)
 void ff_nn_send(uint key, uint data, uint fwd_rty, uint add_id)
 {
     if (add_id) {
-	key |= next_id();
+        key |= next_id();
     }
 
-    uint count = fwd_rty & 7;		// Number of times to send
-    uint delay = fwd_rty & 0xf8;	// Delay between transmissions
-    uint forward = fwd_rty >> 8;	// Set of links to forward to
+    uint count = fwd_rty & 7;           // Number of times to send
+    uint delay = fwd_rty & 0xf8;        // Delay between transmissions
+    uint forward = fwd_rty >> 8;        // Set of links to forward to
 
     key |= chksum_64(key, data);
 
     do {
-	for (uint link = 0; link < NUM_LINKS; link++) {
-	    if (forward & (1 << link) & link_en) {
-		sark_delay_us(delay);
-		(void) pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
-	    }
-	}
+        for (uint link = 0; link < NUM_LINKS; link++) {
+            if (forward & (1 << link) & link_en) {
+                sark_delay_us(delay);
+                (void) pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+            }
+        }
     } while (count--);
 }
 
@@ -447,9 +447,9 @@ void biff_nn_send(uint data)
 
     uint forward = 0x07; // East, North-East, North only
     for (uint link = 0; link < NUM_LINKS; link++) {
-	if (forward & (1 << link) & link_en) {
-	    sark_delay_us(8);  // !! const
-	    (void) pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+        if (forward & (1 << link) & link_en) {
+            sark_delay_us(8);  // !! const
+            (void) pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
         }
     }
 }
@@ -461,17 +461,17 @@ void p2pc_addr_nn_send(uint arg1, uint arg2)
 {
     // Don't send anything if our address is actually unknown...
     if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA) {
-	return;
+        return;
     }
 
     uint key = (NN_CMD_P2PC << 24) | (P2PC_ADDR << 2);
     uint data = ((p2p_addr_guess_x & 0xFFFF) << 16) |
-	    (p2p_addr_guess_y & 0xFFFF);
+            (p2p_addr_guess_y & 0xFFFF);
 
     key |= chksum_64(key, data);
 
     for (uint link = 0; link < NUM_LINKS; link++) {
-	pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+        pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
     }
 }
 
@@ -484,7 +484,7 @@ void p2pc_new_nn_send(uint x, uint y)
     key |= chksum_64(key, data);
 
     for (uint link = 0; link < NUM_LINKS; link++) {
-	pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+        pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
     }
 }
 
@@ -493,14 +493,14 @@ void p2pc_dims_nn_send(uint arg1, uint arg2)
 {
     uint key = (NN_CMD_P2PC << 24) | (P2PC_DIMS << 2);
     uint data = ((p2p_min_x & 0xFF) << 24) |
-	    ((p2p_min_y & 0xFF) << 16) |
-	    ((p2p_max_x & 0xFF) << 8) |
-	    ((p2p_max_y & 0xFF) << 0);
+            ((p2p_min_y & 0xFF) << 16) |
+            ((p2p_max_x & 0xFF) << 8) |
+            ((p2p_max_y & 0xFF) << 0);
 
     key |= chksum_64(key, data);
 
     for (uint link = 0; link < NUM_LINKS; link++) {
-	pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+        pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
     }
 }
 
@@ -515,9 +515,9 @@ void p2pb_nn_send(uint arg1, uint arg2)
     key |= chksum_64(key, data);
 
     for (uint link = 0; link < NUM_LINKS; link++) {
-	if (link_en & (1 << link)) {
-	    pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
-	}
+        if (link_en & (1 << link)) {
+            pkt_tx(PKT_NN + PKT_PL + (link << 18), data, key);
+        }
     }
 }
 
@@ -529,10 +529,10 @@ void nn_rcv_p2pc_addr_pct(uint link, uint data, uint key)
     int nx = data >> 16;
     int ny = data & 0xFFFF;
     if (nx & 0x8000) {
-	nx |= 0xFFFF0000;
+        nx |= 0xFFFF0000;
     }
     if (ny & 0x8000) {
-	ny |= 0xFFFF0000;
+        ny |= 0xFFFF0000;
     }
 
     // Work out our coordinates
@@ -541,36 +541,36 @@ void nn_rcv_p2pc_addr_pct(uint link, uint data, uint key)
 
     // Ignore if this address has wrapped around a few too many times...
     if (x < -255 || x > 255 || y < -255 || y > 255) {
-	return;
+        return;
     }
 
     // Ignore if in board-test mode and coordinate is not within a SpiNN-5
     // board boundary.
     if ((sv->bt_flags & 1) &&
-	    (x >= 8 || x < 0 || y >= 8 || y < 0 ||
-		    eth_map[y][x] != ((x << 4) + y))) {
-	return;
+            (x >= 8 || x < 0 || y >= 8 || y < 0 ||
+                    eth_map[y][x] != ((x << 4) + y))) {
+        return;
     }
 
     // Update out current guess
     int updated = 0;
     if ((p2p_addr_guess_x < 0 && x >= 0) || // X has gone non-negative or
-	    (((x < 0) == (p2p_addr_guess_x < 0)) && // Sign is the same and...
-		    (abs(x) < abs(p2p_addr_guess_x)))) { // ...magnitude reduced
-	p2p_addr_guess_x = x;
-	updated |= 1;
+            (((x < 0) == (p2p_addr_guess_x < 0)) && // Sign is the same and...
+                    (abs(x) < abs(p2p_addr_guess_x)))) { // ...magnitude reduced
+        p2p_addr_guess_x = x;
+        updated |= 1;
     }
     if ((p2p_addr_guess_y < 0 && y >= 0) || // Y has gone non-negative or
-	    (((y < 0) == (p2p_addr_guess_y < 0)) && // Sign is the same and...
-		    (abs(y) < abs(p2p_addr_guess_y)))) { // ...magnitude reduced
-	p2p_addr_guess_y = y;
-	updated |= 2;
+            (((y < 0) == (p2p_addr_guess_y < 0)) && // Sign is the same and...
+                    (abs(y) < abs(p2p_addr_guess_y)))) { // ...magnitude reduced
+        p2p_addr_guess_y = y;
+        updated |= 2;
     }
 
     // If guess was updated, broadcast this fact
     if (updated) {
-	ticks_since_last_p2pc_new = 0;
-	p2pc_new_nn_send(p2p_addr_guess_x, p2p_addr_guess_y);
+        ticks_since_last_p2pc_new = 0;
+        p2pc_new_nn_send(p2p_addr_guess_x, p2p_addr_guess_y);
     }
 }
 
@@ -581,17 +581,17 @@ void nn_rcv_p2pc_new_pct(uint link, uint data, uint key)
     int x = data >> 16;
     int y = data & 0xFFFF;
     if (x & 0x8000) {
-	x |= 0xFFFF0000;
+        x |= 0xFFFF0000;
     }
     if (y & 0x8000) {
-	y |= 0xFFFF0000;
+        y |= 0xFFFF0000;
     }
 
     // Ignore if this address has wrapped around a few too many times (should
     // not occur but here as a sanity check since we'll be indexing with
     // this...)
     if (x < -255 || x > 255 || y < -255 || y > 255) {
-	return;
+        return;
     }
 
     // Update the bitmap of known coordinates
@@ -602,8 +602,8 @@ void nn_rcv_p2pc_new_pct(uint link, uint data, uint key)
 
     // Re-broadcast only newly discovered coordinates
     if (byte != new_byte) {
-	ticks_since_last_p2pc_new = 0;
-	p2pc_new_nn_send(x, y);
+        ticks_since_last_p2pc_new = 0;
+        p2pc_new_nn_send(x, y);
     }
 }
 
@@ -614,10 +614,10 @@ void nn_rcv_p2pc_dims_pct(uint link, uint data, uint key)
     int new_min_x = (data >> 24) & 0xFF;
     int new_min_y = (data >> 16) & 0xFF;
     if (new_min_x) {
-	new_min_x |= 0xFFFFFF00;
+        new_min_x |= 0xFFFFFF00;
     }
     if (new_min_y) {
-	new_min_y |= 0xFFFFFF00;
+        new_min_y |= 0xFFFFFF00;
     }
 
     int new_max_x = (data >> 8) & 0xFF;
@@ -626,27 +626,27 @@ void nn_rcv_p2pc_dims_pct(uint link, uint data, uint key)
     // Expand bounds as required
     int changed = 0;
     if (new_min_x < p2p_min_x) {
-	p2p_min_x = new_min_x;
-	changed = 1;
+        p2p_min_x = new_min_x;
+        changed = 1;
     }
     if (new_min_y < p2p_min_y) {
-	p2p_min_y = new_min_y;
-	changed = 1;
+        p2p_min_y = new_min_y;
+        changed = 1;
     }
     if (new_max_x > p2p_max_x) {
-	p2p_max_x = new_max_x;
-	changed = 1;
+        p2p_max_x = new_max_x;
+        changed = 1;
     }
     if (new_max_y > p2p_max_y) {
-	p2p_max_y = new_max_y;
-	changed = 1;
+        p2p_max_y = new_max_y;
+        changed = 1;
     }
 
     // Re-broadcast immediately if bounds expanded to minimise propagation
     // delay
     if (changed) {
-	ticks_since_last_p2pc_dims = 0;
-	p2pc_dims_nn_send(0, 0);
+        ticks_since_last_p2pc_dims = 0;
+        p2pc_dims_nn_send(0, 0);
     }
 }
 
@@ -688,25 +688,25 @@ void nn_cmd_rtrc(uint data)
     uint t1 = 0;
     uint t2 = 0;
 
-    if (data & 0x20) {				// Wait2
-	t2 |= data & 0xff000000;
-	t1 |= 0xff000000;
+    if (data & 0x20) {                          // Wait2
+        t2 |= data & 0xff000000;
+        t1 |= 0xff000000;
     }
-    if (data & 0x10) {				// Wait1
-	t2 |= data & 0x00ff0000;
-	t1 |= 0x00ff0000;
+    if (data & 0x10) {                          // Wait1
+        t2 |= data & 0x00ff0000;
+        t1 |= 0x00ff0000;
     }
-    if (data & 0x08) {				// W bit
-	t2 |= data & 0x00008000;
-	t1 |= 0x00008000;
+    if (data & 0x08) {                          // W bit
+        t2 |= data & 0x00008000;
+        t1 |= 0x00008000;
     }
-    if (data & 0x04) {				// MP
-	t2 |= data & 0x00001f00;
-	t1 |= 0x00001f00;
+    if (data & 0x04) {                          // MP
+        t2 |= data & 0x00001f00;
+        t1 |= 0x00001f00;
     }
-    if (data & 0x02) {				// TP
-	t2 |= data & 0x000000c0;
-	t1 |= 0x000000c0;
+    if (data & 0x02) {                          // TP
+        t2 |= data & 0x000000c0;
+        t1 |= 0x000000c0;
     }
 
     t1 = rtr[RTR_CONTROL] & ~t1;
@@ -725,40 +725,40 @@ uint nn_cmd_sig0(uint data)
 
     switch (op) {
     case 0: // Set forward & retry
-	nn_desc.forward = sv->forward = data >> 8;	// 8 bits
-	nn_desc.retry = sv->retry = data;		// 8 bits
-	break;
+        nn_desc.forward = sv->forward = data >> 8;      // 8 bits
+        nn_desc.retry = sv->retry = data;               // 8 bits
+        break;
 
     case 1: // Set LEDs
-	sark_led_set(data);
-	break;
+        sark_led_set(data);
+        break;
 
     case 2: // Global Time Phase
-	sv->tp_scale = data & 15;
-	sv->tp_timer = 0;
-	break;
+        sv->tp_scale = data & 15;
+        sv->tp_timer = 0;
+        break;
 
     case 3: // ID set/reset ## what's this? Set last_id here ?
-	if (data == nn_desc.gidr_id) {
-	    return 0;
-	}
+        if (data == nn_desc.gidr_id) {
+            return 0;
+        }
 
-	nn_desc.gidr_id = data;
-	sark_word_set(nn_desc.id_set, (data & 1) ? 0xff : 0x00, 16);
-	break;
+        nn_desc.gidr_id = data;
+        sark_word_set(nn_desc.id_set, (data & 1) ? 0xff : 0x00, 16);
+        break;
 
     case 4: // Trigger "level_config"
-	event_queue_proc((event_proc) level_config, 0, 0, PRIO_0);
-	break;
+        event_queue_proc((event_proc) level_config, 0, 0, PRIO_0);
+        break;
 
     case 5: // Signal application
-	signal_app(data);
-	break;
+        signal_app(data);
+        break;
       /*
-    case GSIG_TP: 	// Router time phase period
-    case GSIG_RST: 	// Shut down APs
-    case GSIG_DOWN:	// Minimum power mode
-    case GSIG_UP:	// Operational mode
+    case GSIG_TP:       // Router time phase period
+    case GSIG_RST:      // Shut down APs
+    case GSIG_DOWN:     // Minimum power mode
+    case GSIG_UP:       // Operational mode
       */
     }
     return 1;
@@ -772,21 +772,21 @@ void nn_cmd_mem(uint data, uint key)
     uint base = SV_SV;
 
     if (op == 1) {
-	base = SYSRAM_BASE;
+        base = SYSRAM_BASE;
     } else if (op == 2) {
-	base = SYSCTL_BASE;
+        base = SYSCTL_BASE;
     } else if (op == 3) {
-	base = sv->mem_ptr;
+        base = sv->mem_ptr;
     }
 
     uint ptr = base + ((key >> 8) & 255);
 
     if (type == 0) {
-	* ((uchar *) ptr) = data;
+        * ((uchar *) ptr) = data;
     } else if (type == 1) {
-	* ((short *) ptr) = data;
+        * ((short *) ptr) = data;
     } else {
-	* ((uint *) ptr) = data;
+        * ((uint *) ptr) = data;
     }
 }
 
@@ -795,8 +795,8 @@ void nn_cmd_sig1(uint data, uint key)
 {
     uint op = (key >> 20) & 15;
 
-    if (op == 0) {		// Memory write
-	nn_cmd_mem(data, key);
+    if (op == 0) {              // Memory write
+        nn_cmd_mem(data, key);
     }
 }
 
@@ -817,32 +817,32 @@ void nn_cmd_sig1(uint data, uint key)
 
 // Returns data with P2P_STOP_BIT set if the packet should not be propagated
 
-#define P2PB_STOP_BIT 0x400	   // Set to stop propagation
+#define P2PB_STOP_BIT 0x400        // Set to stop propagation
 
 uint nn_cmd_p2pb(uint id, uint data, uint link)
 {
     uint addr = data >> 16;
-    uint hops = data & 0x3ff;	// Bottom 10 bits
+    uint hops = data & 0x3ff;   // Bottom 10 bits
 
     uint table_id = hop_table[addr] >> 24;
     uint table_hops = hop_table[addr] & 0xffff;
 
     if (addr != p2p_addr &&
-	    (id != table_id || hops < table_hops) &&
-	    (link_en & (1 << link))) {
-	if (table_hops == 0xffff) {
-	    sv->p2p_active++;
-	}
+            (id != table_id || hops < table_hops) &&
+            (link_en & (1 << link))) {
+        if (table_hops == 0xffff) {
+            sv->p2p_active++;
+        }
 
-	hop_table[addr] = (id << 24) + hops;
+        hop_table[addr] = (id << 24) + hops;
 
-	rtr_p2p_set(addr, link);
+        rtr_p2p_set(addr, link);
 
-	if (hops >= 0x3FF) {
-	    data |= P2PB_STOP_BIT;
-	}
+        if (hops >= 0x3FF) {
+            data |= P2PB_STOP_BIT;
+        }
     } else {
-	data |= P2PB_STOP_BIT;
+        data |= P2PB_STOP_BIT;
     }
 
     return data + 1;
@@ -856,9 +856,9 @@ void nn_cmd_ffs(uint data, uint key)
 {
     nn_desc.aplx_addr = sv->sdram_sys;
     nn_desc.region = data;
-    nn_desc.id = (key >> 17) & 127;	// 8 bits (LSB zero)
-    nn_desc.block_len = key >> 8;	// 8 bits
-    nn_desc.block_count = 0;		// 8 bits
+    nn_desc.id = (key >> 17) & 127;     // 8 bits (LSB zero)
+    nn_desc.block_len = key >> 8;       // 8 bits
+    nn_desc.block_count = 0;            // 8 bits
     nn_desc.error = nn_desc.load = 0;
 
     sark_word_set(nn_desc.fbs_set, 0, 32);
@@ -873,9 +873,9 @@ void nn_cmd_ffs(uint data, uint key)
     uint level = region & 3;
 
     if ((mask == 0) ||
-	    (((levels[level].level_addr >> 16) == region)) &&
-	    (levels[level].level_addr & mask)) {
-	nn_desc.load = 1;
+            (((levels[level].level_addr >> 16) == region)) &&
+            (levels[level].level_addr & mask)) {
+        nn_desc.load = 1;
     }
 
     nn_desc.state = FF_ST_EXBLK;
@@ -897,18 +897,18 @@ uint nn_cmd_ffcs(uint data, uint key)
     // shouldn't be forwarded.
     uint64 id = (((uint64) data) << 18) | cores;
     if (id <= nn_desc.last_ffcs) {
-	return 1;
+        return 1;
     }
     nn_desc.last_ffcs = id;
 
     if ((mask == 0) ||
-	    (((levels[level].level_addr >> 16) == region)) &&
-	    (levels[level].level_addr & mask)) {
-	// We're in the region, so ensure that load is set
-	nn_desc.load = 1;
+            (((levels[level].level_addr >> 16) == region)) &&
+            (levels[level].level_addr & mask)) {
+        // We're in the region, so ensure that load is set
+        nn_desc.load = 1;
 
-	// And include the cores that we wish to load
-	nn_desc.cores |= cores;
+        // And include the cores that we wish to load
+        nn_desc.cores |= cores;
     }
 
     return 0;
@@ -918,7 +918,7 @@ uint nn_cmd_ffcs(uint data, uint key)
 uint nn_cmd_fbs(uint id, uint data, uint key)
 {
     if (id != nn_desc.id || nn_desc.state != FF_ST_EXBLK) {
-	return 0;
+        return 0;
     }
 
     uint block_num = (key >> 16) & 255;
@@ -927,7 +927,7 @@ uint nn_cmd_fbs(uint id, uint data, uint key)
     uint mask = nn_desc.fbs_set[word];
 
     if ((mask & bit) != 0) {
-	return 0;
+        return 0;
     }
 
     nn_desc.fbs_set[word] = mask | bit;
@@ -951,8 +951,8 @@ uint nn_cmd_fbd(uint id, uint data, uint key)
     uint block_num = (key >> 16) & 0xff; // Block num
 
     if (id != nn_desc.id || block_num != nn_desc.block_num ||
-	    nn_desc.state != FF_ST_INBLK) {
-	return 0;
+            nn_desc.state != FF_ST_INBLK) {
+        return 0;
     }
 
     uint offset = (key >> 8) & 0xff;
@@ -961,7 +961,7 @@ uint nn_cmd_fbd(uint id, uint data, uint key)
     uint mask = nn_desc.fbd_set[word];
 
     if ((mask & bit) != 0) {
-	return 0;
+        return 0;
     }
 
     nn_desc.word_count++;
@@ -978,8 +978,8 @@ uint nn_cmd_fbe(uint id, uint data, uint key)
     uint block_num = (key >> 16) & 0xff;
 
     if (id != nn_desc.id || block_num != nn_desc.block_num ||
-	    nn_desc.state != FF_ST_INBLK) {
-	return 0;
+            nn_desc.state != FF_ST_INBLK) {
+        return 0;
     }
 
     uint word = block_num >> 5;
@@ -987,18 +987,18 @@ uint nn_cmd_fbe(uint id, uint data, uint key)
     uint mask = nn_desc.fbe_set[word];
 
     if ((mask & bit) != 0) {
-	return 0;
+        return 0;
     }
 
     nn_desc.fbe_set[word] = mask | bit;
     nn_desc.sum += data;
 
     if (nn_desc.sum == 0 && nn_desc.word_count == nn_desc.word_len) {
-	nn_desc.block_count++;
-	sark_word_cpy((void *) nn_desc.load_addr, nn_desc.buf,
-		nn_desc.word_len * 4);
+        nn_desc.block_count++;
+        sark_word_cpy((void *) nn_desc.load_addr, nn_desc.buf,
+                nn_desc.word_len * 4);
     } else {
-	nn_desc.error = 1;
+        nn_desc.error = 1;
     }
 
     nn_desc.state = FF_ST_EXBLK;
@@ -1009,16 +1009,16 @@ uint nn_cmd_fbe(uint id, uint data, uint key)
 uint nn_cmd_ffe(uint id, uint data, uint key)
 {
     if (id != nn_desc.id || nn_desc.state != FF_ST_EXBLK) {
-	return 0;
+        return 0;
     }
 
     nn_desc.state = FF_ST_IDLE;
 
     if (nn_desc.error == 0 && nn_desc.block_count == nn_desc.block_len
-	    && nn_desc.load) {
-	if (!event_queue_proc(proc_start_app, (uint) nn_desc.aplx_addr,
-		data | nn_desc.cores, PRIO_0)) {
-	    sw_error(SW_OPT);
+            && nn_desc.load) {
+        if (!event_queue_proc(proc_start_app, (uint) nn_desc.aplx_addr,
+                data | nn_desc.cores, PRIO_0)) {
+            sw_error(SW_OPT);
         }
     }
 
@@ -1035,31 +1035,31 @@ void proc_pkt_bc(uint i_pkt, uint count)
     uint offset = (forward & 0x40) ? 0 : link;
 
     for (uint lnk = 0; lnk < NUM_LINKS; lnk++) {
-	if (forward & (1 << lnk)) {
-	    uint p = lnk + offset;
+        if (forward & (1 << lnk)) {
+            uint p = lnk + offset;
 
-	    if (p >= NUM_LINKS) {
-		p -= NUM_LINKS;
-	    }
+            if (p >= NUM_LINKS) {
+                p -= NUM_LINKS;
+            }
 
-	    if ((1 << p) & link_en) {
-		if (! pkt_tx(pkt->pkt.ctrl + (p << 18), pkt->pkt.data,
-			pkt->pkt.key)) {
-		    sw_error(SW_OPT);
-		}
-	    }
-	}
+            if ((1 << p) & link_en) {
+                if (! pkt_tx(pkt->pkt.ctrl + (p << 18), pkt->pkt.data,
+                        pkt->pkt.key)) {
+                    sw_error(SW_OPT);
+                }
+            }
+        }
     }
 
     count--;
 
     if (count != 0) {
-	if (!timer_schedule_proc(proc_pkt_bc, (uint) pkt, count,
-		pkt->delay)) {
-	    sw_error(SW_OPT);
-	}
+        if (!timer_schedule_proc(proc_pkt_bc, (uint) pkt, count,
+                pkt->delay)) {
+            sw_error(SW_OPT);
+        }
     } else {
-	pkt_buf_free(pkt);
+        pkt_buf_free(pkt);
     }
 }
 
@@ -1078,28 +1078,28 @@ void nn_cmd_biff(uint x, uint y, uint data)
 
     switch (type) {
     case 0: {
-	uint target_x = (data >> 27) & 7;
-	uint target_y = (data >> 24) & 7;
+        uint target_x = (data >> 27) & 7;
+        uint target_y = (data >> 24) & 7;
 
-	// Ignore if not targeted at this chip
-	if (target_x != x || target_y != y) {
-	    return;
-	}
+        // Ignore if not targeted at this chip
+        if (target_x != x || target_y != y) {
+            return;
+        }
 
-	// NB: *Dead* links are given as '1'
-	sv->link_en = link_en = ((~data) >> 18) & 0x3f;
+        // NB: *Dead* links are given as '1'
+        sv->link_en = link_en = ((~data) >> 18) & 0x3f;
 
-	// Kill any cores noted as dead (note this may kill the core running
-	// the monitor process, rendering the chip dead. This is the desired
-	// effect in this instance since rebooting another core as monitor
-	// would be difficult.
-	uint dead_cores = data & 0x3ffff;
-	remap_phys_cores(dead_cores);
-	break;
+        // Kill any cores noted as dead (note this may kill the core running
+        // the monitor process, rendering the chip dead. This is the desired
+        // effect in this instance since rebooting another core as monitor
+        // would be difficult.
+        uint dead_cores = data & 0x3ffff;
+        remap_phys_cores(dead_cores);
+        break;
     }
 
     default: // Ignore...
-	break;
+        break;
     }
 }
 
@@ -1115,25 +1115,25 @@ void nn_rcv_biff_pct(uint link, uint data, uint key)
 
     // Fliter the packet if it came from another board
     if (x >= 8 || x < 0 || y >= 8 || y < 0 ||
-	    eth_map[y][x] != ((x << 4) + y)) {
-	return;
+            eth_map[y][x] != ((x << 4) + y)) {
+        return;
     }
 
     uint id = (key >> 1) & 127;
 
     // Packets must have an ID at present
     if (id == 0) {
-	return;
+        return;
     }
 
     // Filter out packets we've seen before (note that IDs are only unique
     // within a board so this process must occur *after* filtering packets
     // from other boards.
-    uint word = id >> 5;			// Word in biff_id_set
-    uint bit = 1 << (id & 31);			// Bit in word
-    uint mask = nn_desc.biff_id_set[word];	// Get mask word from array
+    uint word = id >> 5;                        // Word in biff_id_set
+    uint bit = 1 << (id & 31);                  // Bit in word
+    uint mask = nn_desc.biff_id_set[word];      // Get mask word from array
     if (mask & bit) {
-	return;
+        return;
     }
 
     // Flag that this ID has been seen
@@ -1160,8 +1160,8 @@ void nn_rcv_biff_pct(uint link, uint data, uint key)
     pkt_buf_t *pkt = pkt_buf_get();
 
     if (pkt == NULL) { // !! ??
-	sw_error(SW_OPT);
-	return;
+        sw_error(SW_OPT);
+        return;
     }
 
     pkt->fwd = 0x3e; // Don't return to sender...
@@ -1172,7 +1172,7 @@ void nn_rcv_biff_pct(uint link, uint data, uint key)
     pkt->pkt = tp;
 
     if (!timer_schedule_proc(proc_pkt_bc, (uint) pkt, 1, 8)) {
-	sw_error(SW_OPT);
+        sw_error(SW_OPT);
     }
 }
 
@@ -1181,8 +1181,8 @@ void nn_rcv_pkt(uint link, uint data, uint key)
 {
     uint t = chksum_64(key, data);
     if (t != 0) {
-	nn_desc.errors++;
-	return;
+        nn_desc.errors++;
+        return;
     }
 
     uint cmd = (key >> 24) & 15;
@@ -1190,11 +1190,11 @@ void nn_rcv_pkt(uint link, uint data, uint key)
 
     // NN_CMD_BIFF and NN_CMD_P2PC are handled seperately
     if (cmd == NN_CMD_BIFF) {
-	nn_rcv_biff_pct(link, data, key);
-	return;
+        nn_rcv_biff_pct(link, data, key);
+        return;
     } else if (cmd == NN_CMD_P2PC) {
-	nn_rcv_p2pc_pct(link, data, key);
-	return;
+        nn_rcv_p2pc_pct(link, data, key);
+        return;
     }
 
 #ifdef NN_STATS
@@ -1202,85 +1202,85 @@ void nn_rcv_pkt(uint link, uint data, uint key)
 #endif
 
     if (cmd < 7 && id != 0) { //const - use (non-zero) ID to stop propagation
-	uint word = id >> 5;			// Word in id_set
-	uint bit = 1 << (id & 31);		// Bit in word
-	uint mask = nn_desc.id_set[word];	// Get mask word from array
-	if (mask & bit) {
-	    return;
+        uint word = id >> 5;                    // Word in id_set
+        uint bit = 1 << (id & 31);              // Bit in word
+        uint mask = nn_desc.id_set[word];       // Get mask word from array
+        if (mask & bit) {
+            return;
         }
 
-	nn_desc.id_set[word] = mask | bit;
-	word = (word + 2) % 4;
-	nn_desc.id_set[word] = 0;
+        nn_desc.id_set[word] = mask | bit;
+        word = (word + 2) % 4;
+        nn_desc.id_set[word] = 0;
     }
 
     switch (cmd) {
     case NN_CMD_SIG0:
-	if (nn_cmd_sig0(data)) {
-	    break;
+        if (nn_cmd_sig0(data)) {
+            break;
         }
-	return;
+        return;
 
     case NN_CMD_RTRC:
-	nn_cmd_rtrc(data);
-	break;
+        nn_cmd_rtrc(data);
+        break;
 
     case NN_CMD_LTPC:
-	t = sv->tp_timer + 2;
-	if ((t <= data) && ((t ^ data) & BIT_31) == 0) {
-	    sv->tp_timer = data - 1;
+        t = sv->tp_timer + 2;
+        if ((t <= data) && ((t ^ data) & BIT_31) == 0) {
+            sv->tp_timer = data - 1;
         } else {
             return;
         }
-	break;
+        break;
 
     case NN_CMD_SIG1:
-	nn_cmd_sig1(data, key);
-	break;
+        nn_cmd_sig1(data, key);
+        break;
 
     case NN_CMD_FFS:
-	nn_cmd_ffs(data, key);
-	break;
+        nn_cmd_ffs(data, key);
+        break;
 
     case NN_CMD_FFCS:
-	if (nn_cmd_ffcs(data, key)) {
-	    return;
+        if (nn_cmd_ffcs(data, key)) {
+            return;
         }
-	break;
+        break;
 
     case NN_CMD_P2PB:
-	data = nn_cmd_p2pb(id, data, link);
-	if (data & P2PB_STOP_BIT) {
-	    return;
+        data = nn_cmd_p2pb(id, data, link);
+        if (data & P2PB_STOP_BIT) {
+            return;
         }
-	break;
+        break;
 
     case NN_CMD_FBS:
-	if (nn_cmd_fbs(id, data, key)) {
-	    break;
+        if (nn_cmd_fbs(id, data, key)) {
+            break;
         }
-	return;
+        return;
 
     case NN_CMD_FBD:
-	if (nn_cmd_fbd(id, data, key)) {
-	    break;
+        if (nn_cmd_fbd(id, data, key)) {
+            break;
         }
-	return;
+        return;
 
     case NN_CMD_FBE:
-	if (nn_cmd_fbe(id, data, key)) {
-	    break;
+        if (nn_cmd_fbe(id, data, key)) {
+            break;
         }
-	return;
+        return;
 
     case NN_CMD_FFE:
-	if (nn_cmd_ffe(id, data, key)) {
-	    break;
+        if (nn_cmd_ffe(id, data, key)) {
+            break;
         }
-	return;
+        return;
 
     default: // Ignore...
-	return;
+        return;
     }
 
     // Now forward the incoming packet
@@ -1303,11 +1303,11 @@ void nn_rcv_pkt(uint link, uint data, uint key)
     uint forward, retry;
 
     if (cmd & 4) { //const
-	forward = nn_desc.forward;
-	retry = nn_desc.retry;
+        forward = nn_desc.forward;
+        retry = nn_desc.retry;
     } else {
-	forward = (key >> 16) & 255;
-	retry = (key >> 8) & 255;
+        forward = (key >> 16) & 255;
+        retry = (key >> 8) & 255;
     }
 
     key &= 0x0fffffff;
@@ -1316,8 +1316,8 @@ void nn_rcv_pkt(uint link, uint data, uint key)
     pkt_buf_t *pkt = pkt_buf_get();
 
     if (pkt == NULL) { // !! ??
-	sw_error(SW_OPT);
-	return;
+        sw_error(SW_OPT);
+        return;
     }
 
     pkt->fwd = forward;
@@ -1328,7 +1328,7 @@ void nn_rcv_pkt(uint link, uint data, uint key)
     pkt->pkt = tp;
 
     if (!timer_schedule_proc(proc_pkt_bc,
-	    (uint) pkt, (retry & 7) + 1, 8)) { // const
-	sw_error(SW_OPT);
+            (uint) pkt, (retry & 7) + 1, 8)) { // const
+        sw_error(SW_OPT);
     }
 }

--- a/scamp/scamp-p2p.c
+++ b/scamp/scamp-p2p.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp-p2p.c	    P2P packet handling for SC&MP
+// scamp-p2p.c      P2P packet handling for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2011
 //
@@ -19,7 +19,7 @@
 
 #define STATS
 
-#define P2P_NUM_STR 8	// Number of streams
+#define P2P_NUM_STR 8   // Number of streams
 
 #define TX_IDLE 0
 #define TX_OPEN_REQ 1
@@ -136,31 +136,31 @@ extern void p2p_send_pkt(uint data, uint addr);
 
 __asm void p2p_send_ctl(uint ctrl, uint addr, uint data)
 {
-	code32
-	import	chksum_32
-	import	pkt_tx
-	export	p2p_send_pkt
+        code32
+        import  chksum_32
+        import  pkt_tx
+        export  p2p_send_pkt
 
-	orr	r0, r0, r2		;// (r0) data = data | ctrl
-	mov	r2, r0			;// r2 = data
-	mov	r3, lr			;// Save lr
-	bl	chksum_32		;// sum = chksum(data)
-	mov	lr, r3			;// Restore lr
-	orr	r0, r0, r2		;// data |= sum
+        orr     r0, r0, r2              ;// (r0) data = data | ctrl
+        mov     r2, r0                  ;// r2 = data
+        mov     r3, lr                  ;// Save lr
+        bl      chksum_32               ;// sum = chksum(data)
+        mov     lr, r3                  ;// Restore lr
+        orr     r0, r0, r2              ;// data |= sum
 
 p2p_send_pkt
-	tst	r1, #BIT_31		;// if addr & BIT_31
+        tst     r1, #BIT_31             ;// if addr & BIT_31
 
-	moveq	r2, r1			;// r2 = addr
-	moveq	r1, r0			;// r1 = data
-	moveq	r0, #TCR_P2P_P		;// r0 = TCR_P2P_P
-	beq	pkt_tx			;// pkt_tx(TCR_P2P_P, data, addr);
+        moveq   r2, r1                  ;// r2 = addr
+        moveq   r1, r0                  ;// r1 = data
+        moveq   r0, #TCR_P2P_P          ;// r0 = TCR_P2P_P
+        beq     pkt_tx                  ;// pkt_tx(TCR_P2P_P, data, addr);
 
-	mov	r2, r1, lsl #18		;// r2 = addr << 18
-	mov	r1, r0	    		;// r1 = data
-	orr	r0, r2, #TCR_NN_P	;// r0 = TCR_NN_P + (addr << 18)
-	mov	r2, #NN_SDP_KEY		;// r2 = NN_SDP_KEY
-	b	pkt_tx
+        mov     r2, r1, lsl #18         ;// r2 = addr << 18
+        mov     r1, r0                  ;// r1 = data
+        orr     r0, r2, #TCR_NN_P       ;// r0 = TCR_NN_P + (addr << 18)
+        mov     r2, #NN_SDP_KEY         ;// r2 = NN_SDP_KEY
+        b       pkt_tx
 
 }
 
@@ -171,7 +171,7 @@ void p2p_send_data(uint data, uint addr)
 #ifdef STATS
     uint r = pkt_tx(PKT_P2P_PL, data, addr + (P2P_DATA << 16));
     if (r == 0) {
-	p2p_stats[TX_FAIL]++;
+        p2p_stats[TX_FAIL]++;
     }
 #else // !STATS
     (void) pkt_tx(PKT_P2P_PL, data, addr + (P2P_DATA << 16));
@@ -185,7 +185,7 @@ void p2p_send_ctl(uint ctrl, uint addr, uint data)
 #ifdef STATS
     uint r = pkt_tx(PKT_P2P_PL, data, addr + (P2P_CTRL << 16));
     if (r == 0) {
-	p2p_stats[TX_FAIL]++;
+        p2p_stats[TX_FAIL]++;
     }
 #else // !STATS
     (void) pkt_tx(PKT_P2P_PL, data, addr + (P2P_CTRL << 16));
@@ -198,10 +198,10 @@ void p2p_send_ctl(uint ctrl, uint addr, uint data)
 // Received ACK from receiver. Cancel ack timeout and update tx_desc
 
 /*      +-------+-----+-+---+-+---------+---------------+---------------+
-	|       |     | |   |P|         |                               |
-  Data	|  Sum  | 001 |1| 00|H|   TID   |           Ack mask            |
-  Ack  	|       |     | |   |A|         |                               |
-	+-------+-----+-+---+-+---------+---------------+---------------+
+        |       |     | |   |P|         |                               |
+  Data  |  Sum  | 001 |1| 00|H|   TID   |           Ack mask            |
+  Ack   |       |     | |   |A|         |                               |
+        +-------+-----+-+---+-+---------+---------------+---------------+
 */
 
 void p2p_data_ack(uint data, uint srce)
@@ -211,15 +211,15 @@ void p2p_data_ack(uint data, uint srce)
     tx_desc_t *desc = &tx_desc;
 
     if (desc->state == TX_OPEN && desc->tid == tid && desc->dest == srce) {
-	timer_cancel(desc->event, desc->event_id); // p2p_ack_timeout
+        timer_cancel(desc->event, desc->event_id); // p2p_ack_timeout
 
-	if (phase != desc->phase) {
-	    desc->phase = phase;
-	    desc->base += 3 * desc->seq_len;
-	}
+        if (phase != desc->phase) {
+            desc->phase = phase;
+            desc->base += 3 * desc->seq_len;
+        }
 
-	desc->mask = data;
-	desc->ack = 1;
+        desc->mask = data;
+        desc->ack = 1;
     }
 }
 
@@ -233,11 +233,11 @@ void p2p_close_req(uint data, uint srce)
     tx_desc_t *desc = &tx_desc;
 
     if (desc->state == TX_OPEN && desc->tid == tid && desc->dest == srce) {
-	timer_cancel(desc->event, desc->event_id); // p2p_ack_timeout
+        timer_cancel(desc->event, desc->event_id); // p2p_ack_timeout
 
-	desc->mask = 0;
-	desc->state = TX_IDLE;
-	desc->ack = 3; //const
+        desc->mask = 0;
+        desc->state = TX_IDLE;
+        desc->ack = 3; //const
     }
 
     p2p_send_ctl(P2P_CLOSE_ACK, srce, data & 0x00ffffff);
@@ -262,10 +262,10 @@ void p2p_ack_timeout(uint txd, uint a2)
 }
 
 /*      +-----+---------+---------------+---------------+---------------+
-	|     |         |                                               |
-  Data	| RID | Seq_num |                     [24]                      |
-       	|     |         |                                               |
-	+-----+-+-----+-+---------------+---------------+---------------+
+        |     |         |                                               |
+  Data  | RID | Seq_num |                     [24]                      |
+        |     |         |                                               |
+        +-----+-+-----+-+---------------+---------------+---------------+
 */
 
 
@@ -281,11 +281,11 @@ void p2p_open_timeout(uint a, uint b)
 
 uint p2p_send_msg(uint addr, sdp_msg_t *msg)
 {
-    uchar *buf = (uchar *) &msg->length;	// Point to len/sum
-    uint len = msg->length;			// 'Real' length
+    uchar *buf = (uchar *) &msg->length;        // Point to len/sum
+    uint len = msg->length;                     // 'Real' length
 
-    msg->flags |= SDPF_SUM;			// Set checksum bit
-    msg->checksum = 0;				// buf[3..2] (BE)
+    msg->flags |= SDPF_SUM;                     // Set checksum bit
+    msg->checksum = 0;                          // buf[3..2] (BE)
 
     tx_desc_t *desc = &tx_desc;
 
@@ -294,10 +294,10 @@ uint p2p_send_msg(uint addr, sdp_msg_t *msg)
     uint seq_len_log = sv->p2p_sql & 7;
     uint ctrl = (seq_len_log << 5) + desc->tid;
 
-    uint sum = ~ipsum(buf, len+4, 0);		// NB "ctrl" omitted from sum
+    uint sum = ~ipsum(buf, len+4, 0);           // NB "ctrl" omitted from sum
 
-    buf[2] = sum >> 8;				// Sum (hi)
-    buf[3] = sum;				// Sum (lo)
+    buf[2] = sum >> 8;                          // Sum (hi)
+    buf[3] = sum;                               // Sum (lo)
 
     uint seq_len = desc->seq_len = 1 << seq_len_log;
 
@@ -317,41 +317,41 @@ uint p2p_send_msg(uint addr, sdp_msg_t *msg)
 #endif
 
     while (1) {
-	desc->ack = 0;
+        desc->ack = 0;
 
-	//##event_t* e = event_new(proc_byte_set, (uint) &desc->ack, 2);
-	event_t* e = event_new(p2p_open_timeout, (uint) desc, 2);
-	desc->event = e;
-	if (e != NULL) {
-	    desc->event_id = e->ID;
-	    timer_schedule(e, open_ack_time);
-	} else {
-	    sw_error(SW_OPT);
-	}
-
-	p2p_send_ctl(P2P_OPEN_REQ, addr, (len << 8) + ctrl);
-
-	while (desc->ack == 0) {	//const - returns 1 for OK, 2 for timeout
-	    continue;
+        //##event_t* e = event_new(proc_byte_set, (uint) &desc->ack, 2);
+        event_t* e = event_new(p2p_open_timeout, (uint) desc, 2);
+        desc->event = e;
+        if (e != NULL) {
+            desc->event_id = e->ID;
+            timer_schedule(e, open_ack_time);
+        } else {
+            sw_error(SW_OPT);
         }
-	if (desc->ack == 1) {
-	    break;
+
+        p2p_send_ctl(P2P_OPEN_REQ, addr, (len << 8) + ctrl);
+
+        while (desc->ack == 0) {        //const - returns 1 for OK, 2 for timeout
+            continue;
+        }
+        if (desc->ack == 1) {
+            break;
         }
 
 #ifdef STATS
-	p2p_stats[OPEN_TO]++;
-	p2p_stats[TCOUNT] = desc->tcount;
+        p2p_stats[OPEN_TO]++;
+        p2p_stats[TCOUNT] = desc->tcount;
 #endif
 
-	if (desc->tcount == 0) {
-	    return desc->rc;
-	}
+        if (desc->tcount == 0) {
+            return desc->rc;
+        }
 
-	desc->tcount--;
+        desc->tcount--;
     }
 
     if (desc->rc != RC_OK) {
-	return desc->rc;
+        return desc->rc;
     }
 
     //-------
@@ -362,51 +362,51 @@ uint p2p_send_msg(uint addr, sdp_msg_t *msg)
     // !! needed  desc->tcount = RETRY; //const
 
     while (1) {
-	for (uint seq = 0; seq < seq_len; seq++) {
-	    uchar *p = desc->base + 3 * seq;
+        for (uint seq = 0; seq < seq_len; seq++) {
+            uchar *p = desc->base + 3 * seq;
 
-	    uint is_last_seq = (p >= desc->limit);
-	    uint next_mask = mask >> 1;
+            uint is_last_seq = (p >= desc->limit);
+            uint next_mask = mask >> 1;
 
-	    if (mask & 1) {
-		if (is_last_seq || (next_mask == 0)) {
-		    desc->ack = 0;
+            if (mask & 1) {
+                if (is_last_seq || (next_mask == 0)) {
+                    desc->ack = 0;
 
-		    event_t* e = event_new(p2p_ack_timeout, (uint) desc, 0);
-		    if (e != NULL) {
-			desc->event = e;
-			desc->event_id = e->ID;
-			timer_schedule(e, data_ack_time);
-		    } else {
-			sw_error(SW_OPT);
-		    }
-		}
+                    event_t* e = event_new(p2p_ack_timeout, (uint) desc, 0);
+                    if (e != NULL) {
+                        desc->event = e;
+                        desc->event_id = e->ID;
+                        timer_schedule(e, data_ack_time);
+                    } else {
+                        sw_error(SW_OPT);
+                    }
+                }
 
-		uint data = (desc->rid << 29) + (desc->phase << 28) //##
-			 + (seq << 24) + (p[2] << 16) + (p[1] << 8) + p[0];
+                uint data = (desc->rid << 29) + (desc->phase << 28) //##
+                         + (seq << 24) + (p[2] << 16) + (p[1] << 8) + p[0];
 
-		p2p_send_data(data, addr);
-	    }
+                p2p_send_data(data, addr);
+            }
 
-	    if (is_last_seq) {
-		desc->done = 1;
-		break;
-	    }
+            if (is_last_seq) {
+                desc->done = 1;
+                break;
+            }
 
-	    mask = next_mask;
-	    if (mask == 0) {
-		break;
-	    }
-	}
+            mask = next_mask;
+            if (mask == 0) {
+                break;
+            }
+        }
 
-	while (desc->ack == 0) { //const - 1 data_ack, 2 timeout, 3 close_req
-	    continue;
-	}
+        while (desc->ack == 0) { //const - 1 data_ack, 2 timeout, 3 close_req
+            continue;
+        }
 
-	mask = desc->mask;
-	if (desc->done && mask == 0) {
-	    break;
-	}
+        mask = desc->mask;
+        if (desc->done && mask == 0) {
+            break;
+        }
     }
 
     return desc->rc;
@@ -425,28 +425,28 @@ void p2p_data_timeout(uint rxd, uint a2)
 
     if (desc->state == RX_OPEN) {
 #ifdef STATS
-	p2p_stats[DATA_TO]++;
+        p2p_stats[DATA_TO]++;
 #endif
 
-	if (desc->tcount == 0) {
-	    sark_msg_free(desc->msg);
-	    desc->state = RX_IDLE;
-	    return;
-	}
+        if (desc->tcount == 0) {
+            sark_msg_free(desc->msg);
+            desc->state = RX_IDLE;
+            return;
+        }
 
-	desc->tcount--;
+        desc->tcount--;
 
-	p2p_send_ctl(P2P_DATA_ACK, desc->srce,
-		(desc->phase << 21) + (desc->tid << 16) + desc->mask);
+        p2p_send_ctl(P2P_DATA_ACK, desc->srce,
+                (desc->phase << 21) + (desc->tid << 16) + desc->mask);
 
-	event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
-	if (e != NULL) {
-	    desc->event = e;
-	    desc->event_id = e->ID;
-	    timer_schedule(e, data_time);
-	} else {
-	    sw_error(SW_OPT);
-	}
+        event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
+        if (e != NULL) {
+            desc->event = e;
+            desc->event_id = e->ID;
+            timer_schedule(e, data_time);
+        } else {
+            sw_error(SW_OPT);
+        }
     }
 }
 
@@ -463,27 +463,27 @@ void p2p_open_ack(uint data, uint srce)
     tx_desc_t *desc = &tx_desc;
 
     if (desc->state == TX_OPEN_REQ && desc->tid == tid &&
-	    desc->dest == srce && rc != RC_P2P_BUSY) {
-	uint rid = (data >> 21) & 7; //##
+            desc->dest == srce && rc != RC_P2P_BUSY) {
+        uint rid = (data >> 21) & 7; //##
 
-	desc->rid = rid;
-	desc->rc = rc;
-	desc->ack = 1; //const
+        desc->rid = rid;
+        desc->rc = rc;
+        desc->ack = 1; //const
 
-	timer_cancel(desc->event, desc->event_id);
+        timer_cancel(desc->event, desc->event_id);
     }
 }
 
 /*      +-------+-----+-+---------------+---------------+-----+---------+
-	|       |     | |                               |     |         |
-  Open	|  Sum  | 1xx |1|            Length             | SQL |   TID   |
-  Req  	|       |     | |                               |     |         |
-	+-------+-----+-+---------------+---------------+-----+---------+
+        |       |     | |                               |     |         |
+  Open  |  Sum  | 1xx |1|            Length             | SQL |   TID   |
+  Req   |       |     | |                               |     |         |
+        +-------+-----+-+---------------+---------------+-----+---------+
         +-------+-----+-+-----+---------+---------------+---------------+
-	|       |     | |     |         |               |               |
-  Open	|  Sum  | 000 |1| RID |   TID   |               |      RC       |
-  Ack  	|       |     | |     |         |               |               |
-	+-------+-----+-+-----+---------+---------------+---------------+
+        |       |     | |     |         |               |               |
+  Open  |  Sum  | 000 |1| RID |   TID   |               |      RC       |
+  Ack   |       |     | |     |         |               |               |
+        +-------+-----+-+-----+---------+---------------+---------------+
 */
 
 void p2p_open_req(uint data, uint addr)
@@ -495,62 +495,62 @@ void p2p_open_req(uint data, uint addr)
     uint seq_len = 1 << (ctrl >> 5);
 
     if (len > (SDP_BUF_SIZE + 8 + 16) || seq_len > 16) { //const
-	p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_REJECT);
+        p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_REJECT);
 #ifdef STATS
-	p2p_stats[P2P_REJECTS]++;
+        p2p_stats[P2P_REJECTS]++;
 #endif
-	return;
+        return;
     }
 
     rx_desc_t *desc = rx_desc_table;
     uint rid = P2P_NUM_STR;
 
     for (uint i = 0; i < P2P_NUM_STR; i++) {
-	if (desc->state == RX_OPEN && desc->srce == addr
-		&& desc->tid == tid) {			// Already open
-	    timer_cancel(desc->event, desc->event_id);	// p2p_data_timeout
+        if (desc->state == RX_OPEN && desc->srce == addr
+                && desc->tid == tid) {                  // Already open
+            timer_cancel(desc->event, desc->event_id);  // p2p_data_timeout
 #ifdef STATS
-	    p2p_stats[OPEN_DUP]++;
+            p2p_stats[OPEN_DUP]++;
 #endif
-	    p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + (i << 22) + RC_OK);
+            p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + (i << 22) + RC_OK);
 
-	    desc->tcount = open_ack_retry;
+            desc->tcount = open_ack_retry;
 
-	    event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
-	    if (e != NULL) {
-		desc->event = e;
-		desc->event_id = e->ID;
-		timer_schedule(e, data_time);
-	    } else {
-		sw_error(SW_OPT);
-	    }
+            event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
+            if (e != NULL) {
+                desc->event = e;
+                desc->event_id = e->ID;
+                timer_schedule(e, data_time);
+            } else {
+                sw_error(SW_OPT);
+            }
 
-	    return;
-	}
+            return;
+        }
 
-	if (desc->state == RX_IDLE) {			// Free ?
-	    rid = i;
-	}
-	desc++;
+        if (desc->state == RX_IDLE) {                   // Free ?
+            rid = i;
+        }
+        desc++;
     }
 
-    if (rid == P2P_NUM_STR) {		// No free streams - send busy
-	p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_BUSY);
+    if (rid == P2P_NUM_STR) {           // No free streams - send busy
+        p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_BUSY);
 #ifdef STATS
-	p2p_stats[P2P_BUSY1]++;
+        p2p_stats[P2P_BUSY1]++;
 #endif
-	return;
+        return;
     }
 
     desc = rx_desc_table + rid;
 
     sdp_msg_t *msg = sark_msg_get();
     if (msg == NULL) {
-	p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_BUSY);
+        p2p_send_ctl(P2P_OPEN_ACK, addr, (tid << 16) + RC_P2P_BUSY);
 #ifdef STATS
-	p2p_stats[P2P_BUSY2]++;
+        p2p_stats[P2P_BUSY2]++;
 #endif
-	return;
+        return;
     }
 
     desc->msg = msg;
@@ -583,11 +583,11 @@ void p2p_open_req(uint data, uint addr)
 
     event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
     if (e != NULL) {
-	desc->event = e;
-	desc->event_id = e->ID;
-	timer_schedule(e, data_time);
+        desc->event = e;
+        desc->event_id = e->ID;
+        timer_schedule(e, data_time);
     } else {
-	sw_error(SW_OPT);
+        sw_error(SW_OPT);
     }
 }
 
@@ -605,23 +605,23 @@ void p2p_close_timeout(uint rxd, uint rid)
 #endif
 
     if (desc->tcount == 0) {
-	sark_msg_free(desc->msg);
-	desc->state = RX_IDLE;
-	return;
+        sark_msg_free(desc->msg);
+        desc->state = RX_IDLE;
+        return;
     }
 
     desc->tcount--;
 
     p2p_send_ctl(P2P_CLOSE_REQ, desc->srce,
-	    (rid << 21) + (desc->tid << 16)); //##
+            (rid << 21) + (desc->tid << 16)); //##
 
     event_t* e = event_new(p2p_close_timeout, (uint) desc, rid);
     if (e != NULL) {
-	desc->event = e;
-	desc->event_id = e->ID;
-	timer_schedule(e, close_ack_time);
+        desc->event = e;
+        desc->event_id = e->ID;
+        timer_schedule(e, close_ack_time);
     } else {
-	sw_error(SW_OPT);
+        sw_error(SW_OPT);
     }
 }
 
@@ -634,11 +634,11 @@ void p2p_close_ack(uint data, uint srce)
     uint tid = (data >> 16) & 31;
 
     if (desc->state == RX_CLOSE_REQ && desc->tid == tid
-	    && desc->srce == srce) {
-	desc->state = RX_IDLE;
-	timer_cancel(desc->event, desc->event_id); // p2p_close_timeout
+            && desc->srce == srce) {
+        desc->state = RX_IDLE;
+        timer_cancel(desc->event, desc->event_id); // p2p_close_timeout
 
-	msg_queue_insert(desc->msg, 0);
+        msg_queue_insert(desc->msg, 0);
     }
 }
 
@@ -648,10 +648,10 @@ void p2p_close_ack(uint data, uint srce)
 // save if ptr < limit
 
 /*      +-----+---------+---------------+---------------+---------------+
-	|     |         |                                               |
-  Data	| RID | Seq_num |                     [24]                      |
-       	|     |         |                                               |
-	+---+-+---------+---------------+---------------+---------------+
+        |     |         |                                               |
+  Data  | RID | Seq_num |                     [24]                      |
+        |     |         |                                               |
+        +---+-+---------+---------------+---------------+---------------+
 */
 
 void p2p_rcv_data(uint data, uint addr)
@@ -661,62 +661,62 @@ void p2p_rcv_data(uint data, uint addr)
     rx_desc_t *desc = rx_desc_table + rid;
 
     if (desc->state == RX_OPEN && desc->srce == addr
-	    && desc->phase == phase) {
-	uint seq = (data >> 24) & (desc->seq_len - 1); //##
-	uchar *ptr = desc->base + (3 * seq);
+            && desc->phase == phase) {
+        uint seq = (data >> 24) & (desc->seq_len - 1); //##
+        uchar *ptr = desc->base + (3 * seq);
 
-	ptr[0] = data;
-	ptr[1] = data >> 8;
-	ptr[2] = data >> 16;
+        ptr[0] = data;
+        ptr[1] = data >> 8;
+        ptr[2] = data >> 16;
 
-	uint seq_bit = 1 << seq;
-	desc->mask &= ~seq_bit;
+        uint seq_bit = 1 << seq;
+        desc->mask &= ~seq_bit;
 
-	if (ptr >= desc->limit) {
-	    desc->mask &= seq_bit - 1;
-	    desc->done = 1;
-	}
+        if (ptr >= desc->limit) {
+            desc->mask &= seq_bit - 1;
+            desc->done = 1;
+        }
 
-	if (desc->mask == 0) {			// Advance
-	    timer_cancel(desc->event, desc->event_id); // p2p_data_timeout
+        if (desc->mask == 0) {                  // Advance
+            timer_cancel(desc->event, desc->event_id); // p2p_data_timeout
 
-	    if (desc->done) {			// Close
-		desc->state = RX_CLOSE_REQ;
-		desc->tcount = close_req_retry;
+            if (desc->done) {                   // Close
+                desc->state = RX_CLOSE_REQ;
+                desc->tcount = close_req_retry;
 
-		p2p_send_ctl(P2P_CLOSE_REQ, desc->srce,
-			(rid << 21) + (desc->tid << 16)); //##
+                p2p_send_ctl(P2P_CLOSE_REQ, desc->srce,
+                        (rid << 21) + (desc->tid << 16)); //##
 
-		// start close timout - mustn't exit until have CLOSE_ACK
+                // start close timout - mustn't exit until have CLOSE_ACK
 
-		event_t* e = event_new(p2p_close_timeout, (uint) desc, rid);
-		if (e != NULL) {
-		    desc->event = e;
-		    desc->event_id = e->ID;
-		    timer_schedule(e, close_ack_time);
-		} else {
-		    sw_error(SW_OPT);
-		}
-	    } else {				// more to do
-		uint phase = desc->phase ^= 1;
-		desc->base += (3 * desc->seq_len);
-		desc->mask = desc->new_mask;
+                event_t* e = event_new(p2p_close_timeout, (uint) desc, rid);
+                if (e != NULL) {
+                    desc->event = e;
+                    desc->event_id = e->ID;
+                    timer_schedule(e, close_ack_time);
+                } else {
+                    sw_error(SW_OPT);
+                }
+            } else {                            // more to do
+                uint phase = desc->phase ^= 1;
+                desc->base += (3 * desc->seq_len);
+                desc->mask = desc->new_mask;
 
-		p2p_send_ctl(P2P_DATA_ACK, desc->srce,
-			(phase << 21) + (desc->tid << 16) + desc->mask);
+                p2p_send_ctl(P2P_DATA_ACK, desc->srce,
+                        (phase << 21) + (desc->tid << 16) + desc->mask);
 
-		desc->tcount = data_ack_retry;
+                desc->tcount = data_ack_retry;
 
-		event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
-		if (e != NULL) {
-		    desc->event = e;
-		    desc->event_id = e->ID;
-		    timer_schedule(e, data_time);
-		} else {
-		    sw_error(SW_OPT);
-		}
-	    }
-	}
+                event_t* e = event_new(p2p_data_timeout, (uint) desc, 0);
+                if (e != NULL) {
+                    desc->event = e;
+                    desc->event_id = e->ID;
+                    timer_schedule(e, data_time);
+                } else {
+                    sw_error(SW_OPT);
+                }
+            }
+        }
     }
 }
 
@@ -724,64 +724,64 @@ void p2p_rcv_data(uint data, uint addr)
 
 __asm void p2p_rcv_pkt(uint data, uint addr)
 {
-	code32
-	import	p2p_data_pkt
-	import	p2p_open_req
-	import	p2p_open_ack
-	import	p2p_data_ack
-	import	p2p_close_req
-	import	p2p_close_ack
+        code32
+        import  p2p_data_pkt
+        import  p2p_open_req
+        import  p2p_open_ack
+        import  p2p_data_ack
+        import  p2p_close_req
+        import  p2p_close_ack
 
-	tst	r0, #P2P_CTRL		;// SDP control packet?
-	beq	p2p_data_pkt		;// Deal with data if not
+        tst     r0, #P2P_CTRL           ;// SDP control packet?
+        beq     p2p_data_pkt            ;// Deal with data if not
 
-	mov	r3, lr			;// Save lr
-	mov	r2, r0			;// Save data in r2 while
-	bl	chksum_32		;// we checksum data field
-	mov	lr, r3			;// Restore lr
+        mov     r3, lr                  ;// Save lr
+        mov     r2, r0                  ;// Save data in r2 while
+        bl      chksum_32               ;// we checksum data field
+        mov     lr, r3                  ;// Restore lr
 
-	cmp	r0, #0			;// Non-zero means error
-	bxne	lr  			;// so return
+        cmp     r0, #0                  ;// Non-zero means error
+        bxne    lr                      ;// so return
 
-	mov	r0, r2			;// Restore data to r0
-	and	r2, r2, #0x0f000000	;// and mask ctrl type field
+        mov     r0, r2                  ;// Restore data to r0
+        and     r2, r2, #0x0f000000     ;// and mask ctrl type field
 
-	cmp	r2, #P2P_DATA_ACK	;// Check for each type
-	beq	p2p_data_ack
+        cmp     r2, #P2P_DATA_ACK       ;// Check for each type
+        beq     p2p_data_ack
 
-	cmp	r2, #P2P_OPEN_REQ
-	beq	p2p_open_req
+        cmp     r2, #P2P_OPEN_REQ
+        beq     p2p_open_req
 
-	cmp	r2, #P2P_OPEN_ACK
-	beq	p2p_open_ack
+        cmp     r2, #P2P_OPEN_ACK
+        beq     p2p_open_ack
 
-	cmp	r2, #P2P_CLOSE_REQ
-	beq	p2p_close_req
+        cmp     r2, #P2P_CLOSE_REQ
+        beq     p2p_close_req
 
-	cmp	r2, #P2P_CLOSE_ACK
-	beq	p2p_close_ack
+        cmp     r2, #P2P_CLOSE_ACK
+        beq     p2p_close_ack
 
-	bx	lr			;// None of the above
+        bx      lr                      ;// None of the above
 }
 #else
 void p2p_rcv_ctrl(uint data, uint addr)
 {
     uint t = chksum_32(data);
     if (t != 0) {
-	return;
+        return;
     }
 
     uint cmd = (data >> 24) & 15;
     if (cmd == P2P_OPEN_REQ >> 24) {
-	p2p_open_req(data, addr);
+        p2p_open_req(data, addr);
     } else if (cmd == P2P_OPEN_ACK >> 24) {
-	p2p_open_ack(data, addr);
+        p2p_open_ack(data, addr);
     } else if (cmd == P2P_DATA_ACK >> 24) {
-	p2p_data_ack(data, addr);
+        p2p_data_ack(data, addr);
     } else if (cmd == P2P_CLOSE_REQ >> 24) {
-	p2p_close_req(data, addr);
+        p2p_close_req(data, addr);
     } else if (cmd == P2P_CLOSE_ACK >> 24) {
-	p2p_close_ack(data, addr);
+        p2p_close_ack(data, addr);
     }
 }
 #endif

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// scamp.h	    Header file for SC&MP
+// scamp.h          Header file for SC&MP
 //
 // Copyright (C)    The University of Manchester - 2009-2013
 //
@@ -16,46 +16,46 @@
 
 // Misc constants
 
-#define MAX_CPUS 		20			// Legacy const!
+#define MAX_CPUS                20                      // Legacy const!
 
-#define MONITOR_CPU 		0			// Virtual CPU number
+#define MONITOR_CPU             0                       // Virtual CPU number
 
 //------------------------------------------------------------------------------
 
 // IPTag table sizes
 
-#define TAG_FIXED_SIZE		8	// At bottom of table
-#define TAG_POOL_SIZE		8
+#define TAG_FIXED_SIZE          8       // At bottom of table
+#define TAG_POOL_SIZE           8
 
-#define FIRST_POOL_TAG		TAG_FIXED_SIZE
-#define LAST_POOL_TAG		(TAG_FIXED_SIZE + TAG_POOL_SIZE - 1)
+#define FIRST_POOL_TAG          TAG_FIXED_SIZE
+#define LAST_POOL_TAG           (TAG_FIXED_SIZE + TAG_POOL_SIZE - 1)
 
-#define TAG_TABLE_SIZE 		(TAG_FIXED_SIZE + TAG_POOL_SIZE)
+#define TAG_TABLE_SIZE          (TAG_FIXED_SIZE + TAG_POOL_SIZE)
 
 // IPTAG definitions
 
-#define IPTAG_NEW		0
-#define IPTAG_SET		1
-#define IPTAG_GET		2
-#define IPTAG_CLR		3
-#define IPTAG_TTO		4
+#define IPTAG_NEW               0
+#define IPTAG_SET               1
+#define IPTAG_GET               2
+#define IPTAG_CLR               3
+#define IPTAG_TTO               4
 
-#define IPTAG_MAX		4
+#define IPTAG_MAX               4
 
-#define IPFLAG_VALID		0x8000	// Entry is valid
-#define IPFLAG_TRANS		0x4000	// Entry is transient
-#define IPFLAG_ARP		0x2000	// Awaiting ARP resolution
+#define IPFLAG_VALID            0x8000  // Entry is valid
+#define IPFLAG_TRANS            0x4000  // Entry is transient
+#define IPFLAG_ARP              0x2000  // Awaiting ARP resolution
 
-#define IPFLAG_REV		0x0200  // Reverse IPTag
-#define IPFLAG_STRIP		0x0100  // Strip SDP headers
+#define IPFLAG_REV              0x0200  // Reverse IPTag
+#define IPFLAG_STRIP            0x0100  // Strip SDP headers
 
 //------------------------------------------------------------------------------
 
 // Bits in SDP Flags byte (3 used)
 
-#define SDPF_REPLY		0x80	// Reply expected
-#define SDPF_SUM		0x40	// Checksum before routing
-#define SDPF_NR			0x20	// Don't route via P2P
+#define SDPF_REPLY              0x80    // Reply expected
+#define SDPF_SUM                0x40    // Checksum before routing
+#define SDPF_NR                 0x20    // Don't route via P2P
 
 //------------------------------------------------------------------------------
 
@@ -68,25 +68,25 @@
 // HW errors have bit 7 set & bit 6 set
 // SW errors have bit 7 set & bit 6 clr
 
-#define FAIL_RESET		0xc0		// Catch-all - set at reset
-#define FAIL_ROMX		0xc1		// Exception in ROM code
-#define FAIL_ITCM0		0xc2		// ITCM top 512 failure
-#define FAIL_ITCM1		0xc3		// ITCM main test failure
-#define FAIL_DTCM		0xc4		// DTCM test failure
+#define FAIL_RESET              0xc0            // Catch-all - set at reset
+#define FAIL_ROMX               0xc1            // Exception in ROM code
+#define FAIL_ITCM0              0xc2            // ITCM top 512 failure
+#define FAIL_ITCM1              0xc3            // ITCM main test failure
+#define FAIL_DTCM               0xc4            // DTCM test failure
 
-#define FAIL_TIMER		0xc5		// Timer reg test failed
-#define FAIL_VIC		0xc6		// VIC reg test failed
-#define FAIL_CC			0xc7		// Comms ctlr reg test failed
-#define FAIL_DMA		0xc8		// DMAC reg test failed
+#define FAIL_TIMER              0xc5            // Timer reg test failed
+#define FAIL_VIC                0xc6            // VIC reg test failed
+#define FAIL_CC                 0xc7            // Comms ctlr reg test failed
+#define FAIL_DMA                0xc8            // DMAC reg test failed
 
-#define FAIL_MP			0xc9		// Previous monitor proc failure
-#define FAIL_LATE		0xca		// App CPU failed to set CPU_OK
-#define FAIL_MANUF		0xcb		// App CPU in manuf test
-#define FAIL_SLEEP		0xcc		// Ordered to sleep in startup
+#define FAIL_MP                 0xc9            // Previous monitor proc failure
+#define FAIL_LATE               0xca            // App CPU failed to set CPU_OK
+#define FAIL_MANUF              0xcb            // App CPU in manuf test
+#define FAIL_SLEEP              0xcc            // Ordered to sleep in startup
 
-#define FAIL_TLM		0xcf		// Special for TLM
+#define FAIL_TLM                0xcf            // Special for TLM
 
-#define FAIL_VEC		0xa0		// Unhandled exception
+#define FAIL_VEC                0xa0            // Unhandled exception
 
 //------------------------------------------------------------------------------
 
@@ -127,25 +127,25 @@
 //   key[1] Must be 0, differentiator between peek/poke responses and other
 //          NN packets
 
-#define NN_CMD_SIG0		0	// Misc (GTPC, Set FwdRty, LED, etc)
-#define NN_CMD_RTRC 		1	// Router Control Reg
-#define NN_CMD_LTPC		2	// Local Time Phase Ctrl (ID=0, Fwd=0)
-#define NN_CMD_SP_3		3	// Spare
+#define NN_CMD_SIG0             0       // Misc (GTPC, Set FwdRty, LED, etc)
+#define NN_CMD_RTRC             1       // Router Control Reg
+#define NN_CMD_LTPC             2       // Local Time Phase Ctrl (ID=0, Fwd=0)
+#define NN_CMD_SP_3             3       // Spare
 
-#define NN_CMD_SIG1     	4	// Misc (MEM, etc)
-#define NN_CMD_P2PC 		5	// P2P Address setup (Handled specially)
-#define NN_CMD_FFS   		6	// Flood fill start
-#define NN_CMD_FFCS		7       // Flood fill core and region select
+#define NN_CMD_SIG1             4       // Misc (MEM, etc)
+#define NN_CMD_P2PC             5       // P2P Address setup (Handled specially)
+#define NN_CMD_FFS              6       // Flood fill start
+#define NN_CMD_FFCS             7       // Flood fill core and region select
 
-#define NN_CMD_P2PB		8	// Hop count limited
-#define NN_CMD_SP_9		9	// Spare
-#define NN_CMD_SP_10 		10	// Spare
-#define NN_CMD_BIFF		11	// Board-info flood-fill (handled specially)
+#define NN_CMD_P2PB             8       // Hop count limited
+#define NN_CMD_SP_9             9       // Spare
+#define NN_CMD_SP_10            10      // Spare
+#define NN_CMD_BIFF             11      // Board-info flood-fill (handled specially)
 
-#define NN_CMD_FBS 		12	// Filtered in FF code
-#define NN_CMD_FBD 		13
-#define NN_CMD_FBE 		14
-#define NN_CMD_FFE 		15
+#define NN_CMD_FBS              12      // Filtered in FF code
+#define NN_CMD_FBD              13
+#define NN_CMD_FBE              14
+#define NN_CMD_FFE              15
 
 // NN_CMD_P2PC sub-command codes
 #define P2PC_ADDR 0  // Your P2P address is...
@@ -156,28 +156,28 @@
 
 // Values in P2P type (seq) field
 
-#define P2P_DATA		0
-#define P2P_CTRL		1
-#define P2P_LEVEL		2
+#define P2P_DATA                0
+#define P2P_CTRL                1
+#define P2P_LEVEL               2
 
 // Distinguish data/control packets in SDP/P2P
 
-#define P2P_OPEN_REQ   		(1 << 24)
-#define P2P_OPEN_ACK   		(2 << 24)
-#define P2P_DATA_ACK   		(3 << 24)
-#define P2P_CLOSE_REQ  		(4 << 24)
-#define P2P_CLOSE_ACK  		(5 << 24)
+#define P2P_OPEN_REQ            (1 << 24)
+#define P2P_OPEN_ACK            (2 << 24)
+#define P2P_DATA_ACK            (3 << 24)
+#define P2P_CLOSE_REQ           (4 << 24)
+#define P2P_CLOSE_ACK           (5 << 24)
 
-#define P2P_DEF_SQL  		4			// Seq len = 2^4
+#define P2P_DEF_SQL             4                       // Seq len = 2^4
 
 
 //------------------------------------------------------------------------------
 
 // Hop table
 
-#define NN_HOP_MASK 		0x3ff		// !! Allows hops <= 1023
+#define NN_HOP_MASK             0x3ff           // !! Allows hops <= 1023
 
-#define HOP_TABLE_SIZE		65536
+#define HOP_TABLE_SIZE          65536
 
 //------------------------------------------------------------------------------
 
@@ -220,20 +220,20 @@ enum ethinit_phase_e {
 //------------------------------------------------------------------------------
 
 enum alloc_cmd_e {
-    ALLOC_SDRAM,		//!< Allocate SDRAM
-    FREE_SDRAM,		 	//!< Free SDRAM
-    FREE_SDRAM_ID,		//!< Free DRAM by ID
-    ALLOC_RTR,		 	//!< Allocate Router
-    FREE_RTR,	 		//!< Free Router
-    FREE_RTR_ID,		//!< Free Router by ID
-    SDRAM_SPACE,		//!< Total free space & largest free block
-    HEAP_TAG_PTR,		//!< Heap block from tag & ID
-    ALLOC_MAX=HEAP_TAG_PTR 	//!< Maximum command
+    ALLOC_SDRAM,                //!< Allocate SDRAM
+    FREE_SDRAM,                 //!< Free SDRAM
+    FREE_SDRAM_ID,              //!< Free DRAM by ID
+    ALLOC_RTR,                  //!< Allocate Router
+    FREE_RTR,                   //!< Free Router
+    FREE_RTR_ID,                //!< Free Router by ID
+    SDRAM_SPACE,                //!< Total free space & largest free block
+    HEAP_TAG_PTR,               //!< Heap block from tag & ID
+    ALLOC_MAX=HEAP_TAG_PTR      //!< Maximum command
 };
 
 //------------------------------------------------------------------------------
 
-typedef struct {		// IPTAG entry (32 bytes)
+typedef struct {                // IPTAG entry (32 bytes)
     uchar ip[4];
     uchar mac[6];
     ushort tx_port;
@@ -247,9 +247,9 @@ typedef struct {		// IPTAG entry (32 bytes)
 } iptag_t;
 
 
-#define PKT_QUEUE_SIZE 		32
+#define PKT_QUEUE_SIZE          32
 
-typedef struct pkt_queue_t {	// Queue of packets
+typedef struct pkt_queue_t {    // Queue of packets
     uchar insert;
     uchar remove;
     volatile uchar count;
@@ -258,7 +258,7 @@ typedef struct pkt_queue_t {	// Queue of packets
 } pkt_queue_t;
 
 
-typedef struct pkt_buf_t {	// Holds a NN packet awaiting transmission
+typedef struct pkt_buf_t {      // Holds a NN packet awaiting transmission
     struct pkt_buf_t *next;
     volatile uchar flags;
     uchar fwd;
@@ -268,15 +268,15 @@ typedef struct pkt_buf_t {	// Holds a NN packet awaiting transmission
 } pkt_buf_t;
 
 
-typedef struct {	// 64 bytes
-    uint   level_addr;	// 0: This chip's region at this level
-    ushort sent;	// 4: Number of requests sent out in this region
-    ushort rcvd;	// 6: Number of responses received
-    ushort parent;	// 8: P2P address of the chip which sent the last request
-    ushort __PAD1;	// 10
-    uint result;	// 12: Result accumulated within this region
-    ushort addr[16];	// 16: A working chip p2p for each subregion, if valid
-    uchar  valid[16];	// 48: Is at least one chip in each sub-region known to be alive?
+typedef struct {        // 64 bytes
+    uint   level_addr;  // 0: This chip's region at this level
+    ushort sent;        // 4: Number of requests sent out in this region
+    ushort rcvd;        // 6: Number of responses received
+    ushort parent;      // 8: P2P address of the chip which sent the last request
+    ushort __PAD1;      // 10
+    uint result;        // 12: Result accumulated within this region
+    ushort addr[16];    // 16: A working chip p2p for each subregion, if valid
+    uchar  valid[16];   // 48: Is at least one chip in each sub-region known to be alive?
 } level_t;
 
 //------------------------------------------------------------------------------
@@ -373,10 +373,10 @@ extern volatile int p2p_max_y;
 extern uchar *p2p_addr_table;
 
 // Initial value of p2p_addr_guess_{x,y} when not the root chip
-#define NO_IDEA			(-1024)
+#define NO_IDEA                 (-1024)
 
 // Size of p2p_addr_table in bytes.
-#define P2P_ADDR_TABLE_BYTES	(512 * 512 / 8)
+#define P2P_ADDR_TABLE_BYTES    (512 * 512 / 8)
 
 //------------------------------------------------------------------------------
 

--- a/scamp/spinn_net.c
+++ b/scamp/spinn_net.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_net.c	    Ethernet/IP support routines for Spinnaker
+// spinn_net.c      Ethernet/IP support routines for Spinnaker
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -32,7 +32,7 @@ const uchar zero_mac[] = {0, 0, 0, 0, 0, 0};
 static void lock_get(uint lock)
 {
     while (sc[SC_TAS0 + lock] & BIT_31) {
-	continue;
+        continue;
     }
 }
 
@@ -70,15 +70,15 @@ void eth_init(uchar *mac)
 uint ipsum(uchar *d, uint len, uint sum) // Use shorts for speed??
 {
     if (len & 1) {
-	sum += d[--len] << 8;
+        sum += d[--len] << 8;
     }
 
     for (uint i = 0; i < len; i += 2) {
-	sum += (d[i] << 8) + d[i+1];
+        sum += (d[i] << 8) + d[i+1];
     }
 
     while (sum >> 16) {
-	sum = (sum >> 16) + (sum & 0xffff);
+        sum = (sum >> 16) + (sum & 0xffff);
     }
 
     return sum;
@@ -120,12 +120,12 @@ void copy_ip_hdr(uchar *dest, uint prot, ip_hdr_t *ip, uint len)
     ip->DS = 0;
     ip->length = htons(len);
     ip->ident = htons(0);
-    ip->flg_off = htons(2 << 13);	// Flags = 010, offset = 0
+    ip->flg_off = htons(2 << 13);       // Flags = 010, offset = 0
     ip->TTL = 64;
-    ip->protocol = prot;		// Insert protocol
+    ip->protocol = prot;                // Insert protocol
     ip->checksum = htons(0);
-    copy_ip(dest, ip->dest);		// Source IP address
-    copy_ip(srom.ip_addr, ip->srce);	// My IP address
+    copy_ip(dest, ip->dest);            // Source IP address
+    copy_ip(srom.ip_addr, ip->srce);    // My IP address
 
     uint sum = ipsum((uchar *) ip, IP_HDR_SIZE, 0);// Update checksum
     ip->checksum = htons(~sum);
@@ -145,13 +145,13 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-	continue;
+        continue;
     }
 
     sark_word_cpy(eth_tx_ram, buf, len);
 
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -170,7 +170,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-	continue;
+        continue;
     }
 
     memcpy(eth_tx_ram, hdr, hdr_len);
@@ -178,7 +178,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
     uint len = buf_len + hdr_len;
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -191,21 +191,21 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
 
 void send_arp_pkt(uchar *buf, const uchar *dest, const uchar *tha,
-	const uchar *tpa, uint type)
+        const uchar *tpa, uint type)
 {
     arp_pkt_t *arp = (arp_pkt_t *) (buf + MAC_HDR_SIZE);
 
-    arp->htype = htons(0x0001);		// Ethernet
-    arp->ptype = htons(0x0800);		// IPv4
+    arp->htype = htons(0x0001);         // Ethernet
+    arp->ptype = htons(0x0800);         // IPv4
     arp->hlen = 6;
     arp->plen = 4;
     arp->op = htons(type);
 
-    copy_mac(tha, arp->tha);		// Copy to THA
-    copy_ip(tpa, arp->tpa);		// Copy to TPA
+    copy_mac(tha, arp->tha);            // Copy to THA
+    copy_ip(tpa, arp->tpa);             // Copy to TPA
 
-    copy_mac(srom.mac_addr, arp->sha);	// Copy my MAC addr
-    copy_ip(srom.ip_addr, arp->spa);	// Copy my IP addr
+    copy_mac(srom.mac_addr, arp->sha);  // Copy my MAC addr
+    copy_ip(srom.ip_addr, arp->spa);    // Copy my IP addr
 
     eth_transmit(buf, 42, ETYPE_ARP, dest);
 }
@@ -223,7 +223,7 @@ void arp_lookup(iptag_t *iptag)
     uchar *target_ip = ip_addr;
 
     if ((*my_ip & *mask) != (*ip & *mask)) {
-	target_ip = srom.gw_addr;
+        target_ip = srom.gw_addr;
     }
 
     copy_ip(target_ip, iptag->mac); // !! Bodge - target IP in MAC field!
@@ -241,34 +241,34 @@ void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size)
     eth_discard();
 
     if (! cmp_ip(arp->tpa, srom.ip_addr)) { // Ignore unless TPA matches
-	return;
+        return;
     }
 
     uint op = ntohs(arp->op);
     if (op == ARP_REQ) {
-	send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
-    } else if (op == ARP_REPLY) {	// Reply & TPA matches
-	iptag_t *tt = tag_table;
+        send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
+    } else if (op == ARP_REPLY) {       // Reply & TPA matches
+        iptag_t *tt = tag_table;
 
-	for (uint i = 0; i < tag_table_size; i++) {
-	    uint f = tt->flags;
-	    if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
-		copy_mac(arp->sha, tt->mac);
-		f &= ~IPFLAG_ARP;
-		tt->flags = f | IPFLAG_VALID;
-		break;
-	    }
-	    tt++;
-	}
+        for (uint i = 0; i < tag_table_size; i++) {
+            uint f = tt->flags;
+            if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
+                copy_mac(arp->sha, tt->mac);
+                f &= ~IPFLAG_ARP;
+                tt->flags = f | IPFLAG_VALID;
+                break;
+            }
+            tt++;
+        }
     }
 }
 
 
 void icmp_pkt(uchar *rx_pkt, uint rx_len)
 {
-    if (rx_len > 138) {		// MAC 14, IP_HDR 60, ICMP 64
-	eth_discard();
-	return;
+    if (rx_len > 138) {         // MAC 14, IP_HDR 60, ICMP 64
+        eth_discard();
+        return;
     }
 
     uchar buf[138];
@@ -277,30 +277,30 @@ void icmp_pkt(uchar *rx_pkt, uint rx_len)
 
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (buf + IP_HDR_OFFSET);
     if (!cmp_ip(ip_hdr->dest, srom.ip_addr)) {
-	return;
+        return;
     }
 
     uint ip_hdr_len = (ip_hdr->ver_len & 15) * 4;
     icmp_hdr_t *icmp = (icmp_hdr_t *) (buf + IP_HDR_OFFSET + ip_hdr_len);
 
     if (icmp->type == ICMP_ECHO_REQ) {
-	uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
+        uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
 
-	copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
+        copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
 
-	if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
-	    icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);	// 'new' ICMP hdr
-	    sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
-	}
+        if (ip_hdr_len > IP_HDR_SIZE) {         // Copy down ICMP header & data
+            icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);       // 'new' ICMP hdr
+            sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
+        }
 
-	icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
-	icmp->code = 0;				// ICMP code = 0
-	icmp->checksum = 0;
+        icmp->type = ICMP_ECHO_REPLY;           // ICMP reply
+        icmp->code = 0;                         // ICMP code = 0
+        icmp->checksum = 0;
 
-	uint sum = ipsum((uchar *) icmp, icmp_len, 0);
-	icmp->checksum = htons(~sum);
+        uint sum = ipsum((uchar *) icmp, icmp_len, 0);
+        icmp->checksum = htons(~sum);
 
-	eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
+        eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
     }
 }
 
@@ -309,16 +309,16 @@ void copy_udp(uchar *buf, uint len, uint dest, uint srce)
 {
     udp_hdr_t *udp_hdr = (udp_hdr_t *) (buf+UDP_HDR_OFFSET);
 
-    udp_hdr->srce = htons(srce);		// Source port
-    udp_hdr->dest = htons(dest);		// Dest port
-    udp_hdr->length = htons(len);		// Insert length
-    udp_hdr->checksum = 0;			// Zero checksum
+    udp_hdr->srce = htons(srce);                // Source port
+    udp_hdr->dest = htons(dest);                // Dest port
+    udp_hdr->length = htons(len);               // Insert length
+    udp_hdr->checksum = 0;                      // Zero checksum
 
     uint t;
-    t = ipsum(buf+IP_HDR_OFFSET+12, 8, 0);	// Sum IP hdr addresses
-    t += len;					// add in UDP data length
-    t += PROT_UDP;				// and UDP protocol number
-    t = ipsum((uchar *) udp_hdr, len, t);	// Final UDP checksum
+    t = ipsum(buf+IP_HDR_OFFSET+12, 8, 0);      // Sum IP hdr addresses
+    t += len;                                   // add in UDP data length
+    t += PROT_UDP;                              // and UDP protocol number
+    t = ipsum((uchar *) udp_hdr, len, t);       // Final UDP checksum
 
     udp_hdr->checksum = htons(~t);
 }

--- a/scamp/spinn_net.h
+++ b/scamp/spinn_net.h
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_net.h	    Ethernet/IP support routines for Spinnaker
+// spinn_net.h      Ethernet/IP support routines for Spinnaker
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -12,28 +12,28 @@
 #ifndef SPINN_NET_H
 #define SPINN_NET_H
 
-#define MAC_HDR_SIZE    	14
-#define IP_HDR_SIZE     	20
-#define UDP_HDR_SIZE		8
-#define SDP_PAD_SIZE		2
+#define MAC_HDR_SIZE            14
+#define IP_HDR_SIZE             20
+#define UDP_HDR_SIZE            8
+#define SDP_PAD_SIZE            2
 
-#define IP_HDR_OFFSET   	MAC_HDR_SIZE
-#define IP_DATA_OFFSET  	(IP_HDR_OFFSET + IP_HDR_SIZE)
+#define IP_HDR_OFFSET           MAC_HDR_SIZE
+#define IP_DATA_OFFSET          (IP_HDR_OFFSET + IP_HDR_SIZE)
 
-#define UDP_HDR_OFFSET		IP_DATA_OFFSET
-#define UDP_DATA_OFFSET		(UDP_HDR_OFFSET + UDP_HDR_SIZE)
+#define UDP_HDR_OFFSET          IP_DATA_OFFSET
+#define UDP_DATA_OFFSET         (UDP_HDR_OFFSET + UDP_HDR_SIZE)
 
-#define ETYPE_IP  		0x0800
-#define ETYPE_ARP 		0x0806
+#define ETYPE_IP                0x0800
+#define ETYPE_ARP               0x0806
 
-#define PROT_ICMP 		1
-#define PROT_UDP  		17
+#define PROT_ICMP               1
+#define PROT_UDP                17
 
-#define ARP_REQ 		1
-#define ARP_REPLY 		2
+#define ARP_REQ                 1
+#define ARP_REPLY               2
 
-#define ICMP_ECHO_REPLY 	0
-#define ICMP_ECHO_REQ 		8
+#define ICMP_ECHO_REPLY         0
+#define ICMP_ECHO_REQ           8
 
 
 typedef struct {
@@ -103,7 +103,7 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest);
 void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len);
 
 void send_arp_pkt(uchar *buf, const uchar *dest,
-		  const uchar *tha, const uchar *tpa, uint type);
+                  const uchar *tha, const uchar *tpa, uint type);
 void arp_lookup(iptag_t *iptag);
 void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size);
 

--- a/scamp/spinn_phy.c
+++ b/scamp/spinn_phy.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_phy.c	    Spinnaker support routines for SMC PHY chip
+// spinn_phy.c      Spinnaker support routines for SMC PHY chip
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -26,19 +26,19 @@ static void phy_shift_out(uint data, uint len)
     uint c = er[ETH_PHY_CTRL];
 
     while (len--) {
-	if (data & 0x80000000) {
-	    c |= PHY_CTRL_DOUT;
-	} else {
-	    c &= ~PHY_CTRL_DOUT;
-	}
+        if (data & 0x80000000) {
+            c |= PHY_CTRL_DOUT;
+        } else {
+            c &= ~PHY_CTRL_DOUT;
+        }
 
-	er[ETH_PHY_CTRL] = c;
-	sark_delay_us(1);
-	er[ETH_PHY_CTRL] = c | PHY_CTRL_CLK;
-	sark_delay_us(1);
-	er[ETH_PHY_CTRL] = c;
+        er[ETH_PHY_CTRL] = c;
+        sark_delay_us(1);
+        er[ETH_PHY_CTRL] = c | PHY_CTRL_CLK;
+        sark_delay_us(1);
+        er[ETH_PHY_CTRL] = c;
 
-	data = data << 1;
+        data = data << 1;
     }
 }
 
@@ -49,14 +49,14 @@ static uint phy_shift_in(uint len)
     uint r = 0;
 
     while (len--) {
-	sark_delay_us(1);
-	r = r << 1;
-	if (er[ETH_PHY_CTRL] & PHY_CTRL_DIN) {
-	    r |= 1;
-	}
-	er[ETH_PHY_CTRL] = c | PHY_CTRL_CLK;
-	sark_delay_us(1);
-	er[ETH_PHY_CTRL] = c;
+        sark_delay_us(1);
+        r = r << 1;
+        if (er[ETH_PHY_CTRL] & PHY_CTRL_DIN) {
+            r |= 1;
+        }
+        er[ETH_PHY_CTRL] = c | PHY_CTRL_CLK;
+        sark_delay_us(1);
+        er[ETH_PHY_CTRL] = c;
     }
 
     return r;

--- a/scamp/spinn_phy.h
+++ b/scamp/spinn_phy.h
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_phy.h	    Spinnaker support routines for SMC PHY chip
+// spinn_phy.h      Spinnaker support routines for SMC PHY chip
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -14,21 +14,21 @@
 
 // PHY registers
 
-#define	PHY_CONTROL		0
-#define	PHY_STATUS		1
-#define	PHY_ID1			2
-#define PHY_ID2			3
-#define PHY_AUTO_ADV		4
-#define PHY_AUTO_LPA		5
-#define PHY_AUTO_EXP		6
-#define PHY_SI_REV		16
-#define PHY_MODE_CSR		17
-#define PHY_SP_MODE		18
-#define PHY_ERR_COUNT		26
-#define PHY_SP_CSIR		27
-#define PHY_INT_SRC		29
-#define	PHY_INT_MASK		30
-#define	PHY_SP_CSR		31
+#define PHY_CONTROL             0
+#define PHY_STATUS              1
+#define PHY_ID1                 2
+#define PHY_ID2                 3
+#define PHY_AUTO_ADV            4
+#define PHY_AUTO_LPA            5
+#define PHY_AUTO_EXP            6
+#define PHY_SI_REV              16
+#define PHY_MODE_CSR            17
+#define PHY_SP_MODE             18
+#define PHY_ERR_COUNT           26
+#define PHY_SP_CSIR             27
+#define PHY_INT_SRC             29
+#define PHY_INT_MASK            30
+#define PHY_SP_CSR              31
 
 
 void phy_reset(void);

--- a/scamp/spinn_srom.c
+++ b/scamp/spinn_srom.c
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_srom.c	    Serial ROM interface routines for Spinnaker
+// spinn_srom.c     Serial ROM interface routines for Spinnaker
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //
@@ -15,17 +15,17 @@
 
 // Serial ROM command codes
 
-#define SROM_READ  	(0x03U << 24)
-#define SROM_WRITE 	(0x02U << 24)
-#define SROM_WREN  	(0x06U << 24)
-#define SROM_WRDI  	(0x04U << 24)
-#define SROM_RDSR  	(0x05U << 24)
-#define SROM_WRSR  	(0x01U << 24)
-#define SROM_PE    	(0x42U << 24)
-#define SROM_SE    	(0xd8U << 24)
-#define SROM_CE    	(0xc7U << 24)
-#define SROM_RDID  	(0xabU << 24)
-#define SROM_DPD   	(0xb9U << 24)
+#define SROM_READ       (0x03U << 24)
+#define SROM_WRITE      (0x02U << 24)
+#define SROM_WREN       (0x06U << 24)
+#define SROM_WRDI       (0x04U << 24)
+#define SROM_RDSR       (0x05U << 24)
+#define SROM_WRSR       (0x01U << 24)
+#define SROM_PE         (0x42U << 24)
+#define SROM_SE         (0xd8U << 24)
+#define SROM_CE         (0xc7U << 24)
+#define SROM_RDID       (0xabU << 24)
+#define SROM_DPD        (0xb9U << 24)
 
 #define WAIT 0x40
 #define WREN 0x80
@@ -62,16 +62,16 @@ static void clock()
 static void send(uint v, uint n)
 {
     do {
-	if (v & 0x80000000) {
-	    sc[GPIO_SET] = SERIAL_SI;
-	} else {
+        if (v & 0x80000000) {
+            sc[GPIO_SET] = SERIAL_SI;
+        } else {
             sc[GPIO_CLR] = SERIAL_SI;
-	}
+        }
 
-	clock();
+        clock();
 
-	v = v << 1;
-	n--;
+        v = v << 1;
+        n--;
     } while (n != 0);
 
     sc[GPIO_CLR] = SERIAL_SI;
@@ -84,15 +84,15 @@ static uint read8()
     uint n = 8;
 
     do {
-	uint p = sc[GPIO_READ];
-	if (p & SERIAL_SO) {
-	    r |= 1;
-	}
+        uint p = sc[GPIO_READ];
+        if (p & SERIAL_SO) {
+            r |= 1;
+        }
 
-	clock();
+        clock();
 
-	r = r << 1;
-	n--;
+        r = r << 1;
+        n--;
     } while (n != 0);
 
     return r >> 1;
@@ -117,14 +117,14 @@ static uint read8()
 uint cmd_srom(sdp_msg_t *msg)
 {
     uint arg1 = msg->arg1;
-    uint port = sc[GPIO_PORT];	// Preserve output state
+    uint port = sc[GPIO_PORT];  // Preserve output state
 
     ncs_high();
 
     if (arg1 & WREN) {
-	ncs_low();
-	send(SROM_WREN, 8);
-	ncs_high();
+        ncs_low();
+        send(SROM_WREN, 8);
+        ncs_high();
     }
 
     ncs_low();
@@ -136,32 +136,32 @@ uint cmd_srom(sdp_msg_t *msg)
     uchar* rbuf = (uchar *) &msg->arg1;
 
     while (len) {
-	if (arg1 & WRITE) {
-	    send(*wbuf++ << 24, 8);
+        if (arg1 & WRITE) {
+            send(*wbuf++ << 24, 8);
         } else {
             *rbuf++ = read8();
         }
 
-	len--;
+        len--;
     }
 
     ncs_high();
 
     while (arg1 & WAIT) {
-	ncs_low();
-	send(SROM_RDSR, 8);
-	uint sr = read8();
-	ncs_high();
+        ncs_low();
+        send(SROM_RDSR, 8);
+        uint sr = read8();
+        ncs_high();
 
-	if ((sr & 1) == 0) {
-	    break;
-	}
+        if ((sr & 1) == 0) {
+            break;
+        }
     }
 
     sc[GPIO_PORT] = port;
 
     if (arg1 & WRITE) {
-	return 0;
+        return 0;
     }
 
     return arg1 >> 16;

--- a/scamp/spinn_srom.h
+++ b/scamp/spinn_srom.h
@@ -1,6 +1,6 @@
 //------------------------------------------------------------------------------
 //
-// spinn_srom.h	    Serial ROM interface routines for Spinnaker
+// spinn_srom.h     Serial ROM interface routines for Spinnaker
 //
 // Copyright (C)    The University of Manchester - 2009, 2010
 //

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -8,13 +8,13 @@
 /* simulation control */
 // ---------------------
 
-uchar leadAp;                    	// lead appl. core has special functions
+uchar leadAp;                           // lead appl. core has special functions
 
-static volatile uint run;           	// controls simulation start/exit
+static volatile uint run;               // controls simulation start/exit
 static volatile uint paused;            // indicates when paused
 static volatile uint resume_sync;       // controls re-synchronisation
-uint ticks;              		// number of elapsed timer periods
-static uint timer_tick;  	        // timer tick period
+uint ticks;                             // number of elapsed timer periods
+static uint timer_tick;                 // timer tick period
 static uint timer_phase;                // additional phase on starting the timer
 
 // default fiq handler -- restored after simulation
@@ -286,11 +286,11 @@ void configure_vic(uint enable_timer)
 {
     uint fiq_select = 0;
     uint int_select = ((1 << TIMER1_INT)   |
-	    (1 << SOFTWARE_INT) |
-	    (1 << CC_MC_INT) |
-	    (1 << CC_FR_INT) |
-	    (1 << DMA_ERR_INT)  |
-	    (1 << DMA_DONE_INT));
+            (1 << SOFTWARE_INT) |
+            (1 << CC_MC_INT) |
+            (1 << CC_FR_INT) |
+            (1 << DMA_ERR_INT)  |
+            (1 << DMA_DONE_INT));
 
     // disable the relevant interrupts while configuring the VIC
 
@@ -306,31 +306,31 @@ void configure_vic(uint enable_timer)
     switch (fiq_event) {
     case MC_PACKET_RECEIVED:
     case MCPL_PACKET_RECEIVED:
-	sark_vec->fiq_vec = cc_rx_ready_fiqsr;
-	fiq_select = (1 << CC_MC_INT);
-	break;
+        sark_vec->fiq_vec = cc_rx_ready_fiqsr;
+        fiq_select = (1 << CC_MC_INT);
+        break;
     case FR_PACKET_RECEIVED:
     case FRPL_PACKET_RECEIVED:
-	sark_vec->fiq_vec = cc_fr_ready_fiqsr;
-	fiq_select = (1 << CC_FR_INT);
-	break;
+        sark_vec->fiq_vec = cc_fr_ready_fiqsr;
+        fiq_select = (1 << CC_FR_INT);
+        break;
     case DMA_TRANSFER_DONE:
-	sark_vec->fiq_vec = dma_done_fiqsr;
-	fiq_select = (1 << DMA_DONE_INT);
-	break;
+        sark_vec->fiq_vec = dma_done_fiqsr;
+        fiq_select = (1 << DMA_DONE_INT);
+        break;
     case TIMER_TICK:
-	sark_vec->fiq_vec = timer1_fiqsr;
-	fiq_select = (1 << TIMER1_INT);
-	break;
+        sark_vec->fiq_vec = timer1_fiqsr;
+        fiq_select = (1 << TIMER1_INT);
+        break;
     case USER_EVENT:
-	sark_vec->fiq_vec = soft_int_fiqsr;
-	fiq_select = (1 << SOFTWARE_INT);
-	break;
+        sark_vec->fiq_vec = soft_int_fiqsr;
+        fiq_select = (1 << SOFTWARE_INT);
+        break;
     }
 
     // Move the SARK interrupt to chosen slot
 
-    vic_controls[sark_vec->sark_slot] = 0;	  // Disable previous slot
+    vic_controls[sark_vec->sark_slot] = 0;        // Disable previous slot
 
     vic_vectors[SARK_PRIORITY]  = sark_int_han;
     vic_controls[SARK_PRIORITY] = 0x20 | CPU_INT;
@@ -365,7 +365,7 @@ void configure_vic(uint enable_timer)
     vic[VIC_SELECT] = fiq_select;
 
     if (!enable_timer) {
-	int_select = int_select & ~(1 << TIMER1_INT);
+        int_select = int_select & ~(1 << TIMER1_INT);
     }
 
 #if USE_WRITE_BUFFER == TRUE
@@ -391,8 +391,8 @@ void spin1_pause()
 void resume()
 {
     if (resume_sync == 1) {
-	resume_sync = 0;
-	event.wait ^= 1;
+        resume_sync = 0;
+        event.wait ^= 1;
     }
     paused = 0;
     sark_cpu_state(CPU_STATE_RUN);
@@ -404,14 +404,14 @@ void resume()
 void spin1_resume(sync_bool sync)
 {
     if (sync == SYNC_NOWAIT) {
-	resume();
+        resume();
     } else {
-	resume_sync = 1;
-	if (event.wait) {
-	    sark_cpu_state(CPU_STATE_SYNC1);
-	} else {
-	    sark_cpu_state(CPU_STATE_SYNC0);
-	}
+        resume_sync = 1;
+        if (event.wait) {
+            sark_cpu_state(CPU_STATE_SYNC1);
+        } else {
+            sark_cpu_state(CPU_STATE_SYNC0);
+        }
     }
 }
 
@@ -421,9 +421,9 @@ uint resume_wait()
     uint bit = 1 << sark.virt_cpu;
 
     if (event.wait) {
-	return (~sc[SC_FLAG] & bit);	// Wait 1
+        return (~sc[SC_FLAG] & bit);    // Wait 1
     }
-    return (sc[SC_FLAG] & bit);		// Wait 0
+    return (sc[SC_FLAG] & bit);         // Wait 0
 }
 
 
@@ -473,69 +473,69 @@ void dispatch()
     // dispatch callbacks from queues until
     // spin1_exit () is called (run = 0)
     while (run) {
-	i = 0;
+        i = 0;
 
-	// disable interrupts to avoid concurrent
-	// scheduler/dispatcher accesses to queues
-	cpsr = spin1_int_disable();
+        // disable interrupts to avoid concurrent
+        // scheduler/dispatcher accesses to queues
+        cpsr = spin1_int_disable();
 
-	while (run && i < (NUM_PRIORITIES-1)) {
-	    tq = &task_queue[i];
+        while (run && i < (NUM_PRIORITIES-1)) {
+            tq = &task_queue[i];
 
-	    i++;  // prepare for next priority queue
+            i++;  // prepare for next priority queue
 
-	    if (tq->start != tq->end) {
-		cback = tq->queue[tq->start].cback;
-		uint arg0 = tq->queue[tq->start].arg0;
-		uint arg1 = tq->queue[tq->start].arg1;
+            if (tq->start != tq->end) {
+                cback = tq->queue[tq->start].cback;
+                uint arg0 = tq->queue[tq->start].arg0;
+                uint arg1 = tq->queue[tq->start].arg1;
 
-		tq->start = (tq->start + 1) % TASK_QUEUE_SIZE;
+                tq->start = (tq->start + 1) % TASK_QUEUE_SIZE;
 
-		if (cback != NULL) {
-		    // run callback with interrupts enabled
-		    spin1_mode_restore(cpsr);
+                if (cback != NULL) {
+                    // run callback with interrupts enabled
+                    spin1_mode_restore(cpsr);
 
-		    // check for if its a timer callback, if it is, update
-		    // tracker values
-		    if (cback == callback[TIMER_TICK].cback) {
-			diagnostics.in_timer_callback = 1;
-		    }
+                    // check for if its a timer callback, if it is, update
+                    // tracker values
+                    if (cback == callback[TIMER_TICK].cback) {
+                        diagnostics.in_timer_callback = 1;
+                    }
 
-		    // execute callback
-		    if (cback != callback[TIMER_TICK].cback || !paused) {
-			cback(arg0, arg1);
-		    }
+                    // execute callback
+                    if (cback != callback[TIMER_TICK].cback || !paused) {
+                        cback(arg0, arg1);
+                    }
 
-		    // update queue size
-		    if (cback == callback[TIMER_TICK].cback) {
-			if (diagnostics.number_timer_tic_in_queue > 0) {
-			    diagnostics.number_timer_tic_in_queue -= 1;
-			}
-			diagnostics.in_timer_callback = 0;
-		    }
+                    // update queue size
+                    if (cback == callback[TIMER_TICK].cback) {
+                        if (diagnostics.number_timer_tic_in_queue > 0) {
+                            diagnostics.number_timer_tic_in_queue -= 1;
+                        }
+                        diagnostics.in_timer_callback = 0;
+                    }
 
-		    cpsr = spin1_int_disable();
+                    cpsr = spin1_int_disable();
 
-		    // re-start examining queues at highest priority
-		    i = 0;
-		}
-	    }
-	}
+                    // re-start examining queues at highest priority
+                    i = 0;
+                }
+            }
+        }
 
-	if (run) {
-	    // go to sleep with interrupts disabled to avoid hazard!
-	    // an interrupt will still wake up the dispatcher
-	    spin1_wfi();
+        if (run) {
+            // go to sleep with interrupts disabled to avoid hazard!
+            // an interrupt will still wake up the dispatcher
+            spin1_wfi();
 
-	    // Handle resume
-	    if (resume_sync == 1) {
-		if (!resume_wait()) {
-		    resume();
-		}
-	    }
+            // Handle resume
+            if (resume_sync == 1) {
+                if (!resume_wait()) {
+                    resume();
+                }
+            }
 
-	    spin1_mode_restore(cpsr);
-	}
+            spin1_mode_restore(cpsr);
+        }
     }
 }
 /*
@@ -573,28 +573,28 @@ void spin1_callback_on(uint event_id, callback_t cback, int priority)
     // Enforce a single callback on FIQ
 
     if (priority < 0) {
-	if (fiq_event == -1 ||
-		(event_id == MC_PACKET_RECEIVED && fiq_event == MCPL_PACKET_RECEIVED) ||
-		(event_id == MCPL_PACKET_RECEIVED && fiq_event == MC_PACKET_RECEIVED) ||
-		(event_id == FR_PACKET_RECEIVED && fiq_event == FRPL_PACKET_RECEIVED) ||
-		(event_id == FRPL_PACKET_RECEIVED && fiq_event == FR_PACKET_RECEIVED)) {
-	    fiq_event = event_id;
-	} else {
-	    rt_error(RTE_API);
-	}
+        if (fiq_event == -1 ||
+                (event_id == MC_PACKET_RECEIVED && fiq_event == MCPL_PACKET_RECEIVED) ||
+                (event_id == MCPL_PACKET_RECEIVED && fiq_event == MC_PACKET_RECEIVED) ||
+                (event_id == FR_PACKET_RECEIVED && fiq_event == FRPL_PACKET_RECEIVED) ||
+                (event_id == FRPL_PACKET_RECEIVED && fiq_event == FR_PACKET_RECEIVED)) {
+            fiq_event = event_id;
+        } else {
+            rt_error(RTE_API);
+        }
     }
 
     // Enforce same interrupt handler for both packet callbacks
 
     if (event_id == MC_PACKET_RECEIVED || event_id == MCPL_PACKET_RECEIVED) {
-	if (mc_pkt_prio == -2) {
-	    mc_pkt_prio = priority;
+        if (mc_pkt_prio == -2) {
+            mc_pkt_prio = priority;
         } else if (mc_pkt_prio == -1 && priority != -1) {
             rt_error(RTE_API);
         }
     } else if (event_id == FR_PACKET_RECEIVED || event_id == FRPL_PACKET_RECEIVED) {
-	if (fr_pkt_prio == -2) {
-	    fr_pkt_prio = priority;
+        if (fr_pkt_prio == -2) {
+            fr_pkt_prio = priority;
         } else if (fr_pkt_prio == -1 && priority != -1) {
             rt_error(RTE_API);
         }
@@ -623,7 +623,7 @@ void spin1_callback_off(uint event_id)
     callback[event_id].cback = NULL;
 
     if (callback[event_id].priority < 0) {
-	fiq_event = -1;
+        fiq_event = -1;
     }
 }
 /*
@@ -656,8 +656,8 @@ void deschedule(uint event_id)
     task_queue_t *tq = &task_queue[callback[event_id].priority-1];
 
     for (uint i = 0; i < TASK_QUEUE_SIZE; i++) {
-	if (tq->queue[i].cback == callback[event_id].cback) {
-	    tq->queue[i].cback = NULL;
+        if (tq->queue[i].cback == callback[event_id].cback) {
+            tq->queue[i].cback = NULL;
         }
     }
 
@@ -707,11 +707,11 @@ void spin1_exit(uint error)
     // Disable API-enabled interrupts to allow simulation to exit,
 
     vic[VIC_DISABLE] = (1 << CC_MC_INT)   |
-	    (1 << CC_FR_INT)   |
-	    (1 << TIMER1_INT)   |
-	    (1 << SOFTWARE_INT) |
-	    (1 << DMA_ERR_INT)  |
-	    (1 << DMA_DONE_INT);
+            (1 << CC_FR_INT)   |
+            (1 << TIMER1_INT)   |
+            (1 << SOFTWARE_INT) |
+            (1 << DMA_ERR_INT)  |
+            (1 << DMA_DONE_INT);
 
     // Report back the return code and exit the simulation
 
@@ -797,24 +797,24 @@ void clean_up()
 void report_debug()
 {
 #if API_DEBUG == TRUE
-    if (leadAp) {	// Only the leader appl. core reports router data
-	// Report router counters
+    if (leadAp) {       // Only the leader appl. core reports router data
+        // Report router counters
 
-	io_printf(IO_API, "\t\t[api_debug] RTR mc     packets: %d\n",
-		rtr[RTR_DGC0] + rtr[RTR_DGC1]);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API, "\t\t[api_debug] RTR mc     packets: %d\n",
+                rtr[RTR_DGC0] + rtr[RTR_DGC1]);
+        io_delay(API_PRINT_DELAY);
 
-	io_printf(IO_API, "\t\t[api_debug] RTR dpd mc packets: %d\n",
-		rtr[RTR_DGC8]);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API, "\t\t[api_debug] RTR dpd mc packets: %d\n",
+                rtr[RTR_DGC8]);
+        io_delay(API_PRINT_DELAY);
     }
 
     io_printf(IO_API, "\t\t[api_debug] ISR thrown packets: %d\n",
-	    diagnostics.discarded_mc_packets);
+            diagnostics.discarded_mc_packets);
     io_delay(API_PRINT_DELAY);
 
     io_printf(IO_API, "\t\t[api_debug] ISR thrown FR packets: %d\n",
-	    diagnostics.discarded_fr_packets);
+            diagnostics.discarded_fr_packets);
     io_delay(API_PRINT_DELAY);
 
     // Report DMAC counters
@@ -839,28 +839,28 @@ void report_debug()
 */
 void report_warns()
 {
-#if API_WARN == TRUE	    // report warnings
+#if API_WARN == TRUE        // report warnings
     if (diagnostics.warnings & TASK_QUEUE_FULL) {
-	io_printf(IO_API, "\t\t[api_warn] warning: task queue full (%u)\n",
-		diagnostics.task_queue_full);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API, "\t\t[api_warn] warning: task queue full (%u)\n",
+                diagnostics.task_queue_full);
+        io_delay(API_PRINT_DELAY);
     }
     if (diagnostics.warnings & DMA_QUEUE_FULL) {
-	io_printf(IO_API, "\t\t[api_warn] warning: DMA queue full (%u)\n",
-		diagnostics.dma_queue_full);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API, "\t\t[api_warn] warning: DMA queue full (%u)\n",
+                diagnostics.dma_queue_full);
+        io_delay(API_PRINT_DELAY);
     }
     if (diagnostics.warnings & PACKET_QUEUE_FULL) {
-	io_printf(IO_API, "\t\t[api_warn] warning: packet queue full (%u)\n",
-		diagnostics.tx_packet_queue_full);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API, "\t\t[api_warn] warning: packet queue full (%u)\n",
+                diagnostics.tx_packet_queue_full);
+        io_delay(API_PRINT_DELAY);
     }
 #if USE_WRITE_BUFFER == TRUE
     if (diagnostics.warnings & WRITE_BUFFER_ERROR) {
-	io_printf(IO_API,
-		"\t\t[api_warn] warning: write buffer errors (%u)\n",
-		diagnostics.writeBack_errors);
-	io_delay(API_PRINT_DELAY);
+        io_printf(IO_API,
+                "\t\t[api_warn] warning: write buffer errors (%u)\n",
+                diagnostics.writeBack_errors);
+        io_delay(API_PRINT_DELAY);
     }
 #endif // USE_WRITE_BUFFER == TRUE
 #endif // API_WARN == TRUE
@@ -889,9 +889,9 @@ uint start(sync_bool sync, uint start_paused)
 {
     paused = start_paused;
     if (paused) {
-	sark_cpu_state(CPU_STATE_PAUSE);
+        sark_cpu_state(CPU_STATE_PAUSE);
     } else {
-	sark_cpu_state(CPU_STATE_RUN);
+        sark_cpu_state(CPU_STATE_RUN);
     }
 
     // Initialise hardware
@@ -920,14 +920,14 @@ uint start(sync_bool sync, uint start_paused)
     // synchronise with other application cores
 
     if (sync == SYNC_WAIT) {
-	event_wait();
+        event_wait();
     }
 
     // initialise counter and ticks for simulation
     // 32-bit, periodic counter, interrupts enabled
 
     if (timer_tick && !paused) {
-	tc[T1_CONTROL] = 0xe2;
+        tc[T1_CONTROL] = 0xe2;
     }
 
     ticks = 0;
@@ -957,11 +957,11 @@ uint start(sync_bool sync, uint start_paused)
     // avoid sending output at the same time as other chips!
     io_delay(10000 * my_chip);
 
-#if API_DEBUG == TRUE	// report debug information
+#if API_DEBUG == TRUE   // report debug information
     report_debug();
 #endif
 
-#if API_WARN == TRUE       	// report warnings
+#if API_WARN == TRUE            // report warnings
     report_warns();
 #endif // API_WARN
 #endif // API_DEBUG || API_WARN
@@ -1047,7 +1047,7 @@ void spin1_delay_us(uint n)
 * SOURCE
 */
 uint spin1_dma_transfer(uint tag, void *system_address, void *tcm_address,
-	uint direction, uint length)
+        uint direction, uint length)
 {
     uint id = 0;
     uint cpsr = spin1_int_disable();
@@ -1055,29 +1055,29 @@ uint spin1_dma_transfer(uint tag, void *system_address, void *tcm_address,
     uint new_end = (dma_queue.end + 1) % DMA_QUEUE_SIZE;
 
     if (new_end != dma_queue.start) {
-	id = diagnostics.dma_transfers++;
+        id = diagnostics.dma_transfers++;
 
-	uint desc = DMA_WIDTH << 24 | DMA_BURST_SIZE << 21
-		| direction << 19 | length;
+        uint desc = DMA_WIDTH << 24 | DMA_BURST_SIZE << 21
+                | direction << 19 | length;
 
-	dma_queue.queue[dma_queue.end].id = id;
-	dma_queue.queue[dma_queue.end].tag = tag;
-	dma_queue.queue[dma_queue.end].system_address = system_address;
-	dma_queue.queue[dma_queue.end].tcm_address = tcm_address;
-	dma_queue.queue[dma_queue.end].description = desc;
+        dma_queue.queue[dma_queue.end].id = id;
+        dma_queue.queue[dma_queue.end].tag = tag;
+        dma_queue.queue[dma_queue.end].system_address = system_address;
+        dma_queue.queue[dma_queue.end].tcm_address = tcm_address;
+        dma_queue.queue[dma_queue.end].description = desc;
 
-	/* if dmac is available and dma_queue empty trigger transfer now */
-	if (!(dma[DMA_STAT] & 4) && (dma_queue.start == dma_queue.end)) {
-	    dma[DMA_ADRS] = (uint) system_address;
-	    dma[DMA_ADRT] = (uint) tcm_address;
-	    dma[DMA_DESC] = desc;
+        /* if dmac is available and dma_queue empty trigger transfer now */
+        if (!(dma[DMA_STAT] & 4) && (dma_queue.start == dma_queue.end)) {
+            dma[DMA_ADRS] = (uint) system_address;
+            dma[DMA_ADRT] = (uint) tcm_address;
+            dma[DMA_DESC] = desc;
         }
 
-	dma_queue.end = new_end;
+        dma_queue.end = new_end;
 #if (API_WARN == TRUE) || (API_DIAGNOSTICS == TRUE)
     } else {
-	diagnostics.warnings |= DMA_QUEUE_FULL;
-	diagnostics.dma_queue_full++;
+        diagnostics.warnings |= DMA_QUEUE_FULL;
+        diagnostics.dma_queue_full++;
 #endif // (API_WARN == TRUE) || (API_DIAGNOSTICS == TRUE)
     }
 
@@ -1109,7 +1109,7 @@ void spin1_memcpy(void *dst, void const *src, uint len)
     char const *pSrc = (char const *) src;
 
     while (len--) {
-	*pDst++ = *pSrc++;
+        *pDst++ = *pSrc++;
     }
 }
 /*
@@ -1175,55 +1175,55 @@ uint spin1_send_packet(uint key, uint data, uint TCR)
     cc[CC_TCR] = TX_TCR_MCDEFAULT;
 
     if (cc[CC_TCR] & TX_FULL_MASK) {
-	if ((tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE
-		== tx_packet_queue.start) {
-	    /* if queue full cannot do anything -- report failure */
-	    rc = FAILURE;
+        if ((tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE
+                == tx_packet_queue.start) {
+            /* if queue full cannot do anything -- report failure */
+            rc = FAILURE;
 #if (API_WARN == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.warnings |= PACKET_QUEUE_FULL;
-	    diagnostics.tx_packet_queue_full++;
+            diagnostics.warnings |= PACKET_QUEUE_FULL;
+            diagnostics.tx_packet_queue_full++;
 #endif
-	} else {
-	    /* if not full queue packet */
-	    tx_packet_queue.queue[tx_packet_queue.end].key = key;
-	    tx_packet_queue.queue[tx_packet_queue.end].data = data;
-	    tx_packet_queue.queue[tx_packet_queue.end].TCR = TCR;
+        } else {
+            /* if not full queue packet */
+            tx_packet_queue.queue[tx_packet_queue.end].key = key;
+            tx_packet_queue.queue[tx_packet_queue.end].data = data;
+            tx_packet_queue.queue[tx_packet_queue.end].TCR = TCR;
 
-	    tx_packet_queue.end = (tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE;
+            tx_packet_queue.end = (tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE;
 
-	    /* turn on tx_empty interrupt (in case it was off) */
-	    vic[VIC_ENABLE] = (1 << CC_TMT_INT);
+            /* turn on tx_empty interrupt (in case it was off) */
+            vic[VIC_ENABLE] = (1 << CC_TMT_INT);
         }
     } else {
-	if ((tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE
-		== tx_packet_queue.start) {
-	    /* if queue full, dequeue and send packet at the */
-	    /* head of the queue to make room for new packet */
-	    uint hkey  = tx_packet_queue.queue[tx_packet_queue.start].key;
-	    uint hdata = tx_packet_queue.queue[tx_packet_queue.start].data;
-	    uint hTCR = tx_packet_queue.queue[tx_packet_queue.start].TCR;
+        if ((tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE
+                == tx_packet_queue.start) {
+            /* if queue full, dequeue and send packet at the */
+            /* head of the queue to make room for new packet */
+            uint hkey  = tx_packet_queue.queue[tx_packet_queue.start].key;
+            uint hdata = tx_packet_queue.queue[tx_packet_queue.start].data;
+            uint hTCR = tx_packet_queue.queue[tx_packet_queue.start].TCR;
 
-	    tx_packet_queue.start = (tx_packet_queue.start + 1) % TX_PACKET_QUEUE_SIZE;
+            tx_packet_queue.start = (tx_packet_queue.start + 1) % TX_PACKET_QUEUE_SIZE;
 
-	    cc[CC_TCR] = hTCR;
+            cc[CC_TCR] = hTCR;
 
-	    if (hTCR & PKT_PL) {
-		cc[CC_TXDATA] = hdata;
-	    }
-	    cc[CC_TXKEY]  = hkey;
+            if (hTCR & PKT_PL) {
+                cc[CC_TXDATA] = hdata;
+            }
+            cc[CC_TXKEY]  = hkey;
         }
 
-	if (tx_packet_queue.start == tx_packet_queue.end) {
-	    // If queue empty send packet
-	    cc[CC_TCR] = TCR;
+        if (tx_packet_queue.start == tx_packet_queue.end) {
+            // If queue empty send packet
+            cc[CC_TCR] = TCR;
 
-	    if (TCR & PKT_PL) {
-		cc[CC_TXDATA] = data;
-	    }
-	    cc[CC_TXKEY]  = key;
+            if (TCR & PKT_PL) {
+                cc[CC_TXDATA] = data;
+            }
+            cc[CC_TXKEY]  = key;
 
-	    // turn off tx_empty interrupt (in case it was on)
-	    vic[VIC_DISABLE] = 1 << CC_TMT_INT;
+            // turn off tx_empty interrupt (in case it was on)
+            vic[VIC_DISABLE] = 1 << CC_TMT_INT;
         } else {
             /* if not empty queue packet */
             tx_packet_queue.queue[tx_packet_queue.end].key = key;
@@ -1327,9 +1327,9 @@ __inline uint spin1_irq_disable(void)
     uint old_val, new_val;
 
     asm volatile (
-    "mrs	%[old_val], cpsr \n\
-     orr	%[new_val], %[old_val], #0x80 \n\
-     msr	cpsr_c, %[new_val] \n"
+    "mrs        %[old_val], cpsr \n\
+     orr        %[new_val], %[old_val], #0x80 \n\
+     msr        cpsr_c, %[new_val] \n"
      : [old_val] "=r" (old_val), [new_val] "=r" (new_val)
      :
      : );
@@ -1372,7 +1372,7 @@ extern void spin1_mode_restore(uint cpsr);
 __inline void spin1_mode_restore(uint cpsr)
 {
     asm volatile (
-    "msr	cpsr_c, %[cpsr]"
+    "msr        cpsr_c, %[cpsr]"
     :
     : [cpsr] "r" (cpsr)
     :);
@@ -1409,9 +1409,9 @@ __inline uint spin1_irq_enable(void)
     uint old_val, new_val;
 
     asm volatile (
-    "mrs	%[old_val], cpsr \n\
-     bic	%[new_val], %[old_val], #0x80 \n\
-     msr	cpsr_c, %[new_val] \n"
+    "mrs        %[old_val], cpsr \n\
+     bic        %[new_val], %[old_val], #0x80 \n\
+     msr        cpsr_c, %[new_val] \n"
      : [old_val] "=r" (old_val), [new_val] "=r" (new_val)
      :
      : );
@@ -1456,9 +1456,9 @@ __inline uint spin1_fiq_disable(void)
     uint old_val, new_val;
 
     asm volatile (
-    "mrs	%[old_val], cpsr \n\
-     orr	%[new_val], %[old_val], #0x40 \n\
-     msr	cpsr_c, %[new_val] \n"
+    "mrs        %[old_val], cpsr \n\
+     orr        %[new_val], %[old_val], #0x40 \n\
+     msr        cpsr_c, %[new_val] \n"
      : [old_val] "=r" (old_val), [new_val] "=r" (new_val)
      :
      : );
@@ -1503,9 +1503,9 @@ __inline uint spin1_int_disable(void)
     uint old_val, new_val;
 
     asm volatile (
-    "mrs	%[old_val], cpsr \n\
-     orr	%[new_val], %[old_val], #0xc0 \n\
-     msr	cpsr_c, %[new_val] \n"
+    "mrs        %[old_val], cpsr \n\
+     orr        %[new_val], %[old_val], #0xc0 \n\
+     msr        cpsr_c, %[new_val] \n"
      : [old_val] "=r" (old_val), [new_val] "=r" (new_val)
      :
      : );
@@ -1612,7 +1612,7 @@ uint spin1_get_chip_id(void)
 uint spin1_set_mc_table_entry(uint entry, uint key, uint mask, uint route)
 {
     if (entry >= APP_MC_ENTRIES) { // top priority entries reserved for the system
-	return FAILURE;
+        return FAILURE;
     }
 
     entry += SYS_MC_ENTRIES;
@@ -1620,8 +1620,8 @@ uint spin1_set_mc_table_entry(uint entry, uint key, uint mask, uint route)
 
 #if API_DEBUG == TRUE
     io_printf(IO_API,
-	    "\t\t[api_debug] MC entry %d: k 0x%8z m 0x%8z r 0x%8z\n",
-	    entry, key, mask, route);
+            "\t\t[api_debug] MC entry %d: k 0x%8z m 0x%8z r 0x%8z\n",
+            entry, key, mask, route);
     io_delay(API_PRINT_DLY);
 #endif
 
@@ -1717,26 +1717,26 @@ void* spin1_malloc(uint bytes)
 void schedule_sysmode(uchar event_id, uint arg0, uint arg1)
 {
     if (callback[event_id].priority <= 0) {
-	callback[event_id].cback(arg0, arg1);
+        callback[event_id].cback(arg0, arg1);
     } else {
-	task_queue_t *tq = &task_queue[callback[event_id].priority-1];
+        task_queue_t *tq = &task_queue[callback[event_id].priority-1];
 
-	if ((tq->end + 1) % TASK_QUEUE_SIZE != tq->start) {
-	    tq->queue[tq->end].cback = callback[event_id].cback;
-	    tq->queue[tq->end].arg0 = arg0;
-	    tq->queue[tq->end].arg1 = arg1;
+        if ((tq->end + 1) % TASK_QUEUE_SIZE != tq->start) {
+            tq->queue[tq->end].cback = callback[event_id].cback;
+            tq->queue[tq->end].arg0 = arg0;
+            tq->queue[tq->end].arg1 = arg1;
 
-	    tq->end = (tq->end + 1) % TASK_QUEUE_SIZE;
+            tq->end = (tq->end + 1) % TASK_QUEUE_SIZE;
 
-	    if (event_id == TIMER_TICK) {
-		diagnostics.number_timer_tic_in_queue += 1;
-	    }
-	} else {		// queue is full
+            if (event_id == TIMER_TICK) {
+                diagnostics.number_timer_tic_in_queue += 1;
+            }
+        } else {                // queue is full
 #if (API_WARN == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.warnings |= TASK_QUEUE_FULL;
-	    diagnostics.task_queue_full++;
+            diagnostics.warnings |= TASK_QUEUE_FULL;
+            diagnostics.task_queue_full++;
 #endif
-	}
+        }
     }
 }
 /*
@@ -1762,7 +1762,7 @@ void schedule_sysmode(uchar event_id, uint arg0, uint arg1)
 * SOURCE
 */
 uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
-	uint priority)
+        uint priority)
 {
     uchar result = SUCCESS;
 
@@ -1772,17 +1772,17 @@ uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
     task_queue_t *tq = &task_queue[priority-1];
 
     if ((tq->end + 1) % TASK_QUEUE_SIZE != tq->start) {
-	tq->queue[tq->end].cback = cback;
-	tq->queue[tq->end].arg0 = arg0;
-	tq->queue[tq->end].arg1 = arg1;
+        tq->queue[tq->end].cback = cback;
+        tq->queue[tq->end].arg0 = arg0;
+        tq->queue[tq->end].arg1 = arg1;
 
-	tq->end = (tq->end + 1) % TASK_QUEUE_SIZE;
+        tq->end = (tq->end + 1) % TASK_QUEUE_SIZE;
     } else {
-	// queue is full
-	result = FAILURE;
+        // queue is full
+        result = FAILURE;
 #if (API_WARN == TRUE) || (API_DIAGNOSTICS == TRUE)
-	diagnostics.warnings |= TASK_QUEUE_FULL;
-	diagnostics.task_queue_full++;
+        diagnostics.warnings |= TASK_QUEUE_FULL;
+        diagnostics.task_queue_full++;
 #endif
     }
 
@@ -1817,17 +1817,17 @@ uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
 uint spin1_trigger_user_event(uint arg0, uint arg1)
 {
     if (!user_pending) {
-	/* remember callback arguments */
-	user_arg0 = arg0;
-	user_arg1 = arg1;
-	user_pending = TRUE;
+        /* remember callback arguments */
+        user_arg0 = arg0;
+        user_arg1 = arg1;
+        user_pending = TRUE;
 
-	/* trigger software interrupt in the VIC */
-	vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
+        /* trigger software interrupt in the VIC */
+        vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
 
-	return (SUCCESS);
+        return (SUCCESS);
     } else {
-	return (FAILURE);
+        return (FAILURE);
     }
 }
 /*

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -35,31 +35,31 @@ extern tx_packet_queue_t tx_packet_queue;
 */
 INT_HANDLER cc_rx_ready_isr(void)
 {
-    uint rx_status = cc[CC_RSR];	// Get Rx status
+    uint rx_status = cc[CC_RSR];        // Get Rx status
 
-    if (rx_status & PKT_PL) {		// Has payload?
-	uint rx_data = cc[CC_RXDATA];
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+    if (rx_status & PKT_PL) {           // Has payload?
+        uint rx_data = cc[CC_RXDATA];
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	// If application callback registered schedule it
+        // If application callback registered schedule it
 
-	if (callback[MCPL_PACKET_RECEIVED].cback != NULL) {
-	    schedule(MCPL_PACKET_RECEIVED, rx_key, rx_data);
-	} else {
+        if (callback[MCPL_PACKET_RECEIVED].cback != NULL) {
+            schedule(MCPL_PACKET_RECEIVED, rx_key, rx_data);
+        } else {
 #if (API_DEBUG == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.discarded_mc_packets++;
-	}
+            diagnostics.discarded_mc_packets++;
+        }
 #endif
     } else {
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	if (callback[MC_PACKET_RECEIVED].cback != NULL) {
-	    schedule(MC_PACKET_RECEIVED, rx_key, 0);
-	} else {
+        if (callback[MC_PACKET_RECEIVED].cback != NULL) {
+            schedule(MC_PACKET_RECEIVED, rx_key, 0);
+        } else {
 #if (API_DEBUG == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.discarded_mc_packets++;
+            diagnostics.discarded_mc_packets++;
 #endif
-	}
+        }
     }
 
     // TODO: maybe clear error flags (sticky) in CC
@@ -90,19 +90,19 @@ INT_HANDLER cc_rx_ready_isr(void)
 */
 INT_HANDLER cc_rx_ready_fiqsr()
 {
-    uint rx_status = cc[CC_RSR];	// Get Rx status
+    uint rx_status = cc[CC_RSR];        // Get Rx status
 
-    if (rx_status & PKT_PL) {		// Has payload?
-	uint rx_data = cc[CC_RXDATA];
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+    if (rx_status & PKT_PL) {           // Has payload?
+        uint rx_data = cc[CC_RXDATA];
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	// Execute preeminent callback
+        // Execute preeminent callback
 
-	callback[MCPL_PACKET_RECEIVED].cback(rx_key, rx_data);
+        callback[MCPL_PACKET_RECEIVED].cback(rx_key, rx_data);
     } else {
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	callback[MC_PACKET_RECEIVED].cback(rx_key, 0);
+        callback[MC_PACKET_RECEIVED].cback(rx_key, 0);
     }
 
     // TODO: maybe clear error flags (sticky) in CC
@@ -130,31 +130,31 @@ INT_HANDLER cc_rx_ready_fiqsr()
 */
 INT_HANDLER cc_fr_ready_isr(void)
 {
-    uint rx_status = cc[CC_RSR];	// Get Rx status
+    uint rx_status = cc[CC_RSR];        // Get Rx status
 
-    if (rx_status & PKT_PL) {		// Has payload?
-	uint rx_data = cc[CC_RXDATA];
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+    if (rx_status & PKT_PL) {           // Has payload?
+        uint rx_data = cc[CC_RXDATA];
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	// If application callback registered schedule it
+        // If application callback registered schedule it
 
-	if (callback[FRPL_PACKET_RECEIVED].cback != NULL) {
-	    schedule(FRPL_PACKET_RECEIVED, rx_key, rx_data);
-	} else {
+        if (callback[FRPL_PACKET_RECEIVED].cback != NULL) {
+            schedule(FRPL_PACKET_RECEIVED, rx_key, rx_data);
+        } else {
 #if (API_DEBUG == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.discarded_fr_packets++;
+            diagnostics.discarded_fr_packets++;
 #endif
-	}
+        }
     } else {
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	if (callback[FR_PACKET_RECEIVED].cback != NULL) {
-	    schedule(FR_PACKET_RECEIVED, rx_key, 0);
-	} else {
+        if (callback[FR_PACKET_RECEIVED].cback != NULL) {
+            schedule(FR_PACKET_RECEIVED, rx_key, 0);
+        } else {
 #if (API_DEBUG == TRUE) || (API_DIAGNOSTICS == TRUE)
-	    diagnostics.discarded_fr_packets++;
+            diagnostics.discarded_fr_packets++;
 #endif
-	}
+        }
     }
 
     // TODO: maybe clear error flags (sticky) in CC
@@ -185,19 +185,19 @@ INT_HANDLER cc_fr_ready_isr(void)
 */
 INT_HANDLER cc_fr_ready_fiqsr()
 {
-    uint rx_status = cc[CC_RSR];	// Get Rx status
+    uint rx_status = cc[CC_RSR];        // Get Rx status
 
-    if (rx_status & PKT_PL) {		// Has payload?
-	uint rx_data = cc[CC_RXDATA];
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+    if (rx_status & PKT_PL) {           // Has payload?
+        uint rx_data = cc[CC_RXDATA];
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	// Execute preeminent callback
+        // Execute preeminent callback
 
-	callback[FRPL_PACKET_RECEIVED].cback(rx_key, rx_data);
+        callback[FRPL_PACKET_RECEIVED].cback(rx_key, rx_data);
     } else {
-	uint rx_key = cc[CC_RXKEY];	// also clears interrupt
+        uint rx_key = cc[CC_RXKEY];     // also clears interrupt
 
-	callback[FR_PACKET_RECEIVED].cback(rx_key, 0);
+        callback[FR_PACKET_RECEIVED].cback(rx_key, 0);
     }
 
     // TODO: maybe clear error flags (sticky) in CC
@@ -258,30 +258,30 @@ INT_HANDLER cc_tx_empty_isr()
     // Drain queue: send packets while queue not empty and CC not full
 
     while (tx_packet_queue.start != tx_packet_queue.end
-	    && ~cc[CC_TCR] & 0x40000000) {
-	// Dequeue packet
+            && ~cc[CC_TCR] & 0x40000000) {
+        // Dequeue packet
 
-	uint key = tx_packet_queue.queue[tx_packet_queue.start].key;
-	uint data = tx_packet_queue.queue[tx_packet_queue.start].data;
-	uint TCR = tx_packet_queue.queue[tx_packet_queue.start].TCR;
+        uint key = tx_packet_queue.queue[tx_packet_queue.start].key;
+        uint data = tx_packet_queue.queue[tx_packet_queue.start].data;
+        uint TCR = tx_packet_queue.queue[tx_packet_queue.start].TCR;
 
-	tx_packet_queue.start = (tx_packet_queue.start + 1) % TX_PACKET_QUEUE_SIZE;
+        tx_packet_queue.start = (tx_packet_queue.start + 1) % TX_PACKET_QUEUE_SIZE;
 
-	// Send the packet
+        // Send the packet
 
-	cc[CC_TCR] = TCR;
+        cc[CC_TCR] = TCR;
 
-	if (TCR & PKT_PL) {
-	    cc[CC_TXDATA] = data;
-	}
+        if (TCR & PKT_PL) {
+            cc[CC_TXDATA] = data;
+        }
 
-	cc[CC_TXKEY]  = key;
+        cc[CC_TXKEY]  = key;
     }
 
     // If queue empty turn off tx_empty interrupt
 
     if (tx_packet_queue.start == tx_packet_queue.end) {
-	vic[VIC_DISABLE] = 1 << CC_TMT_INT;
+        vic[VIC_DISABLE] = 1 << CC_TMT_INT;
     }
 
     // ack VIC
@@ -323,19 +323,19 @@ INT_HANDLER dma_done_isr()
     dma_queue.start = (dma_queue.start + 1) % DMA_QUEUE_SIZE;
 
     if (dma_queue.start != dma_queue.end) {
-	uint *system_address = dma_queue.queue[dma_queue.start].system_address;
-	uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
-	uint  description = dma_queue.queue[dma_queue.start].description;
+        uint *system_address = dma_queue.queue[dma_queue.start].system_address;
+        uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
+        uint  description = dma_queue.queue[dma_queue.start].description;
 
-	dma[DMA_ADRS] = (uint) system_address;
-	dma[DMA_ADRT] = (uint) tcm_address;
-	dma[DMA_DESC] = description;
+        dma[DMA_ADRS] = (uint) system_address;
+        dma[DMA_ADRT] = (uint) tcm_address;
+        dma[DMA_DESC] = description;
     }
 
     // If application callback registered schedule it
 
     if (callback[DMA_TRANSFER_DONE].cback != NULL) {
-	schedule(DMA_TRANSFER_DONE, completed_id, completed_tag);
+        schedule(DMA_TRANSFER_DONE, completed_id, completed_tag);
     }
 
     // Ack VIC
@@ -379,13 +379,13 @@ INT_HANDLER dma_done_fiqsr()
     dma_queue.start = (dma_queue.start + 1) % DMA_QUEUE_SIZE;
 
     if (dma_queue.start != dma_queue.end) {
-	uint *system_address = dma_queue.queue[dma_queue.start].system_address;
-	uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
-	uint  description = dma_queue.queue[dma_queue.start].description;
+        uint *system_address = dma_queue.queue[dma_queue.start].system_address;
+        uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
+        uint  description = dma_queue.queue[dma_queue.start].description;
 
-	dma[DMA_ADRS] = (uint) system_address;
-	dma[DMA_ADRT] = (uint) tcm_address;
-	dma[DMA_DESC] = description;
+        dma[DMA_ADRS] = (uint) system_address;
+        dma[DMA_ADRT] = (uint) tcm_address;
+        dma[DMA_DESC] = description;
     }
 
     // Execute preeminent callback
@@ -446,20 +446,20 @@ INT_HANDLER timer1_isr()
     // If application callback registered schedule it
     if (callback[TIMER_TICK].cback != NULL) {
 
-	// check for timer tic overload and store in diagnostics
-	if (diagnostics.in_timer_callback != 0) {
+        // check for timer tic overload and store in diagnostics
+        if (diagnostics.in_timer_callback != 0) {
 
-	    // if in timer tic callback already, add to tracker for total failures
-	    diagnostics.total_times_tick_tic_callback_overran += 1;
+            // if in timer tic callback already, add to tracker for total failures
+            diagnostics.total_times_tick_tic_callback_overran += 1;
 
-	    // if number of timer callbacks in queue is greater than previously seen
-	    if (diagnostics.number_timer_tic_in_queue >
-		    diagnostics.largest_number_of_concurrent_timer_tic_overruns) {
-		diagnostics.largest_number_of_concurrent_timer_tic_overruns =
-			diagnostics.number_timer_tic_in_queue;
-	    }
-	}
-	schedule(TIMER_TICK, ticks, NULL);
+            // if number of timer callbacks in queue is greater than previously seen
+            if (diagnostics.number_timer_tic_in_queue >
+                    diagnostics.largest_number_of_concurrent_timer_tic_overruns) {
+                diagnostics.largest_number_of_concurrent_timer_tic_overruns =
+                        diagnostics.number_timer_tic_in_queue;
+            }
+        }
+        schedule(TIMER_TICK, ticks, NULL);
     }
 
     // Ack VIC
@@ -513,7 +513,7 @@ INT_HANDLER soft_int_isr()
 
     // If application callback registered schedule it
     if (callback[USER_EVENT].cback != NULL) {
-	schedule(USER_EVENT, user_arg0, user_arg1);
+        schedule(USER_EVENT, user_arg0, user_arg1);
     }
 
     // Clear flag to indicate event has been serviced


### PR DESCRIPTION
Used command
```
find \( -name \*.h -o -name \*.c -o -name \*.cpp \) -exec vim -c ":set tabstop=8 shiftwidth=8 expandtab" -c ":retab" -c ":wq" \{\} \;
```

This appears to have generated the same tab usage as the files.