### PR TITLE
make ybug 'app_sig' command more robust

### DIFF
--- a/tools/ybug
+++ b/tools/ybug
@@ -750,13 +750,12 @@ sub cmd_app_sig
         $state = $state{$state};
     }
 
+    my $level = ($region >> 16) & 3;
     my $data = ($app_mask << 8) + $app_id;
     my $mask = $region & 0xffff;
 
     if ($type == 1)
     {
-        my $level = ($region >> 16) & 3;
-
         my ($op, $mode) = (2, 2);	# sig, sum
         $op = 1 if $signal >= 16;	# stat
 
@@ -782,9 +781,11 @@ sub cmd_app_sig
 	my $yb = ($region >> 16) & 0xfc;
 
 	# find a working chip in the target region (try at most 16 addresses)
+	my $inc = ($level == 3) ? 1 : 2;  # if possible, spread out target chips
+	
 	for (my $i = 0; $i < 16; $i++)
 	{
-	    my $addr = [$xb + ($i >> 2), $yb + ($i & 3), 0];
+	    my $addr = [$xb + ($inc * ($i >> 2)), $yb + ($inc * ($i & 3)), 0];
 	    my $res;
 
 	    eval


### PR DESCRIPTION
In SpiNNaker machines without wrap around there are 'half-hexagon' holes around the periphery, i.e., there are areas with 22 or 26 missing neighbouring chips.

When executing 'app_sig', 'ybug' may retry the command up to 16 times, each time addressing a different chip within the target region. The current implementation of 'ybug' uses 16 neighbouring chips in a 4x4 area. This means that the 'app_sig' command will fail if all 16 chips fall into a 'half-hexagon' hole.

This pull request spreads the 16 chips, for level-0 to level-2 region 'app_sig' commands, into an 8x8 area, guaranteed to be larger that any periphery hole.

Note that, if the 'app_sig' command targets a level-3 region, the 16 chips must be in a 4x4 area, because that is the size of a level-3 region. If the region falls within a periphery hole then the 'app_sig' will ***correctly*** fail with an 'RC_ROUTE' error, given that there is no route to any of the chips in that region.