### PR TITLE
Update to Xenial from Trusty for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,11 @@ addons:
       - freeglut3-dev
 
 install:
-  - export SPINN_DIRS=$PWD SPINN_PATH=$SPINN_DIRS/tools/boot PATH=$SPINN_DIRS/tools:$PATH PERL5LIB=$SPINN_DIRS/tools:$PERL5LIB GCC_COLORS='error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:diff-hunk=32:diff-delete=31:diff-insert=32'
+  - export SPINN_DIRS=$PWD
+  - export SPINN_PATH=$SPINN_DIRS/tools/boot
+  - export PATH=$SPINN_DIRS/tools:$PATH
+  - export PERL5LIB=$SPINN_DIRS/tools:$PERL5LIB
+  - export GCC_COLORS='error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:diff-hunk=32:diff-delete=31:diff-insert=32'
 
 before_script:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: c
 
 addons:
@@ -10,13 +10,12 @@ addons:
       - freeglut3-dev
 
 install:
-  - export SPINN_DIRS=`pwd -P`
-  - export SPINN_PATH=$SPINN_DIRS/tools/boot
-  - export PATH=$SPINN_DIRS/tools:$PATH
-  - export PERL5LIB=$SPINN_DIRS/tools:$PERL5LIB
+  - export SPINN_DIRS=$PWD SPINN_PATH=$SPINN_DIRS/tools/boot PATH=$SPINN_DIRS/tools:$PATH PERL5LIB=$SPINN_DIRS/tools:$PERL5LIB GCC_COLORS='error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:diff-hunk=32:diff-delete=31:diff-insert=32'
 
 before_script:
   - git clone https://github.com/SpiNNakerManchester/SupportScripts.git support
+  # Work around ludicrous Travis bug
+  - python support/travis_blocking_stdout.py
 
 script:
   - make
@@ -26,6 +25,7 @@ script:
   - make -C apps/hello_cpp
   - make -C apps/life
   - make -C apps/pt_demo
+  # These profiles are carefully chosen
   - support/run-vera.sh sark
   - support/run-vera.sh scamp --profile spinnaker-asm.tcl
   - support/run-vera.sh spin1_api


### PR DESCRIPTION
This has already been trialled for other repositories, and is required because the version of GCC in Trusty doesn't support ISO C11.