### PR TITLE
Clear Eclipse warning due to variable hiding

### DIFF
--- a/tools/SpiNN/Util.pm
+++ b/tools/SpiNN/Util.pm
@@ -121,7 +121,7 @@ sub parse_region
 
     return 0 if $level < 0 || $level > 3;
 
-    my ($x, $y) = (0, 0);
+    ($x, $y) = (0, 0);
 
     for (my $i = 0; $i < $level; $i++)
     {


### PR DESCRIPTION
I was going through the Perl code (as part of trying to address multiple real errors in my Eclipse configuration and Perl installation) and I noticed that I was getting these genuine warnings:

Description |	Resource |	Path |	Location |	Type
---------- | ----------- | ---------- | ----------- | ----------
"my" variable $x masks earlier declaration in same scope	| Util.pm |	/spinnaker_tools/tools/SpiNN |	line 124 |	Perl Problem
"my" variable $y masks earlier declaration in same scope |	Util.pm |	/spinnaker_tools/tools/SpiNN |	line 124 |	Perl Problem

This PR fixes these real issues; there was simply no need for the `my` on that particular line as the variables concerned were already local to the subroutine (and were made so on the first line of it, line 89).