### PR TITLE
Fix SCAMP ARP

### DIFF
--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -171,13 +171,13 @@ void iptag_timer()
     iptag_t *tag = tag_table;
 
     for (uint i = 0; i < TAG_TABLE_SIZE; i++) {
-	if ((tag->flags & IPFLAG_VALID) && (tag->timeout > 0)) {
-	    tag->timeout--;
-	    if (tag->timeout == 0) {
-		tag->flags = 0;
-	    }
-	}
-	tag++;
+        if ((tag->flags & IPFLAG_VALID) && (tag->timeout > 0)) {
+            tag->timeout--;
+            if (tag->timeout == 0) {
+                tag->flags = 0;
+            }
+        }
+        tag++;
     }
 }
 
@@ -185,8 +185,8 @@ void iptag_timer()
 uint iptag_new()
 {
     for (uint i = FIRST_POOL_TAG; i <= LAST_POOL_TAG; i++) {
-	if (tag_table[i].flags == 0) {
-	    return i;
+        if (tag_table[i].flags == 0) {
+            return i;
         }
     }
 
@@ -198,17 +198,17 @@ uint transient_tag(uchar *ip, uchar *mac, uint port, uint timeout)
     uint tag = iptag_new();
 
     if (tag != TAG_NONE) {
-	iptag_t *tt = tag_table+tag;
+        iptag_t *tt = tag_table+tag;
 
-	tt->flags = IPFLAG_VALID + IPFLAG_TRANS + timeout;
-	tt->tx_port = port;
-	tt->rx_port = 0;
-	copy_ip(ip, tt->ip);
-	copy_mac(mac, tt->mac);
-	if (timeout != 0) {
-	    timeout = 1 << (timeout - 1);
-	}
-	tt->timeout = timeout;
+        tt->flags = IPFLAG_VALID + IPFLAG_TRANS + timeout;
+        tt->tx_port = port;
+        tt->rx_port = 0;
+        copy_ip(ip, tt->ip);
+        copy_mac(mac, tt->mac);
+        if (timeout != 0) {
+            timeout = 1 << (timeout - 1);
+        }
+        tt->timeout = timeout;
     }
 
     return tag;
@@ -234,8 +234,8 @@ void proc_route_msg(uint arg1, uint arg2);
 void msg_queue_insert(sdp_msg_t *msg, uint srce_ip)
 {
     if (event_queue_proc(proc_route_msg, (uint) msg, srce_ip, PRIO_0) == 0) {
-	// if no event is queued free SDP msg buffer
-	sark_msg_free(msg);
+        // if no event is queued free SDP msg buffer
+        sark_msg_free(msg);
     }
 }
 
@@ -253,17 +253,17 @@ uint pkt_tx(uint tcr, uint data, uint key)
     uint cpsr = cpu_irq_disable();
 
     if (txq->count >= PKT_QUEUE_SIZE) {
-	cpu_int_restore(cpsr);
-	return 0;
+        cpu_int_restore(cpsr);
+        return 0;
     }
 
     if (txq->count == 0) {
-	vic[VIC_ENABLE] = 1 << CC_TMT_INT;
+        vic[VIC_ENABLE] = 1 << CC_TMT_INT;
     }
 
     txq->count++;
     if (txq->count > txq->max) {
-	txq->max = txq->count;
+        txq->max = txq->count;
     }
 
     txq->queue[txq->insert] = pkt;
@@ -301,8 +301,8 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (rx_pkt + IP_HDR_OFFSET);
 
     if (!cmp_ip(ip_hdr->dest, srom.ip_addr)) {
-	eth_discard();
-	return;
+        eth_discard();
+        return;
     }
 
     uint ip_len = (ip_hdr->ver_len & 15) * 4;
@@ -312,92 +312,93 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
     int len = ntohs(udp_hdr->length);
 
     if (udp_dest == srom.udp_port) {
-	len -= 10;			//const UDP_HDR + UDP_PAD
+        len -= 10;			//const UDP_HDR + UDP_PAD
 
-	if (len > 24 + SDP_BUF_SIZE) {	// SDP=8, CMD=16
-	    eth_discard();
-	    return;
-	}
+        if (len > 24 + SDP_BUF_SIZE) {	// SDP=8, CMD=16
+            eth_discard();
+            return;
+        }
 
-	sdp_msg_t *msg = sark_msg_get();
+        sdp_msg_t *msg = sark_msg_get();
 
-	if (msg == NULL) {		// !! fix this - reply somehow?
-	    sw_error(SW_OPT);
-	    eth_discard();
-	    return;
-	}
+        if (msg == NULL) {		// !! fix this - reply somehow?
+            sw_error(SW_OPT);
+            eth_discard();
+            return;
+        }
 
-	sark_word_cpy(&msg->flags, (uchar *) udp_hdr+10, len); //const
+        sark_word_cpy(&msg->flags, (uchar *) udp_hdr+10, len); //const
 
-	msg->length = len;
-	msg->srce_addr = p2p_addr;
+        msg->length = len;
+        msg->srce_addr = p2p_addr;
 
-	uint flags = msg->flags;
-	uint tag = msg->tag;
-	uint srce_ip;
+        uint flags = msg->flags;
+        uint tag = msg->tag;
+        uint srce_ip;
 
-	copy_ip(ip_hdr->srce, (uchar *) &srce_ip);
+        copy_ip(ip_hdr->srce, (uchar *) &srce_ip);
 
-	if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
-	    tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
-	}
+        if ((tag == TAG_NONE) && (flags & SDPF_REPLY)) { // transient tag & reply req
+            tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
+        }
 
-	eth_discard();
+        eth_discard();
 
-	if ((flags & SDPF_REPLY) == 0 ||
-		(tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
-	    msg_queue_insert(msg, srce_ip);
-	} else {
-	    sark_msg_free(msg);
-	}
+        if ((flags & SDPF_REPLY) == 0 ||
+                (tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
+            arp_add(rx_pkt+6, ip_hdr->srce);
+            msg_queue_insert(msg, srce_ip);
+        } else {
+            sark_msg_free(msg);
+        }
     } else {				// Reverse IPTag...
-	len -= 8;			//const UDP_HDR
+        len -= 8;			//const UDP_HDR
 
-	if (len > 16 + SDP_BUF_SIZE) {	// CMD=16
-	    eth_discard();
-	    return;
-	}
+        if (len > 16 + SDP_BUF_SIZE) {	// CMD=16
+            eth_discard();
+            return;
+        }
 
-	uint i = 0;
+        uint i = 0;
 
-	while (i < TAG_FIXED_SIZE) {
-	    if (tag_table[i].flags != 0 && tag_table[i].rx_port == udp_dest) {
-		break;
-	    }
-	    i++;
-	}
+        while (i < TAG_FIXED_SIZE) {
+            if (tag_table[i].flags != 0 && tag_table[i].rx_port == udp_dest) {
+                break;
+            }
+            i++;
+        }
 
-	if (i == TAG_FIXED_SIZE) {
-	    eth_discard();
-	    return;
-	}
+        if (i == TAG_FIXED_SIZE) {
+            eth_discard();
+            return;
+        }
 
-	sdp_msg_t *msg = sark_msg_get();
-	if (msg == NULL) {
-	    sw_error(SW_OPT);
-	    eth_discard();
-	    return;
-	}
+        sdp_msg_t *msg = sark_msg_get();
+        if (msg == NULL) {
+            sw_error(SW_OPT);
+            eth_discard();
+            return;
+        }
 
-	// Set up reply path
+        // Set up reply path
 
-	tag_table[i].tx_port = udp_srce;
-	copy_ip(ip_hdr->srce, tag_table[i].ip);
-	copy_mac(rx_pkt+6, tag_table[i].mac);
+        tag_table[i].tx_port = udp_srce;
+        copy_ip(ip_hdr->srce, tag_table[i].ip);
+        copy_mac(rx_pkt+6, tag_table[i].mac);
 
-	memcpy(&msg->cmd_rc, (uchar *) udp_hdr+8, len); //const
+        memcpy(&msg->cmd_rc, (uchar *) udp_hdr+8, len); //const
 
-	eth_discard();
+        eth_discard();
 
-	msg->flags = 0x07;
-	msg->tag = i;
-	msg->srce_addr = p2p_addr;
-	msg->srce_port = PORT_ETH;
-	msg->length = len + 8;
-	msg->dest_addr = tag_table[i].dest_addr;
-	msg->dest_port = tag_table[i].dest_port;
+        msg->flags = 0x07;
+        msg->tag = i;
+        msg->srce_addr = p2p_addr;
+        msg->srce_port = PORT_ETH;
+        msg->length = len + 8;
+        msg->dest_addr = tag_table[i].dest_addr;
+        msg->dest_port = tag_table[i].dest_port;
 
-	msg_queue_insert(msg, 0);
+        msg_queue_insert(msg, 0);
     }
 }
 
@@ -405,30 +406,30 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
 void eth_receive()
 {
     while (1) {
-	uint count = (er[ETH_STATUS] >> 1) & 63;
-	if (count == 0) {
-	    er[ETH_INT_CLR] = ETH_RX_CLR;
-	    return;
-	}
+        uint count = (er[ETH_STATUS] >> 1) & 63;
+        if (count == 0) {
+            er[ETH_INT_CLR] = ETH_RX_CLR;
+            return;
+        }
 
-	uint rx_desc = er[ETH_RX_DESC_RP] & 0x3f;	// Descriptor table index
-	uint rx_len = eth_rx_desc[rx_desc] & 0x7ff;	// Frame size
-	uchar *rx_pkt = eth_rx_ram + (er[ETH_RX_BUF_RP] & 0xfff);
+        uint rx_desc = er[ETH_RX_DESC_RP] & 0x3f;	// Descriptor table index
+        uint rx_len = eth_rx_desc[rx_desc] & 0x7ff;	// Frame size
+        uchar *rx_pkt = eth_rx_ram + (er[ETH_RX_BUF_RP] & 0xfff);
 
-	uint etype = (rx_pkt[12] << 8) + rx_pkt[13];
+        uint etype = (rx_pkt[12] << 8) + rx_pkt[13];
 
-	if (etype == ETYPE_IP) {
-	    uint ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
+        if (etype == ETYPE_IP) {
+            uint ip_prot = rx_pkt[IP_HDR_OFFSET + 9];
 
-	    if (ip_prot == PROT_UDP) {
-		udp_pkt(rx_pkt, rx_len);
-	    } else if (ip_prot == PROT_ICMP) {
-		icmp_pkt(rx_pkt, rx_len);
-	    } else {
-		eth_discard();
-	    }
-	} else if (etype == ETYPE_ARP) {
-	    arp_pkt(rx_pkt, rx_len, TAG_TABLE_SIZE);
+            if (ip_prot == PROT_UDP) {
+                udp_pkt(rx_pkt, rx_len);
+            } else if (ip_prot == PROT_ICMP) {
+                icmp_pkt(rx_pkt, rx_len);
+            } else {
+                eth_discard();
+            }
+        } else if (etype == ETYPE_ARP) {
+            arp_pkt(rx_pkt, rx_len, TAG_TABLE_SIZE);
         } else {
             eth_discard();
         }
@@ -444,7 +445,7 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
     iptag_t *iptag = tag_table + tag;
 
     if ((iptag->flags & IPFLAG_VALID) == 0) {
-	return;
+        return;
     }
 
     uchar hdr[44];
@@ -456,22 +457,22 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
     uint pad;
 
     if (iptag->flags & IPFLAG_STRIP) {
-	buf = (uchar *) &msg->cmd_rc;
-	len -= 8;
-	pad = 0;
+        buf = (uchar *) &msg->cmd_rc;
+        len -= 8;
+        pad = 0;
     } else {
-	buf = (uchar *) &msg->flags;
-	pad = 2;
+        buf = (uchar *) &msg->flags;
+        pad = 2;
     }
 
     if (iptag->flags & IPFLAG_REV) {
-	udp_hdr->srce = htons(iptag->rx_port);
+        udp_hdr->srce = htons(iptag->rx_port);
     } else {
-	udp_hdr->srce = htons(srom.udp_port);
+        udp_hdr->srce = htons(srom.udp_port);
     }
 
     copy_ip_hdr(iptag->ip, PROT_UDP, ip_hdr,
-	    len + pad + IP_HDR_SIZE + UDP_HDR_SIZE);
+            len + pad + IP_HDR_SIZE + UDP_HDR_SIZE);
 
     udp_hdr->length = htons(len + pad + UDP_HDR_SIZE);
     udp_hdr->dest = htons(iptag->tx_port);
@@ -497,9 +498,9 @@ void eth_send_msg(uint tag, sdp_msg_t *msg)
     sark_delay_us(5);		//## !! Trouble with back-to-back packets??
 
     if (iptag->flags & IPFLAG_TRANS) {		//transient tag
-	iptag->flags = 0;
+        iptag->flags = 0;
     } else {
-	iptag->count++;
+        iptag->count++;
     }
 }
 
@@ -516,19 +517,19 @@ uint shm_ping(uint dest)
     volatile uchar flag = 0;
     event_t *e = event_new(proc_byte_set, (uint) &flag, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	return 1;
+        sw_error(SW_OPT);
+        return 1;
     }
 
     uint id = e->ID;
     timer_schedule(e, 1000); // !! const??
 
     while (vcpu->mbox_ap_cmd != SHM_IDLE && flag == 0) {
-	continue;
+        continue;
     }
 
     if (flag != 0) {
-	return 0;
+        return 0;
     }
 
     timer_cancel(e, id);
@@ -543,7 +544,7 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
 
     sdp_msg_t *shm_msg = sark_shmsg_get();
     if (shm_msg == NULL) {
-	return RC_BUF;
+        return RC_BUF;
     }
 
     sark_msg_cpy(shm_msg, msg);
@@ -556,21 +557,21 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
     volatile uchar flag = 0;
     event_t *e = event_new(proc_byte_set, (uint) &flag, 2);
     if (e == NULL) {
-	sw_error(SW_OPT);
-	sark_shmsg_free(shm_msg);
-	return RC_BUF;		// !! not the right RC
+        sw_error(SW_OPT);
+        sark_shmsg_free(shm_msg);
+        return RC_BUF;		// !! not the right RC
     }
 
     uint id = e->ID;
     timer_schedule(e, 1000);	// !! const??
 
     while (vcpu->mbox_ap_cmd != SHM_IDLE && flag == 0) {
-	continue;
+        continue;
     }
 
     if (flag != 0) {
-	sark_shmsg_free(shm_msg);
-	return RC_TIMEOUT;
+        sark_shmsg_free(shm_msg);
+        return RC_TIMEOUT;
     }
 
     timer_cancel(e, id);
@@ -596,17 +597,17 @@ void return_msg(sdp_msg_t *msg, uint rc) // Zero "rc" skips updating cmd_hdr
     uint f = msg->flags;
 
     if (f & SDPF_REPLY) {
-	msg->flags = f & ~SDPF_REPLY;
-	swap_sdp_hdr(msg);
+        msg->flags = f & ~SDPF_REPLY;
+        swap_sdp_hdr(msg);
 
-	if (rc != 0) {
-	    msg->cmd_rc = rc;
-	    msg->length = 12;
-	}
+        if (rc != 0) {
+            msg->cmd_rc = rc;
+            msg->length = 12;
+        }
 
-	msg_queue_insert(msg, 0);
+        msg_queue_insert(msg, 0);
     } else {
-	sark_msg_free(msg);
+        sark_msg_free(msg);
     }
 }
 
@@ -618,69 +619,69 @@ void proc_route_msg(uint arg1, uint srce_ip)
 
     if (flags & SDPF_SUM) {
 /*
-	uint sum = ipsum((uchar *) &msg->length, msg->length+4, 0);
-	if (sum != 0xffff) { // !! fix this
-	  //	  msg_free(msg);
-	  //	  return;
-	}
+        uint sum = ipsum((uchar *) &msg->length, msg->length+4, 0);
+        if (sum != 0xffff) { // !! fix this
+          //	  msg_free(msg);
+          //	  return;
+        }
 */
-	msg->flags = flags &= ~SDPF_SUM;
+        msg->flags = flags &= ~SDPF_SUM;
     }
 
     // Map (255, 255) to the root chip's coordinates
     if (msg->dest_addr == 0xFFFF) {
-	msg->dest_addr = p2p_root;
+        msg->dest_addr = p2p_root;
     }
     if (msg->srce_addr == 0xFFFF) {
-	msg->srce_addr = p2p_root;
+        msg->srce_addr = p2p_root;
     }
 
     // Off-chip via P2P
 
     if (msg->dest_addr != msg->srce_addr && msg->dest_addr != p2p_addr &&
-	    (flags & SDPF_NR) == 0) {
-	if (p2p_up == 0 || rtr_p2p_get(msg->dest_addr) == 6) {
-	    return_msg(msg, RC_ROUTE);
-	    return;
-	}
+            (flags & SDPF_NR) == 0) {
+        if (p2p_up == 0 || rtr_p2p_get(msg->dest_addr) == 6) {
+            return_msg(msg, RC_ROUTE);
+            return;
+        }
 
-	uint rc = p2p_send_msg(msg->dest_addr, msg);
-	if (rc == RC_OK) {
-	    sark_msg_free(msg);
+        uint rc = p2p_send_msg(msg->dest_addr, msg);
+        if (rc == RC_OK) {
+            sark_msg_free(msg);
         } else {
             return_msg(msg, rc);
         }
-	return;
+        return;
     }
 
     if (msg->dest_port == PORT_ETH) {
-	eth_send_msg(msg->tag, msg);
-	sark_msg_free(msg);
-	return;
+        eth_send_msg(msg->tag, msg);
+        sark_msg_free(msg);
+        return;
     }
 
     uint dest_cpu = msg->dest_port & CPU_MASK;
     if (dest_cpu >= num_cpus) {
-	return_msg(msg, RC_CPU);
-	return;
+        return_msg(msg, RC_CPU);
+        return;
     }
 
     if (dest_cpu != sark.virt_cpu) {	// !! virt_cpu always zero
-	uint rc = shm_send_msg(dest_cpu, msg);
-	if (rc == RC_OK) {
-	    sark_msg_free(msg);
+        uint rc = shm_send_msg(dest_cpu, msg);
+        if (rc == RC_OK) {
+            sark_msg_free(msg);
         } else {
             return_msg(msg, rc);
         }
-	return;
+        return;
     }
 
     uint dest_port = msg->dest_port >> PORT_SHIFT;
     if (dest_port == 0) {
-	msg->length = 12 + scamp_debug(msg, srce_ip);
-	return_msg(msg, 0);
+        msg->length = 12 + scamp_debug(msg, srce_ip);
+        return_msg(msg, 0);
     } else {
-	return_msg(msg, RC_PORT);	// APs should not do this!!
+        return_msg(msg, RC_PORT);	// APs should not do this!!
     }
 }
 
@@ -694,7 +695,7 @@ void proc_route_msg(uint arg1, uint srce_ip)
 void assign_virt_cpu(uint phys_cpu)
 {
     for (uint phys = 0; phys < MAX_CPUS; phys++) {
-	sv->p2v_map[phys] = 255;
+        sv->p2v_map[phys] = 255;
     }
 
     sv->p2v_map[phys_cpu] = sark.virt_cpu = 0;
@@ -704,28 +705,28 @@ void assign_virt_cpu(uint phys_cpu)
     uint virt = 1;
 
     for (uint phys = 0; phys < NUM_CPUS; phys++) {
-	if (phys == phys_cpu) {
-	    continue;
+        if (phys == phys_cpu) {
+            continue;
         }
 
-	if (sc[SC_CPU_OK] & (1 << phys)) {
-	    sv->p2v_map[phys] = virt;
-	    sv->v2p_map[virt] = phys;
-	    virt++;
-	}
+        if (sc[SC_CPU_OK] & (1 << phys)) {
+            sv->p2v_map[phys] = virt;
+            sv->v2p_map[virt] = phys;
+            virt++;
+        }
     }
 
     sv->num_cpus = num_cpus = virt;
 
     while (virt < MAX_CPUS) {
-	sv->v2p_map[virt++] = 255;
+        sv->v2p_map[virt++] = 255;
     }
 
     // Turn off clocks of dead cores. If the monitor (this core) is marked as
     // dead, turn off the LED to make deadness more obvious.
     uint cpsr = cpu_int_disable();
     if (!(sc[SC_CPU_OK] & (1 << phys_cpu))) {
-	sark_led_set(LED_OFF(0));
+        sark_led_set(LED_OFF(0));
     }
     sc[SC_CPU_DIS] = SC_CODE + (~sc[SC_CPU_OK] & ((1 << NUM_CPUS) - 1));
     cpu_int_restore(cpsr);
@@ -755,7 +756,7 @@ void remap_phys_cores(uint phys_cores)
     boot_ap();
 
     sark_word_set(sv_vcpu + num_cpus, 0,
-		  (NUM_CPUS - num_cpus) * sizeof(vcpu_t));
+                  (NUM_CPUS - num_cpus) * sizeof(vcpu_t));
 }
 
 //------------------------------------------------------------------------------
@@ -773,20 +774,20 @@ uint ram_size(void *mem)
 
     uint v, z;
     do {
-	uint a = 1 << i++;
-	uint s = ram[a];
+        uint a = 1 << i++;
+        uint s = ram[a];
 
-	ram[a] = i;
+        ram[a] = i;
 
-	z = ram[0];
-	v = ram[a];
-	ram[a] = s;
+        z = ram[0];
+        v = ram[a];
+        ram[a] = s;
     } while ((v == i) && (z == zf));
 
     ram[0] = s;
 
     if (i == 1) {
-	return 0;
+        return 0;
     }
 
     return 1 << (i + 1);
@@ -797,7 +798,7 @@ uint ram_size(void *mem)
 
 
 const uint rst_init[] = {0x45206e49, 0x79726576, 0x65724420, 0x48206d61,
-			 0x20656d6f, 0x65482061, 0x61747261, 0x00656863};
+                         0x20656d6f, 0x65482061, 0x61747261, 0x00656863};
 
 
 void get_board_info(void)
@@ -812,7 +813,7 @@ void get_board_info(void)
     sark_word_cpy(sv_board_info, &msg.arg1, 256);
 
     if (sv_board_info[0] < 64) {
-	sv->board_info = sv_board_info;
+        sv->board_info = sv_board_info;
     }
 }
 
@@ -825,11 +826,11 @@ void sv_init(void)
     sark_word_set((void *) 0xf5007fc0, 0, 64);		// Kludge...
 
     if (srom.flags & SRF_PRESENT) {			// Get board_info ??
-	get_board_info();
+        get_board_info();
     }
 
     if (sv->hw_ver == 0 && srom.flags & SRF_PRESENT) {	// Set hardware version
-	sv->hw_ver = (srom.flags >> 4) & 15;
+        sv->hw_ver = (srom.flags >> 4) & 15;
     }
 
     sv->sw_ver = SLLT_VER_NUM;				// Set software version
@@ -849,7 +850,7 @@ void sv_init(void)
 
     // Set up SHM buffers
     sv->shm_buf = sark_xalloc(sv->sysram_heap,
-	    sv->num_buf * sizeof(sdp_msg_t), 0, 0);
+            sv->num_buf * sizeof(sdp_msg_t), 0, 0);
 
     sv->shm_root.free = (mem_link_t *) sv->shm_buf;
     //sv->shm_root.count = sv->shm_root.max = 0;	//## Not needed now...
