### PR TITLE
add inter-chip link checks before P2P table setup

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -12,7 +12,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"3.2.2"
-#define	SLLT_VER_NUM	0x030202
+#define	SLLT_VER_STR	"3.2.3"
+#define	SLLT_VER_NUM	0x030203
 
 #endif

--- a/release.txt
+++ b/release.txt
@@ -4,6 +4,17 @@
 #
 #-------------------------------------------------------------------------------
 
+Version 3.2.3 - Bug fixing
+
+Bug fix:
+
+* SCAMP: the state of the inter-chip links is checked before P2P table
+  setup to avoid using a broken link as part of a P2P route. Note that
+  links can be working in one direction but broken in the reverse one.
+
+#-------------------------------------------------------------------------------
+
+
 Version 3.2.2 - Refactoring
 
 Refactoring:

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -1087,7 +1087,7 @@ void nn_cmd_biff(uint x, uint y, uint data)
 
 	// disable blacklisted links
 	// NB: blacklisted links are given as '1'
-	sv->link_en = link_en = ((~data) >> 18) & 0x3f;
+	sv->link_en = link_en = ((~data) >> 18) & link_en;
 
         // remember blacklisted cores
 	uint dead_cores = data & 0x3ffff;


### PR DESCRIPTION
The state of the inter-chip links is checked before P2P table setup to avoid using a broken link as part of a P2P route. Note that links can be working in one direction but broken in the reverse one.
