### PR TITLE
Jenkins

### DIFF
--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -96,7 +96,7 @@ uint cmd_iptag(sdp_msg_t *msg, uint srce_ip)
 
 	if (tag != TAG_NONE) {
 	    iptag_t *tt = tag_table + tag;
-            iptag_t *source_tag = tag_table + msg->tag;
+	    iptag_t *source_tag = tag_table + msg->tag;
 
 	    sark_word_set(tt, 0, sizeof(iptag_t));
 
@@ -116,12 +116,12 @@ uint cmd_iptag(sdp_msg_t *msg, uint srce_ip)
 	    if (msg->arg3 != 0) {
 		uchar *ip_addr = (uchar *) &msg->arg3;
 		copy_ip(ip_addr, tt->ip);
-	    } else if (!(flags & IPFLAG_REV)) {
-	        if (flags & IPFLAG_USE_SENDER) {
-	            copy_ip(source_tag->ip, tt->ip);
-	        } else {
+	    } else if (! (flags & IPFLAG_REV)) {
+		if (flags & IPFLAG_USE_SENDER) {
+		    copy_ip(source_tag->ip, tt->ip);
+		} else {
 		    copy_ip((uchar *) &srce_ip, tt->ip);
-	        }
+		}
 	    }
 
 	    if (flags & IPFLAG_REV) {
@@ -129,11 +129,11 @@ uint cmd_iptag(sdp_msg_t *msg, uint srce_ip)
 
 		tt->flags |= IPFLAG_VALID;
 	    } else {
-	        if (flags & IPFLAG_USE_SENDER) {
-	            tt->tx_port = source_tag->tx_port;
-	        } else {
+		if (flags & IPFLAG_USE_SENDER) {
+		    tt->tx_port = source_tag->tx_port;
+		} else {
 		    tt->tx_port = msg->arg2 & 0xffff;
-	        }
+		}
 
 		tt->flags |= IPFLAG_ARP;
 		arp_lookup(tt);
@@ -167,11 +167,6 @@ uint cmd_iptag(sdp_msg_t *msg, uint srce_ip)
 	return 4;
     } else if (op == IPTAG_CLR) {
 	tag_table[tag].flags = 0;
-    } else { // IPTAG_LKP
-        iptag_t *tt = tag_table + msg->tag;
-        msg->arg1 = tt->tx_port;
-        copy_ip(tt->ip, (uchar*) &msg->arg2);
-
     }
 
     return 0;

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -39,13 +39,16 @@
 #define IPTAG_GET		2
 #define IPTAG_CLR		3
 #define IPTAG_TTO		4
+#define IPTAG_LKP               5
 
-#define IPTAG_MAX		4
+#define IPTAG_MAX		5
+
 
 #define IPFLAG_VALID		0x8000	// Entry is valid
 #define IPFLAG_TRANS		0x4000	// Entry is transient
 #define IPFLAG_ARP		0x2000	// Awaiting ARP resolution
 
+#define IPFLAG_USE_SENDER       0x0400  // Use sender address and port
 #define IPFLAG_REV		0x0200  // Reverse IPTag
 #define IPFLAG_STRIP		0x0100  // Strip SDP headers
 

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -39,10 +39,8 @@
 #define IPTAG_GET		2
 #define IPTAG_CLR		3
 #define IPTAG_TTO		4
-#define IPTAG_LKP               5
 
-#define IPTAG_MAX		5
-
+#define IPTAG_MAX		4
 
 #define IPFLAG_VALID		0x8000	// Entry is valid
 #define IPFLAG_TRANS		0x4000	// Entry is transient


### PR DESCRIPTION
This adds an option to allow the use of the IP address and port of the sender of a tag when setting up the tag.  This then works through a NAT firewall (provided the sender of the tag will be the receiver of the data).