### PR TITLE
bug fix: correct p2p-related variable update by monitor delegate.

### DIFF
--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1647,10 +1647,14 @@ void c_main(void)
 	queue_init();			// Initialise various queues
 	nn_init();			// Initialise NN package
 	
-	// Record the coordinates/dimensions discovered by previous monitor
+	// recover the coordinates/dimensions discovered by previous monitor
 	p2p_addr = sv->p2p_addr;
+	p2p_dims = sv->p2p_dims;
+	p2p_root = sv->p2p_root;
+	p2p_up   = sv->p2p_up;
+
+	// (re-)construct the level/region information (not in shared memory)
 	level_config();
-	p2p_up = sv->p2p_up;
 
 	// Reseed uniquely for each chip
 	sark_srand(p2p_addr);


### PR DESCRIPTION
When monitor delegation happens, the delegate has to update some of its local variables from variable 'sv' in shared memory. Variables 'p2p_dims' and 'p2p_root' were not updated. This has been fixed.
