### PR TITLE
P2P table setup correction

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -12,7 +12,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define	SLLT_VER_STR	"3.2.3"
-#define	SLLT_VER_NUM	0x030203
+#define	SLLT_VER_STR	"3.2.4"
+#define	SLLT_VER_NUM	0x030204
 
 #endif

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -829,7 +829,7 @@ uint nn_cmd_p2pb(uint id, uint data, uint link)
 	(hops < table_hops) &&
 	(link_en & (1 << link))) {
 
-        // keep a count of reported P2P addresses 
+        // keep a count of P2P addresses we've heard of
 	if (table_hops == 0xffff) {
 	    sv->p2p_active++;
 	}

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -805,14 +805,14 @@ void nn_cmd_sig1(uint data, uint key)
 // P2P Broadcast - used to propagate P2P addresses and maintain the P2P
 // routing table.
 
-// Two additional tables are kept with entries for each possible address.
-// The "hop table" contains the number of hops to the address (initialised
-// with 65535) and the "id table" contains the last ID that was used to
-// update the tables (initialised to 128)
+// Table "hop_table" has entries of type (id << 24, hops) for each possible
+// P2P address. Field "hops" contains the number of hops to the address
+// (initialised to 65535) and "id" contains the ID of the last packet
+// used to update the table (initialised to 128).
 
-// An update occurs when a packet with a new ID arrives or a packet with a
-// lower hop count than the current one via an enabled link. The link on which
-// the packet arrived is used to update the P2P routing table.
+// An update occurs when a packet with a lower hop count than the current
+// one arrives via an enabled link. The link on which the packet arrived
+// is used to update the P2P routing table.
 
 // Returns data with P2P_STOP_BIT set if the packet should not be propagated
 
@@ -823,12 +823,13 @@ uint nn_cmd_p2pb(uint id, uint data, uint link)
     uint addr = data >> 16;
     uint hops = data & 0x3ff;	// Bottom 10 bits
 
-    uint table_id = hop_table[addr] >> 24;
     uint table_hops = hop_table[addr] & 0xffff;
 
     if (addr != p2p_addr &&
-	    (id != table_id || hops < table_hops) &&
-	    (link_en & (1 << link))) {
+	(hops < table_hops) &&
+	(link_en & (1 << link))) {
+
+        // keep a count of reported P2P addresses 
 	if (table_hops == 0xffff) {
 	    sv->p2p_active++;
 	}


### PR DESCRIPTION
During P2P table setup, sc&mp keeps a table with 'hop count'/'packet id' to every P2P address seen. On branch 'master', the table is updated when a packet for a P2P address is received and either has a lower 'hop count' or a different 'packet id'.

It seems that the update on a new 'packet id' is an attempt at fault tolerance with the assumption that a newer 'packet id' may have come through a different (potentially longer) route in the presence of a new hardware fault. Using a longer route is not fatal, as such, but it can lead to the presence of loops in the route, which *is* fatal. Additionally, adopting a longer route without good reason makes the algorithm less robust to packet loss, which is much more likely to happen that a dynamic hardware failure.

For these reasons, the algorithm in this pull request updates the table only on the reception of a lower hop count.