### PR TITLE
Signal count fix

### DIFF
--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -258,7 +258,7 @@ uint pkt_tx(uint tcr, uint data, uint key)
     }
 
     if (txq->count == 0) {
-	    vic[VIC_ENABLE] = 1 << CC_TMT_INT;
+	vic[VIC_ENABLE] = 1 << CC_TMT_INT;
     }
 
     txq->count++;
@@ -678,8 +678,14 @@ void proc_route_msg(uint arg1, uint srce_ip)
 
     uint dest_port = msg->dest_port >> PORT_SHIFT;
     if (dest_port == 0) {
-	msg->length = 12 + scamp_debug(msg, srce_ip);
-	return_msg(msg, 0);
+	uint len = scamp_debug(msg, srce_ip);
+
+        // a 'wrong' length indicates that the return
+	// message should not be sent at this time.
+	if (len <= SDP_BUF_SIZE) {
+	    msg->length = 12 + len;  // !!const
+	    return_msg(msg, 0);
+	}
     } else {
 	return_msg(msg, RC_PORT);	// APs should not do this!!
     }

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -451,6 +451,9 @@ void proc_ret_msg(uint arg1, uint level)
     } else {
         return_msg(msg, RC_P2P_NOREPLY);
     }
+
+    //NB: clear result just in case
+    levels[level].result = 0;
 }
 
 
@@ -484,7 +487,7 @@ void proc_send(uint data, uint mask)
 
     // schedule the sending of the return message in plenty of time
     if (mask & 0xffff0000) {
-        timer_schedule_proc(proc_gather, level, mode, 250 * (4 - level));
+        timer_schedule_proc(proc_gather, level, mode, 500 * (4 - level));
     }
 }
 
@@ -496,6 +499,9 @@ void proc_gather(uint level, uint mode)
     uint d = (mode << 20) + ((level - 1) << 26) + levels[level].result;
 
     p2p_send_reg(APP_RET << 22, srce, d);
+
+    //NB: clear result just in case
+    levels[level].result = 0;
 }
 
 

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -358,7 +358,6 @@ extern uint p2p_root;
 extern uint p2p_up;
 extern uint link_en;
 extern uint num_cpus;
-extern uchar v2p_map[MAX_CPUS];
 
 extern uint* hop_table;
 

--- a/tools/ybug
+++ b/tools/ybug
@@ -734,6 +734,7 @@ sub cmd_app_sig
 
     return "bad app_id" unless $app_id >=0 && $app_id <= 255;
 
+    my $save_region = $region;
     $region = parse_region ($region);
 
     return "bad region" if $region == 0;
@@ -775,23 +776,49 @@ sub cmd_app_sig
     printf "Type %d data %08x mask %08x\n", $type, $data, $mask if $debug;
     printf "Region %08x signal %d state %d\n", $region, $signal, $state if $debug;
 
-    eval
+    if ($type == 1)
     {
-        my $data = $spin->signal ($type, $data, $mask, addr => []);
+	my $xb = $region >> 24;
+	my $yb = ($region >> 16) & 0xfc;
 
-        if ($type == 1)
-        {
-            my $r = unpack "V", $data;
-            if ($signal == 18) # Count
-            {
-                printf "Count %d\n", $r;
-            }
-            else
-            {
-                printf "Mask 0x%08x\n", $r;
-            }
-        }
-    };
+	# find a working chip in the target region (try at most 16 addresses)
+	for (my $i = 0; $i < 16; $i++)
+	{
+	    my $addr = [$xb + ($i >> 2), $yb + ($i & 3), 0];
+	    my $res;
+
+	    eval
+	    {
+		$res = $spin->signal ($type, $data, $mask, addr => $addr);
+	    };
+
+	    if (index($@, "RC_") != -1)
+	    {
+		next;
+	    };
+
+	    my $r = unpack "V", $res;
+	    if ($signal == 18) # Count
+	    {
+		printf "Count %d\n", $r;
+	    }
+	    else
+	    {
+		printf "Mask 0x%08x\n", $r;
+	    }
+
+	    return $@;
+	}
+
+	printf "Region $save_region is unreachable\n";
+    }
+    else
+    {
+	eval
+	{
+	    my $data = $spin->signal ($type, $data, $mask, addr => []);
+	};
+    }
 
     return $@;
 }

--- a/tools/ybug
+++ b/tools/ybug
@@ -792,6 +792,11 @@ sub cmd_app_sig
 		$res = $spin->signal ($type, $data, $mask, addr => $addr);
 	    };
 
+	    if (index($@, "retries") != -1)
+	    {
+		return $@;
+	    };
+
 	    if (index($@, "RC_") != -1)
 	    {
 		next;


### PR DESCRIPTION
This pull request fixes a reliability issue with signal 'count'. The current implementation of signal handling on scamp is based on 'timed events', which run with interrupts disabled. Some of these timed events can take a long time to execute and may lead to point-to-point (p2p) packet loss and wrong counts.

The fix implemented here uses 'events', which execute with interrupts enabled, reducing the risk of packet loss (on SpiNNaker, packet delivery can not be guaranteed).

This pull request also fixes issue #74, related to the handling of signal regions in ybug.