@@ -857,7 +858,7 @@ void sv_init(void)
     sark_block_init(sv->shm_buf, sv->num_buf, sizeof(sdp_msg_t));
 
     if (sv->boot_delay == 0 && sv->rom_cpus == 0) {
-	sv->root_chip = 1;
+        sv->root_chip = 1;
     }
 }
 
@@ -903,7 +904,7 @@ void sdram_init(void)
     // Router MC table copy (NB 1 extra entry in copy table)
 
     sv->rtr_copy = sark_xalloc(sv->sys_heap,
-	    (MC_TABLE_SIZE + 1) * sizeof(rtr_entry_t), 0, 0);
+            (MC_TABLE_SIZE + 1) * sizeof(rtr_entry_t), 0, 0);
 
     // Alloc ID table
 
@@ -921,22 +922,22 @@ void random_init(void)
 {
     /* Now done from SDRAM...
       if (sv->random == 0) {
-	  uint rand = 0xa5;				// Set up random seed
-	  for (uint i = 0; i < SV_RSIZE / 4; i++) {
-	      rand ^= (i & 1) ? sv_random[i] : ~sv_random[i];
-	  }
-	  sv->random = rand;
+          uint rand = 0xa5;				// Set up random seed
+          for (uint i = 0; i < SV_RSIZE / 4; i++) {
+              rand ^= (i & 1) ? sv_random[i] : ~sv_random[i];
+          }
+          sv->random = rand;
       }
      */
     // Make random seed
 
     uint *rnd = sark_xalloc(sv->sys_heap, 256 * 4, 0, 0);
     if (sv->random == 0) {
-	uint rand = 0xa5;				// Set up random seed
-	for (uint i = 0; i < 256; i++) {
-	    rand ^= (i & 1) ? rnd[i] : ~rnd[i];
+        uint rand = 0xa5;				// Set up random seed
+        for (uint i = 0; i < 256; i++) {
+            rand ^= (i & 1) ? rnd[i] : ~rnd[i];
         }
-	sv->random = rand;
+        sv->random = rand;
     }
 
     sark_srand(sv->random);
@@ -954,17 +955,17 @@ void update_load(uint arg1, uint arg2)
     uint sleeping_cpus = sc[SC_SLEEP];
 
     for (uint cpu = 1; cpu < NUM_CPUS; cpu++) {
-	vcpu_t *vcpu = sv_vcpu + cpu;
+        vcpu_t *vcpu = sv_vcpu + cpu;
 
-	if (vcpu->cpu_state != CPU_STATE_DEAD) {
-	    num_working++;
+        if (vcpu->cpu_state != CPU_STATE_DEAD) {
+            num_working++;
         }
 
-	// NB: Ignores cores not running apps
-	if (vcpu->app_id > 0) {
-	    num_with_apps++;
-	    if (!(sleeping_cpus & (1 << vcpu->phys_cpu))) {
-		num_awake++;
+        // NB: Ignores cores not running apps
+        if (vcpu->app_id > 0) {
+            num_with_apps++;
+            if (!(sleeping_cpus & (1 << vcpu->phys_cpu))) {
+                num_awake++;
             }
         }
     }
@@ -974,7 +975,7 @@ void update_load(uint arg1, uint arg2)
     // are loaded.
     uint new_load = (num_awake * 255) / (num_working);
     if (num_with_apps > 0 && new_load == 0) {
-	new_load = 1;
+        new_load = 1;
     }
     load = new_load;
 }
@@ -986,12 +987,12 @@ void update_load(uint arg1, uint arg2)
 void proc_1hz(uint a1, uint a2)
 {
     if (srom.flags & SRF_ETH) {
-	uint s = phy_read(PHY_STATUS);
-	sv->eth_up = (s & 4) >> 2;
+        uint s = phy_read(PHY_STATUS);
+        sv->eth_up = (s & 4) >> 2;
 
-	// If the Ethernet is up now, we are done
-	if (sv->eth_up) {
-	    ethinit_phase = ETHINIT_PHASE_DONE;
+        // If the Ethernet is up now, we are done
+        if (sv->eth_up) {
+            ethinit_phase = ETHINIT_PHASE_DONE;
         }
     }
 
@@ -1013,20 +1014,20 @@ void soft_wdog(uint max)
     vcpu_t *vcpu = sv_vcpu + ping_cpu;
 
     if (vcpu->cpu_state >= 4) {				// !! const
-	if (shm_ping(ping_cpu)) {
-	    watchdog[ping_cpu] = 0;
-	} else if (++watchdog[ping_cpu] == max) {
-	    clock_ap(1 << v2p_map[ping_cpu], 0);	// Disable clock
+        if (shm_ping(ping_cpu)) {
+            watchdog[ping_cpu] = 0;
+        } else if (++watchdog[ping_cpu] == max) {
+            clock_ap(1 << v2p_map[ping_cpu], 0);	// Disable clock
 
-	    vcpu_t *vcpu = sv_vcpu + ping_cpu;
-	    vcpu->cpu_state = CPU_STATE_WDOG;
-	}
+            vcpu_t *vcpu = sv_vcpu + ping_cpu;
+            vcpu->cpu_state = CPU_STATE_WDOG;
+        }
     } else {
-	watchdog[ping_cpu] = 0;
+        watchdog[ping_cpu] = 0;
     }
 
     if (++ping_cpu >= num_cpus) {
-	ping_cpu = 1;
+        ping_cpu = 1;
     }
 }
 
@@ -1046,11 +1047,11 @@ void netinit_start(void)
 
     // Initial P2P address guess
     if (sv->root_chip) {
-	p2p_addr_guess_x = 0;
-	p2p_addr_guess_y = 0;
+        p2p_addr_guess_x = 0;
+        p2p_addr_guess_y = 0;
     } else {
-	p2p_addr_guess_x = NO_IDEA;
-	p2p_addr_guess_y = NO_IDEA;
+        p2p_addr_guess_x = NO_IDEA;
+        p2p_addr_guess_y = NO_IDEA;
     }
 
     // Initial P2P dimension range, initially empty
@@ -1082,28 +1083,28 @@ void compute_st(void)
     // and add them to the route, forming a spanning tree.
     uint timeout = sv->peek_time;
     for (uint link = 0; link < NUM_LINKS; link++) {
-	if (!((1 << link) & link_en)) {
-	    continue;
+        if (!((1 << link) & link_en)) {
+            continue;
         }
 
-	// Try to read multiple times if required
-	uint attempts_remaining = 2;
-	uint remote_rtr_p2p;
-	uint rc;
-	do {
-	    rc = link_read_word((uint)(rtr_p2p + word), link,
-		    &remote_rtr_p2p, timeout);
+        // Try to read multiple times if required
+        uint attempts_remaining = 2;
+        uint remote_rtr_p2p;
+        uint rc;
+        do {
+            rc = link_read_word((uint)(rtr_p2p + word), link,
+                    &remote_rtr_p2p, timeout);
         } while (rc != RC_OK && (--attempts_remaining));
 
-	// Flag an error if we could not get a p2p entry from a neighbour
-	if (rc != RC_OK) {
-	    sw_error(SW_OPT);
-	    continue;
+        // Flag an error if we could not get a p2p entry from a neighbour
+        if (rc != RC_OK) {
+            sw_error(SW_OPT);
+            continue;
         }
 
-	// Check if p2p_root route from neighbour points at this chip.
-	if (((remote_rtr_p2p >> offset) & 0x7) == ((link + 3) % 6)) {
-	    route |= MC_LINK_ROUTE(link);
+        // Check if p2p_root route from neighbour points at this chip.
+        if (((remote_rtr_p2p >> offset) & 0x7) == ((link + 3) % 6)) {
+            route |= MC_LINK_ROUTE(link);
         }
     }
 
@@ -1123,152 +1124,152 @@ void proc_100hz(uint a1, uint a2)
     // Boot-up related packet sending and boot-phase advancing
     switch (netinit_phase) {
     case NETINIT_PHASE_P2P_ADDR:
-	// Periodically re-send the neighbours their P2P address as
-	// neighbouring chips may take some time to come online.
-	p2pc_addr_nn_send(0, 0);
+        // Periodically re-send the neighbours their P2P address as
+        // neighbouring chips may take some time to come online.
+        p2pc_addr_nn_send(0, 0);
 
-	// If no new P2P addresses have been broadcast for a while we can
-	// assume all chips are have a valid P2P address so it is now time to
-	// determine the system's dimensions.
-	if (ticks_since_last_p2pc_new++ > (uint)sv->netinit_bc_wait) {
-	    netinit_phase = NETINIT_PHASE_P2P_DIMS;
+        // If no new P2P addresses have been broadcast for a while we can
+        // assume all chips are have a valid P2P address so it is now time to
+        // determine the system's dimensions.
+        if (ticks_since_last_p2pc_new++ > (uint)sv->netinit_bc_wait) {
+            netinit_phase = NETINIT_PHASE_P2P_DIMS;
 
-	    p2p_min_x = (p2p_addr_guess_x < 0) ? p2p_addr_guess_x : 0;
-	    p2p_min_y = (p2p_addr_guess_y < 0) ? p2p_addr_guess_y : 0;
-	    p2p_max_x = (p2p_addr_guess_x > 0) ? p2p_addr_guess_x : 0;
-	    p2p_max_y = (p2p_addr_guess_y > 0) ? p2p_addr_guess_y : 0;
+            p2p_min_x = (p2p_addr_guess_x < 0) ? p2p_addr_guess_x : 0;
+            p2p_min_y = (p2p_addr_guess_y < 0) ? p2p_addr_guess_y : 0;
+            p2p_max_x = (p2p_addr_guess_x > 0) ? p2p_addr_guess_x : 0;
+            p2p_max_y = (p2p_addr_guess_y > 0) ? p2p_addr_guess_y : 0;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_P2P_DIMS:
-	// Periodically re-broadcast the local best guess of system
-	// dimensions as a safety net in the event of packet loss.
-	p2pc_dims_nn_send(0, 0);
+        // Periodically re-broadcast the local best guess of system
+        // dimensions as a safety net in the event of packet loss.
+        p2pc_dims_nn_send(0, 0);
 
-	// If no new guesses have been broadcast for a while we can assume
-	// the current guess is accurate so its time to move onto the next
-	// phase
-	if (ticks_since_last_p2pc_dims++ > (uint)sv->netinit_bc_wait) {
-	    // If no coordinate discovered, just shut down this chip
-	    if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA) {
-		remap_phys_cores(0x3ffff);
+        // If no new guesses have been broadcast for a while we can assume
+        // the current guess is accurate so its time to move onto the next
+        // phase
+        if (ticks_since_last_p2pc_dims++ > (uint)sv->netinit_bc_wait) {
+            // If no coordinate discovered, just shut down this chip
+            if (p2p_addr_guess_x == NO_IDEA || p2p_addr_guess_y == NO_IDEA) {
+                remap_phys_cores(0x3ffff);
             }
 
-	    // Record the coordinates/dimensions discovered
-	    sv->p2p_addr = p2p_addr = ((p2p_addr_guess_x - p2p_min_x) << 8) |
-		    ((p2p_addr_guess_y - p2p_min_y) << 0);
-	    sv->p2p_dims = p2p_dims = ((1 + p2p_max_x - p2p_min_x) << 8) |
-		    ((1 + p2p_max_y - p2p_min_y) << 0);
-	    sv->p2p_root = p2p_root = (-p2p_min_x << 8) | -p2p_min_y;
+            // Record the coordinates/dimensions discovered
+            sv->p2p_addr = p2p_addr = ((p2p_addr_guess_x - p2p_min_x) << 8) |
+                    ((p2p_addr_guess_y - p2p_min_y) << 0);
+            sv->p2p_dims = p2p_dims = ((1 + p2p_max_x - p2p_min_x) << 8) |
+                    ((1 + p2p_max_y - p2p_min_y) << 0);
+            sv->p2p_root = p2p_root = (-p2p_min_x << 8) | -p2p_min_y;
 
-	    sv->p2p_active += 1;
+            sv->p2p_active += 1;
 
-	    // Reseed uniquely for each chip
-	    sark_srand(p2p_addr);
+            // Reseed uniquely for each chip
+            sark_srand(p2p_addr);
 
-	    // Set our P2P addr in the comms controller
-	    cc[CC_SAR] = 0x07000000 + p2p_addr;
+            // Set our P2P addr in the comms controller
+            cc[CC_SAR] = 0x07000000 + p2p_addr;
 
-	    // Work out the local Ethernet connected chip coordinates
-	    compute_eth();
+            // Work out the local Ethernet connected chip coordinates
+            compute_eth();
 
-	    netinit_biff_tick_counter = 0;
-	    netinit_phase = NETINIT_PHASE_BIFF;
+            netinit_biff_tick_counter = 0;
+            netinit_phase = NETINIT_PHASE_BIFF;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_BIFF:
-	// The board information floodfill is allowed three 100Hz ticks. In
-	// the first tick, the board information is actually broadcast. In
-	// the second tick, nothing happens and in the third the state
-	// advances to the P2P table generation phase.
-	//
-	// The reason for using more than one tick is that the 10ms ticks
-	// around the machine are not aligned. As a result, some chips may be
-	// *almost* 10ms ahead of others. Since it is important that
-	// blacklisting information is broadcast ahead of P2P generation,
-	// leaving an extra "tick" before moving to the next state should
-	// deal with the problem. A third tick is left to allow extra leeway
-	// accounting for the fact that the timers are not necessarily
-	// *perfectly* aligned to within 10ms...
+        // The board information floodfill is allowed three 100Hz ticks. In
+        // the first tick, the board information is actually broadcast. In
+        // the second tick, nothing happens and in the third the state
+        // advances to the P2P table generation phase.
+        //
+        // The reason for using more than one tick is that the 10ms ticks
+        // around the machine are not aligned. As a result, some chips may be
+        // *almost* 10ms ahead of others. Since it is important that
+        // blacklisting information is broadcast ahead of P2P generation,
+        // leaving an extra "tick" before moving to the next state should
+        // deal with the problem. A third tick is left to allow extra leeway
+        // accounting for the fact that the timers are not necessarily
+        // *perfectly* aligned to within 10ms...
 
-	netinit_biff_tick_counter++;
+        netinit_biff_tick_counter++;
 
-	if (netinit_biff_tick_counter == 1) {
-	    if (sv->board_info) {
-		uint num_info_words = sv->board_info[0];
-		uint *info_word = sv->board_info + 1;
-		while (num_info_words--) {
-		    // Handle command on this chip
-		    nn_cmd_biff(0, 0, *(info_word));
-		    // Also flood to other chips on this board
-		    biff_nn_send(*(info_word++));
+        if (netinit_biff_tick_counter == 1) {
+            if (sv->board_info) {
+                uint num_info_words = sv->board_info[0];
+                uint *info_word = sv->board_info + 1;
+                while (num_info_words--) {
+                    // Handle command on this chip
+                    nn_cmd_biff(0, 0, *(info_word));
+                    // Also flood to other chips on this board
+                    biff_nn_send(*(info_word++));
                 }
             }
         } else if (netinit_biff_tick_counter >= 3) {
             netinit_p2p_tick_counter = 0;
             netinit_phase = NETINIT_PHASE_P2P_TABLE;
         }
-	break;
+        break;
 
     case NETINIT_PHASE_P2P_TABLE: {
-	// Broadcast P2P table generation packets, staggered by chip to
-	// reduce network load.
-	uint p2pb_period = ((p2p_dims >> 8) * (p2p_dims & 0xFF)) * P2PB_OFFSET_USEC;
-	if (netinit_p2p_tick_counter == 0) {
-	    hop_table[p2p_addr] = 0;
-	    rtr_p2p_set(p2p_addr, 7);
-	    timer_schedule_proc(p2pb_nn_send, 0, 0,
-		    (sark_rand() % p2pb_period) + 1);
-	}
+        // Broadcast P2P table generation packets, staggered by chip to
+        // reduce network load.
+        uint p2pb_period = ((p2p_dims >> 8) * (p2p_dims & 0xFF)) * P2PB_OFFSET_USEC;
+        if (netinit_p2p_tick_counter == 0) {
+            hop_table[p2p_addr] = 0;
+            rtr_p2p_set(p2p_addr, 7);
+            timer_schedule_proc(p2pb_nn_send, 0, 0,
+                    (sark_rand() % p2pb_period) + 1);
+        }
 
-	// Once all P2P messages have had ample time to send (and the
-	// required number of repeats have occurred), compute the level
-	// config and signalling broadcast spanning tree.
-	if (netinit_p2p_tick_counter++ >= (p2pb_period / 10000) + 2) {
-	    netinit_p2p_tick_counter = 0;
+        // Once all P2P messages have had ample time to send (and the
+        // required number of repeats have occurred), compute the level
+        // config and signalling broadcast spanning tree.
+        if (netinit_p2p_tick_counter++ >= (p2pb_period / 10000) + 2) {
+            netinit_p2p_tick_counter = 0;
 
-	    if (sv->p2pb_repeats-- == 0) {
-		netinit_phase = NETINIT_PHASE_DONE;
+            if (sv->p2pb_repeats-- == 0) {
+                netinit_phase = NETINIT_PHASE_DONE;
 
-		level_config();
-		compute_st();
-		sv->p2p_up = p2p_up = 1;
+                level_config();
+                compute_st();
+                sv->p2p_up = p2p_up = 1;
 
-		if (srom.flags & SRF_ETH) {
-		    uint s = phy_read(PHY_STATUS);
-		    sv->eth_up = (s & 4) >> 2;
-		    if (sv->eth_up) {
-			ethinit_phase = ETHINIT_PHASE_DONE;
-		    }
-		}
-	    }
-	}
-	break;
+                if (srom.flags & SRF_ETH) {
+                    uint s = phy_read(PHY_STATUS);
+                    sv->eth_up = (s & 4) >> 2;
+                    if (sv->eth_up) {
+                        ethinit_phase = ETHINIT_PHASE_DONE;
+                    }
+                }
+            }
+        }
+        break;
     }
 
     case NETINIT_PHASE_DONE:
     default:
-	// Unrecognised or finished state? Do nothing.
-	break;
+        // Unrecognised or finished state? Do nothing.
+        break;
     }
     sv->netinit_phase = netinit_phase;
 
     // Light the LED every-so-often to make it clear that this chip is alive
     if (netinit_phase == NETINIT_PHASE_DONE) {
-	static uint ticks = 0;
+        static uint ticks = 0;
 
-	uint p2p_x = p2p_addr >> 8;
-	uint p2p_y = p2p_addr & 0xFF;
-	uint p2p_dist = p2p_x + p2p_y;
-	uint flash_time = (p2p_dist * LIVENESS_FLASH_SPACING)
-		% LIVENESS_FLASH_INTERVAL;
-	if (ticks == flash_time) {
-	    disp_load = ((load < 128) ? 255 : 0) << LOAD_FRAC_BITS;
+        uint p2p_x = p2p_addr >> 8;
+        uint p2p_y = p2p_addr & 0xFF;
+        uint p2p_dist = p2p_x + p2p_y;
+        uint flash_time = (p2p_dist * LIVENESS_FLASH_SPACING)
+                % LIVENESS_FLASH_INTERVAL;
+        if (ticks == flash_time) {
+            disp_load = ((load < 128) ? 255 : 0) << LOAD_FRAC_BITS;
         }
 
-	if (++ticks >= LIVENESS_FLASH_INTERVAL) {
-	    ticks = 0;
+        if (++ticks >= LIVENESS_FLASH_INTERVAL) {
+            ticks = 0;
         }
     }
 
@@ -1280,15 +1281,15 @@ void proc_100hz(uint a1, uint a2)
 
     // Ping application CPUs to check on status
     if (sv->soft_wdog) {
-	soft_wdog(sv->soft_wdog);
+        soft_wdog(sv->soft_wdog);
     }
 
     // Send LTPC packet (untested!)
     if (sv->ltpc_period > 0 && ++ltpc_timer >= sv->ltpc_period) {
-	ltpc_timer = 0;
+        ltpc_timer = 0;
 
-	ff_nn_send((NN_CMD_LTPC << 24) + (0x3e00 << 8),
-		sv->tp_timer, 0x3f00, 0);
+        ff_nn_send((NN_CMD_LTPC << 24) + (0x3e00 << 8),
+                sv->tp_timer, 0x3f00, 0);
     }
 }
 
@@ -1301,43 +1302,43 @@ void proc_1khz(uint a1, uint a2)
 {
     // Display status on LED0 except when booting
     if (netinit_phase >= NETINIT_PHASE_DONE) {
-	if (sv->led_period == 1) {
-	    // sv->led_period == 1: Display current load using PWM
+        if (sv->led_period == 1) {
+            // sv->led_period == 1: Display current load using PWM
 
-	    // Slowly track the actual load value
-	    uint fractional_load = ((uint)load) << LOAD_FRAC_BITS;
-	    if (disp_load < fractional_load) {
-		disp_load++;
+            // Slowly track the actual load value
+            uint fractional_load = ((uint)load) << LOAD_FRAC_BITS;
+            if (disp_load < fractional_load) {
+                disp_load++;
             } else if (disp_load > fractional_load) {
-        	disp_load--;
+                disp_load--;
             }
 
-	    // PWM generation
-	    static uint period = 0;
-	    uint duty = disp_load >> (LOAD_FRAC_BITS + PWM_BITS);
+            // PWM generation
+            static uint period = 0;
+            uint duty = disp_load >> (LOAD_FRAC_BITS + PWM_BITS);
 
-	    // If there is *any* load, keep the LED on a little bit.
-	    if (disp_load > 0 && duty == 0) {
-		duty = 1;
-	    }
+            // If there is *any* load, keep the LED on a little bit.
+            if (disp_load > 0 && duty == 0) {
+                duty = 1;
+            }
 
-	    if (period >= duty) {
-		sark_led_set(LED_OFF(0));
-	    } else {
-		sark_led_set(LED_ON(0));
-	    }
+            if (period >= duty) {
+                sark_led_set(LED_OFF(0));
+            } else {
+                sark_led_set(LED_ON(0));
+            }
 
-	    if (++period >= (1 << PWM_BITS)) {
-		period = 0;
-	    }
-	} else if (sv->led_period >= 2) {
-	    // sv->led_period >= 2: Blink at a given frequency
-	    static uint last_toggle = 0;
-	    if (last_toggle++ > (sv->led_period * 10)) {
-		last_toggle = 0;
-		sark_led_set(LED_INV(0));	// !! assumes LED_0 always there
-	    }
-	}
+            if (++period >= (1 << PWM_BITS)) {
+                period = 0;
+            }
+        } else if (sv->led_period >= 2) {
+            // sv->led_period >= 2: Blink at a given frequency
+            static uint last_toggle = 0;
+            if (last_toggle++ > (sv->led_period * 10)) {
+                last_toggle = 0;
+                sark_led_set(LED_INV(0));	// !! assumes LED_0 always there
+            }
+        }
     }
 }
 
@@ -1350,13 +1351,13 @@ static uint pll_mult(uint freq)
     uint f = 0;
 
     if (freq >= 50) {
-	f = 1;
+        f = 1;
     }
     if (freq >= 100) {
-	f = 2;
+        f = 2;
     }
     if (freq >= 200) {
-	f = 3;
+        f = 3;
     }
 
     return f << 16;
@@ -1406,28 +1407,28 @@ void pll_init()
 void eth_setup()
 {
     if (srom.flags & SRF_ETH) {			// Ethernet present (possibly)
-	eth_init(srom.mac_addr);
-	sark_word_cpy(sv->ip_addr, srom.ip_addr, 4);
+        eth_init(srom.mac_addr);
+        sark_word_cpy(sv->ip_addr, srom.ip_addr, 4);
 
-	if (srom.flags & SRF_PHY_RST) {		// Hardware reset PHY
-	    phy_reset();
-	}
+        if (srom.flags & SRF_PHY_RST) {		// Hardware reset PHY
+            phy_reset();
+        }
 
-	if (srom.flags & SRF_PHY_INIT) {	// (Re-)initialise PHY
-	    phy_write(PHY_AUTO_ADV, 0x01e1);	// Allow 100/10 meg
-	    phy_write(PHY_CONTROL, 0x1200);	// Enable & restart auto-neg
-	}
+        if (srom.flags & SRF_PHY_INIT) {	// (Re-)initialise PHY
+            phy_write(PHY_AUTO_ADV, 0x01e1);	// Allow 100/10 meg
+            phy_write(PHY_CONTROL, 0x1200);	// Enable & restart auto-neg
+        }
 
-	while (srom.flags & SRF_PHY_WAIT) {	// Wait (without timeout)
-	    uint s = phy_read(PHY_STATUS);	// Read PHY status
-	    sv->eth_up = (s & 4) >> 2;		// Bit 2 says link up
-	    if (sv->eth_up) {
-		ethinit_phase = ETHINIT_PHASE_DONE;
-		break;
-	    }
-	    ethinit_phase = ETHINIT_PHASE_WAIT_1;
-	    event_run(1);
-	}
+        while (srom.flags & SRF_PHY_WAIT) {	// Wait (without timeout)
+            uint s = phy_read(PHY_STATUS);	// Read PHY status
+            sv->eth_up = (s & 4) >> 2;		// Bit 2 says link up
+            if (sv->eth_up) {
+                ethinit_phase = ETHINIT_PHASE_DONE;
+                break;
+            }
+            ethinit_phase = ETHINIT_PHASE_WAIT_1;
+            event_run(1);
+        }
     }
 }
 
@@ -1474,7 +1475,7 @@ void c_main(void)
     rtr_init(sark.phys_cpu);		// Initialise router
 
     if (sv->boot_delay) {		// If bootROM boot
-	boot_nn(sv->hw_ver);		// Flood fill neighbours
+        boot_nn(sv->hw_ver);		// Flood fill neighbours
     }
     boot_ap();				// Start local APs
 
@@ -1486,23 +1487,23 @@ void c_main(void)
     vic_setup();			// Set VIC, interrupts on
 
     if (sv->boot_delay) {
-	eth_setup();		        // Set up Ethernet if present
+        eth_setup();		        // Set up Ethernet if present
     }
 
     while (1) {				// Run event loop (forever...)
-	event_run(0);
+        event_run(0);
 
-	// interrupts must be disabled to avoid queue-access hazard
-	uint cpsr = cpu_int_disable();
+        // interrupts must be disabled to avoid queue-access hazard
+        uint cpsr = cpu_int_disable();
 
-	// check if queue is empty
-	if (event.proc_queue->proc_head == NULL) {
-	    // NB: interrupts will wake up the core even if disabled
-	    cpu_wfi();
-	}
+        // check if queue is empty
+        if (event.proc_queue->proc_head == NULL) {
+            // NB: interrupts will wake up the core even if disabled
+            cpu_wfi();
+        }
 
-	// re-enable interrupts to service them
-	cpu_int_restore(cpsr);
+        // re-enable interrupts to service them
+        cpu_int_restore(cpsr);
     }
 }
 

--- a/scamp/spinn_net.c
+++ b/scamp/spinn_net.c
@@ -25,14 +25,22 @@ extern iptag_t tag_table[];
 
 const uchar bc_mac[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 const uchar zero_mac[] = {0, 0, 0, 0, 0, 0};
+const uchar zero_ip[] = {0, 0, 0, 0};
 
+#define MAX_ARP_ENTRIES 5
+static struct arp_entry {
+    uchar mac[6];
+    uchar ip[4];
+    struct arp_entry *next;
+} arp_entries[MAX_ARP_ENTRIES];
+static uint next_arp_entry = MAX_ARP_ENTRIES;
 
 #ifdef LOCK_ETH
 
 static void lock_get(uint lock)
 {
     while (sc[SC_TAS0 + lock] & BIT_31) {
-	continue;
+        continue;
     }
 }
 
@@ -70,15 +78,15 @@ void eth_init(uchar *mac)
 uint ipsum(uchar *d, uint len, uint sum) // Use shorts for speed??
 {
     if (len & 1) {
-	sum += d[--len] << 8;
+        sum += d[--len] << 8;
     }
 
     for (uint i = 0; i < len; i += 2) {
-	sum += (d[i] << 8) + d[i+1];
+        sum += (d[i] << 8) + d[i+1];
     }
 
     while (sum >> 16) {
-	sum = (sum >> 16) + (sum & 0xffff);
+        sum = (sum >> 16) + (sum & 0xffff);
     }
 
     return sum;
@@ -145,13 +153,13 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-	continue;
+        continue;
     }
 
     sark_word_cpy(eth_tx_ram, buf, len);
 
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -170,7 +178,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-	continue;
+        continue;
     }
 
     memcpy(eth_tx_ram, hdr, hdr_len);
@@ -178,7 +186,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
     uint len = buf_len + hdr_len;
     if (len < 60) {
-	len = 60;
+        len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -191,7 +199,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
 
 void send_arp_pkt(uchar *buf, const uchar *dest, const uchar *tha,
-	const uchar *tpa, uint type)
+        const uchar *tpa, uint type)
 {
     arp_pkt_t *arp = (arp_pkt_t *) (buf + MAC_HDR_SIZE);
 
@@ -213,6 +221,17 @@ void send_arp_pkt(uchar *buf, const uchar *dest, const uchar *tha,
 
 void arp_lookup(iptag_t *iptag)
 {
+
+    for (uint i = 0; i < MAX_ARP_ENTRIES; i++) {
+        if (cmp_ip(iptag->ip, arp_entries[i].ip)) {
+            copy_mac(arp_entries[i].mac, iptag->mac);
+            uint f = iptag->flags;
+            f &= ~IPFLAG_ARP;
+            iptag->flags = f | IPFLAG_VALID;
+            return;
+        }
+    }
+
     uchar buf[42];
 
     uchar *ip_addr = iptag->ip;
@@ -223,7 +242,7 @@ void arp_lookup(iptag_t *iptag)
     uchar *target_ip = ip_addr;
 
     if ((*my_ip & *mask) != (*ip & *mask)) {
-	target_ip = srom.gw_addr;
+        target_ip = srom.gw_addr;
     }
 
     copy_ip(target_ip, iptag->mac); // !! Bodge - target IP in MAC field!
@@ -241,34 +260,44 @@ void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size)
     eth_discard();
 
     if (! cmp_ip(arp->tpa, srom.ip_addr)) { // Ignore unless TPA matches
-	return;
+        return;
     }
 
     uint op = ntohs(arp->op);
     if (op == ARP_REQ) {
-	send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
+        send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
     } else if (op == ARP_REPLY) {	// Reply & TPA matches
-	iptag_t *tt = tag_table;
+        arp_add(arp->sha, arp->spa);
+        iptag_t *tt = tag_table;
 
-	for (uint i = 0; i < tag_table_size; i++) {
-	    uint f = tt->flags;
-	    if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
-		copy_mac(arp->sha, tt->mac);
-		f &= ~IPFLAG_ARP;
-		tt->flags = f | IPFLAG_VALID;
-		break;
-	    }
-	    tt++;
-	}
+        for (uint i = 0; i < tag_table_size; i++) {
+            uint f = tt->flags;
+            if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
+                copy_mac(arp->sha, tt->mac);
+                f &= ~IPFLAG_ARP;
+                tt->flags = f | IPFLAG_VALID;
+                break;
+            }
+            tt++;
+        }
     }
+}
+
+void arp_add(uchar *mac, uchar* ip) {
+    next_arp_entry += 1;
+    if (next_arp_entry >= MAX_ARP_ENTRIES) {
+        next_arp_entry = 0;
+    }
+    copy_mac(mac, arp_entries[next_arp_entry].mac);
+    copy_ip(ip, arp_entries[next_arp_entry].ip);
 }
 
 
 void icmp_pkt(uchar *rx_pkt, uint rx_len)
 {
     if (rx_len > 138) {		// MAC 14, IP_HDR 60, ICMP 64
-	eth_discard();
-	return;
+        eth_discard();
+        return;
     }
 
     uchar buf[138];
@@ -277,30 +306,30 @@ void icmp_pkt(uchar *rx_pkt, uint rx_len)
 
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (buf + IP_HDR_OFFSET);
     if (!cmp_ip(ip_hdr->dest, srom.ip_addr)) {
-	return;
+        return;
     }
 
     uint ip_hdr_len = (ip_hdr->ver_len & 15) * 4;
     icmp_hdr_t *icmp = (icmp_hdr_t *) (buf + IP_HDR_OFFSET + ip_hdr_len);
 
     if (icmp->type == ICMP_ECHO_REQ) {
-	uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
+        uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
 
-	copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
+        copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
 
-	if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
-	    icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);	// 'new' ICMP hdr
-	    sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
-	}
+        if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
+            icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);	// 'new' ICMP hdr
+            sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
+        }
 
-	icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
-	icmp->code = 0;				// ICMP code = 0
-	icmp->checksum = 0;
+        icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
+        icmp->code = 0;				// ICMP code = 0
+        icmp->checksum = 0;
 
-	uint sum = ipsum((uchar *) icmp, icmp_len, 0);
-	icmp->checksum = htons(~sum);
+        uint sum = ipsum((uchar *) icmp, icmp_len, 0);
+        icmp->checksum = htons(~sum);
 
-	eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
+        eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
     }
 }
 

--- a/scamp/spinn_net.c
+++ b/scamp/spinn_net.c
@@ -40,7 +40,7 @@ static uint next_arp_entry = MAX_ARP_ENTRIES;
 static void lock_get(uint lock)
 {
     while (sc[SC_TAS0 + lock] & BIT_31) {
-        continue;
+	continue;
     }
 }
 
@@ -78,15 +78,15 @@ void eth_init(uchar *mac)
 uint ipsum(uchar *d, uint len, uint sum) // Use shorts for speed??
 {
     if (len & 1) {
-        sum += d[--len] << 8;
+	sum += d[--len] << 8;
     }
 
     for (uint i = 0; i < len; i += 2) {
-        sum += (d[i] << 8) + d[i+1];
+	sum += (d[i] << 8) + d[i+1];
     }
 
     while (sum >> 16) {
-        sum = (sum >> 16) + (sum & 0xffff);
+	sum = (sum >> 16) + (sum & 0xffff);
     }
 
     return sum;
@@ -153,13 +153,13 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-        continue;
+	continue;
     }
 
     sark_word_cpy(eth_tx_ram, buf, len);
 
     if (len < 60) {
-        len = 60;
+	len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -178,7 +178,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 #endif
 
     while (er[ETH_STATUS] & 1) {
-        continue;
+	continue;
     }
 
     memcpy(eth_tx_ram, hdr, hdr_len);
@@ -186,7 +186,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
     uint len = buf_len + hdr_len;
     if (len < 60) {
-        len = 60;
+	len = 60;
     }
 
     er[ETH_TX_LEN] = len;
@@ -199,7 +199,7 @@ void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len)
 
 
 void send_arp_pkt(uchar *buf, const uchar *dest, const uchar *tha,
-        const uchar *tpa, uint type)
+	const uchar *tpa, uint type)
 {
     arp_pkt_t *arp = (arp_pkt_t *) (buf + MAC_HDR_SIZE);
 
@@ -223,13 +223,13 @@ void arp_lookup(iptag_t *iptag)
 {
 
     for (uint i = 0; i < MAX_ARP_ENTRIES; i++) {
-        if (cmp_ip(iptag->ip, arp_entries[i].ip)) {
-            copy_mac(arp_entries[i].mac, iptag->mac);
-            uint f = iptag->flags;
-            f &= ~IPFLAG_ARP;
-            iptag->flags = f | IPFLAG_VALID;
-            return;
-        }
+	if (cmp_ip(iptag->ip, arp_entries[i].ip)) {
+	    copy_mac(arp_entries[i].mac, iptag->mac);
+	    uint f = iptag->flags;
+	    f &= ~IPFLAG_ARP;
+	    iptag->flags = f | IPFLAG_VALID;
+	    return;
+	}
     }
 
     uchar buf[42];
@@ -242,7 +242,7 @@ void arp_lookup(iptag_t *iptag)
     uchar *target_ip = ip_addr;
 
     if ((*my_ip & *mask) != (*ip & *mask)) {
-        target_ip = srom.gw_addr;
+	target_ip = srom.gw_addr;
     }
 
     copy_ip(target_ip, iptag->mac); // !! Bodge - target IP in MAC field!
@@ -260,33 +260,33 @@ void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size)
     eth_discard();
 
     if (! cmp_ip(arp->tpa, srom.ip_addr)) { // Ignore unless TPA matches
-        return;
+	return;
     }
 
     uint op = ntohs(arp->op);
     if (op == ARP_REQ) {
-        send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
+	send_arp_pkt(buf, buf+6, arp->sha, arp->spa, ARP_REPLY);
     } else if (op == ARP_REPLY) {	// Reply & TPA matches
-        arp_add(arp->sha, arp->spa);
-        iptag_t *tt = tag_table;
+	arp_add(arp->sha, arp->spa);
+	iptag_t *tt = tag_table;
 
-        for (uint i = 0; i < tag_table_size; i++) {
-            uint f = tt->flags;
-            if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
-                copy_mac(arp->sha, tt->mac);
-                f &= ~IPFLAG_ARP;
-                tt->flags = f | IPFLAG_VALID;
-                break;
-            }
-            tt++;
-        }
+	for (uint i = 0; i < tag_table_size; i++) {
+	    uint f = tt->flags;
+	    if ((f & IPFLAG_ARP) && cmp_ip(arp->spa, tt->mac)) { // !! Bodge
+		copy_mac(arp->sha, tt->mac);
+		f &= ~IPFLAG_ARP;
+		tt->flags = f | IPFLAG_VALID;
+		break;
+	    }
+	    tt++;
+	}
     }
 }
 
 void arp_add(uchar *mac, uchar* ip) {
     next_arp_entry += 1;
     if (next_arp_entry >= MAX_ARP_ENTRIES) {
-        next_arp_entry = 0;
+	next_arp_entry = 0;
     }
     copy_mac(mac, arp_entries[next_arp_entry].mac);
     copy_ip(ip, arp_entries[next_arp_entry].ip);
@@ -296,8 +296,8 @@ void arp_add(uchar *mac, uchar* ip) {
 void icmp_pkt(uchar *rx_pkt, uint rx_len)
 {
     if (rx_len > 138) {		// MAC 14, IP_HDR 60, ICMP 64
-        eth_discard();
-        return;
+	eth_discard();
+	return;
     }
 
     uchar buf[138];
@@ -306,30 +306,30 @@ void icmp_pkt(uchar *rx_pkt, uint rx_len)
 
     ip_hdr_t *ip_hdr = (ip_hdr_t *) (buf + IP_HDR_OFFSET);
     if (!cmp_ip(ip_hdr->dest, srom.ip_addr)) {
-        return;
+	return;
     }
 
     uint ip_hdr_len = (ip_hdr->ver_len & 15) * 4;
     icmp_hdr_t *icmp = (icmp_hdr_t *) (buf + IP_HDR_OFFSET + ip_hdr_len);
 
     if (icmp->type == ICMP_ECHO_REQ) {
-        uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
+	uint icmp_len = ntohs(ip_hdr->length) - ip_hdr_len; // Size of ICMP hdr+data
 
-        copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
+	copy_ip_hdr(ip_hdr->srce, PROT_ICMP, ip_hdr, icmp_len + IP_HDR_SIZE);
 
-        if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
-            icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);	// 'new' ICMP hdr
-            sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
-        }
+	if (ip_hdr_len > IP_HDR_SIZE) {		// Copy down ICMP header & data
+	    icmp = (icmp_hdr_t *) (buf + IP_DATA_OFFSET);	// 'new' ICMP hdr
+	    sark_mem_cpy((uchar *) icmp, (uchar *) icmp + ip_hdr_len, icmp_len);
+	}
 
-        icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
-        icmp->code = 0;				// ICMP code = 0
-        icmp->checksum = 0;
+	icmp->type = ICMP_ECHO_REPLY;		// ICMP reply
+	icmp->code = 0;				// ICMP code = 0
+	icmp->checksum = 0;
 
-        uint sum = ipsum((uchar *) icmp, icmp_len, 0);
-        icmp->checksum = htons(~sum);
+	uint sum = ipsum((uchar *) icmp, icmp_len, 0);
+	icmp->checksum = htons(~sum);
 
-        eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
+	eth_transmit(buf, IP_DATA_OFFSET + icmp_len, ETYPE_IP, buf+6);
     }
 }
 

--- a/scamp/spinn_net.h
+++ b/scamp/spinn_net.h
@@ -103,7 +103,7 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest);
 void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len);
 
 void send_arp_pkt(uchar *buf, const uchar *dest,
-                  const uchar *tha, const uchar *tpa, uint type);
+		  const uchar *tha, const uchar *tpa, uint type);
 void arp_lookup(iptag_t *iptag);
 void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size);
 void arp_add(uchar *mac, uchar *ip);

--- a/scamp/spinn_net.h
+++ b/scamp/spinn_net.h
@@ -103,9 +103,10 @@ void eth_transmit(uchar *buf, uint len, uint type, const uchar *dest);
 void eth_transmit2(uchar *hdr, uchar *buf, uint hdr_len, uint buf_len);
 
 void send_arp_pkt(uchar *buf, const uchar *dest,
-		  const uchar *tha, const uchar *tpa, uint type);
+                  const uchar *tha, const uchar *tpa, uint type);
 void arp_lookup(iptag_t *iptag);
 void arp_pkt(uchar *rx_pkt, uint rx_len, uint tag_table_size);
+void arp_add(uchar *mac, uchar *ip);
 
 void icmp_pkt(uchar *rx_pkt, uint rx_len);
 void copy_udp(uchar *buf, uint len, uint dest, uint srce);


### PR DESCRIPTION
This adds an ARP cache to SCAMP, which is pre-populated on receipt of an SDP message, and used when ARP is needed.  This avoids issues with setting up IP tags from a host where the host is not technically on the same subnet as the machine (e.g. the machine thinks it has 192.168.240.254 on 255.255.255.0, but the host is 192.168.1.100 on 255.255.0.0 - at which point SCAMP currently attempts to send to the "default gateway" of 192.168.240.253, which doesn't exist).