### PR TITLE
Fix p2p busy wait

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -909,7 +909,7 @@ SV_SV       +-------------------------------+   f5007f00
 SV_VECTORS  +-------------------------------+   f5007ee0
             | 64 bytes                      |
 SV_RANDOM   +-------------------------------+   f5007ea0
-            | xxx bytes                     |
+            | 1440 bytes                    |
 SV_SPARE    +-------------------------------+   f5007900
             | NUM_CPUS * VCPU_SIZE          |
 SV_VCPU     +-------------------------------+   f5007000 sv->sysram_top
@@ -2522,7 +2522,7 @@ uint event_user (uint arg1, uint arg2);
 
 /*!
 Schedule an event to occur at some time in the future. Requires that
-the second timer has been set up by a call to timer_register.
+(hardware) TIMER2 has been set up by a call to timer_register.
 
 NOTE: this procedure assumes the following event conditions on entry:
 e->next == NULL

--- a/include/sark.h
+++ b/include/sark.h
@@ -552,6 +552,10 @@ SDP message definition
 Note that the length field is the number of bytes following the
 checksum. It will be a minimum of 8 as the SDP header should always
 be present.
+
+NOTE: make sure to comply with 'sark_block_init()' requirements:
+    1. size must be a non-zero multiple of 4 bytes.
+    2. first field must be a pointer to same struct type.
 */
 
 typedef struct sdp_msg {        // SDP message - 292 bytes
@@ -760,9 +764,13 @@ the event is invoked, the proc is called with the two supplied
 arguments. Queues of events are maintained either on a timer queue for
 events which have to occur at a particular time or on a set of
 priority ordered queues for events which are processed by a scheduler.
+
+NOTE: make sure to comply with 'sark_block_init()' requirements:
+    1. size must be a non-zero multiple of 4 bytes.
+    2. first field must be a pointer to same struct type.
 */
 
-typedef struct event {          // 24 bytes
+typedef struct event {          // 28 bytes
     struct event *next;         //!< Next in Q or NULL
 
     event_proc proc;            //!< Proc to be called or NULL
@@ -771,6 +779,11 @@ typedef struct event {          // 24 bytes
     uint time;                  //!< Time (CPU ticks) until event due
                                 //!< (or 0 if at head of Q)
     uint ID;                    //!< Unique ID for active event (0 if inactive)
+
+    uchar reuse;                //!< do not free event after queue processing
+    uchar __PAD1;               //!< (spare - included for correct size)
+    uchar __PAD2;               //!< (spare - included for correct size)
+    uchar __PAD3;               //!< (spare - included for correct size)
 } event_t;
 
 /*!
@@ -809,7 +822,7 @@ typedef struct event_data {
     uint rc;                    //!< Failure codes
 
     volatile uchar state;       //!< Stop/pauses event loop
-    uchar __PAD1;               //!< (Spare)
+    uchar id_rsvd;              //!< number of reserved IDs
     uchar wait;                 //!< Wait state
     uchar user;                 //!< Non-zero if user event pending
 
@@ -2242,6 +2255,19 @@ and "arg2" fields. The "ID", "next" and "time" fields are also set.
 
 event_t* event_new (event_proc proc, uint arg1, uint arg2);
 
+/*
+// Configure a (reusable) event that has already been allocated.
+// Configure fields "proc", "arg1" and "arg2" from the parameters.
+// Fields "next" and "time" are set to default values.
+
+\param event pointer to an event (to be configured)
+\param proc pointer to an event_proc
+\param arg1 argument 1 to the event_proc
+\param arg2 argument 2 to the event_proc
+*/
+
+void event_config(event_t* event, event_proc proc, uint arg1, uint arg2);
+
 /*!
 Transmit a packet which contains only a key. The packet is placed on a
 transmit queue and sent when it reaches the head of the queue. The
@@ -2526,15 +2552,29 @@ means that a timer event which may be cancelled must be allocated by
 event_new, the ID noted and the event then scheduled with
 timer_schedule.
 
-It is potentially quite difficult to cancel an timer at the head
-of the timer queue so in this case the "proc" is made NULL and
-the timer left to terminate on the timer interrupt.
+It is potentially quite difficult to cancel a timer at the head
+of the timer queue so in that case the timer is replaced with a
+placeholder with "proc" set to NULL and the placeholder is left
+to terminate on the timer interrupt.
 
 \param e event to cancel
 \param ID ID of event to cancel
 */
 
 void timer_cancel (event_t *e, uint ID);
+
+/*!
+Initialise a statically allocated event to be used in place
+of an event that is cancelled at the head of the timer queue.
+
+It is potentially quite difficult to cancel a timer at the head
+of the timer queue so in that case the timer is replaced with a
+placeholder with "proc" set to NULL and the placeholder is left
+to terminate on the timer interrupt.
+*/
+
+void timer_cancel_init(void);
+
 
 //------------------------------------------------------------------------------
 

--- a/include/sark.h
+++ b/include/sark.h
@@ -2524,6 +2524,10 @@ uint event_user (uint arg1, uint arg2);
 Schedule an event to occur at some time in the future. Requires that
 the second timer has been set up by a call to timer_register.
 
+NOTE: this procedure assumes the following event conditions on entry:
+e->next == NULL
+e->time == 0
+
 \param e event to execute
 \param time delay in microseconds (non-zero)
 */

--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -466,6 +466,7 @@ uint __attribute__((weak)) sark_init(uint *stack)
 
 #ifdef SARK_EVENT
     event_alloc(sark_vec->num_events);
+    timer_cancel_init();
 #endif
 
     // Finally return target mode

--- a/sark/sark_timer.c
+++ b/sark/sark_timer.c
@@ -13,6 +13,10 @@
 
 //------------------------------------------------------------------------------
 
+event_t cancelled;  // placeholder for events cancelled @ timer_queue head
+
+//------------------------------------------------------------------------------
+
 
 extern INT_HANDLER timer2_int_han(void);
 
@@ -38,11 +42,15 @@ void event_register_timer(vic_slot slot)
 
 void timer_schedule(event_t *e, uint time)
 {
-    time *= sark.cpu_clk;                       // Convert us to timer ticks
+    if (e->proc == NULL){               // may compromise cancelled placeholder
+        return;
+    }
+
+    time *= sark.cpu_clk;               // Convert us to timer ticks
 
     uint cpsr = cpu_int_disable();
 
-    if (event.timer_queue == NULL) {            // Queue empty - just insert
+    if (event.timer_queue == NULL) {    // Queue empty - just insert
         event.timer_queue = e;
 
         tc[T2_LOAD] = time;
@@ -54,12 +62,18 @@ void timer_schedule(event_t *e, uint time)
 
     uint t2c = tc[T2_COUNT];
 
-    if (time < t2c) {                           // Earlier than current head - replace
-        tc[T2_LOAD] = time;                     // Set counter to new time
+    if (time < t2c) {                   // Earlier than current head - replace
+        tc[T2_LOAD] = time;             // Set counter to new time
 
-        event.timer_queue->time = t2c - time;   // Adjust old head time
+        // remove cancelled placeholder if present
+        // NOTE: placeholder must only be present at head of queue
+        if (event.timer_queue->proc == NULL){
+            event.timer_queue = event.timer_queue->next;
+        }
 
-        e->next = event.timer_queue;            // and insert new timer at head
+        event.timer_queue->time += t2c - time;   // Adjust old head time
+
+        e->next = event.timer_queue;   // and insert new timer at head
         event.timer_queue = e;
 
         cpu_int_restore(cpsr);
@@ -124,9 +138,10 @@ uint timer_schedule_proc(event_proc proc, uint arg1, uint arg2, uint time)
 // allocated when the timer was created must be given in case the
 // timer has already executed and possibly been recycled.
 
-// It is potentially quite difficult to cancel an timer at the head
-// of the timer queue so in this case the "proc" is made NULL and
-// the timer left to terminate on the timer interrupt.
+// It is potentially quite difficult to cancel a timer at the head
+// of the timer queue so in that case the timer is replaced with a
+// placeholder with "proc" set to NULL and the placeholder is left
+// to terminate on the timer interrupt.
 
 
 void timer_cancel(event_t *e, uint ID)
@@ -142,8 +157,9 @@ void timer_cancel(event_t *e, uint ID)
     uint cpsr = cpu_int_disable();
     event_t* q = event.timer_queue;
 
-    if (q == e) {               // At head of queue - nullify proc
-        e->proc = NULL;
+    if (q == e) {   // At head of queue - replace with cancelled placeholder
+        cancelled.next    = e->next;
+        event.timer_queue = &cancelled;
     } else {                    // Further down queue - remove
         event_t* pq = q;
         q = q->next;
@@ -156,11 +172,6 @@ void timer_cancel(event_t *e, uint ID)
                     e->next->time += e->time;
                 }
 
-                e->next = event.free;   // Return to free queue
-                event.free = e;
-                e->ID = 0;
-                event.count--;
-
                 break;
             }
 
@@ -169,7 +180,40 @@ void timer_cancel(event_t *e, uint ID)
         }
     }
 
+    // update event if cancelled
+    if (q != NULL) {
+        e->ID = 0;                  // mark event as inactive
+
+        // free event if not reused
+        if (e->reuse == 0) {
+            e->next = event.free;   // Return to free queue
+            event.free = e;
+            event.count--;
+        }
+    }
+
     cpu_int_restore(cpsr);
+}
+
+
+//------------------------------------------------------------------------------
+
+
+// Initialise a statically-allocated event that can be used in place
+// of an event that is cancelled at the head of the timer queue.
+
+// It is potentially quite difficult to cancel a timer at the head
+// of the timer queue so in that case the timer is replaced with a
+// placeholder with "proc" set to NULL and the placeholder is left
+// to terminate on the timer interrupt.
+
+
+void timer_cancel_init(void)
+{
+    cancelled.proc  = (event_proc) NULL;
+    cancelled.ID    = 0;
+    cancelled.time  = 0;
+    cancelled.reuse = 1;                // event must not be freed!
 }
 
 
@@ -201,16 +245,21 @@ void timer2_int(void)
     }
 
     while (eq != NULL) {                // Run the execute queue
+        // mark event as inactive - do it here in case 'proc' reuses it
+        eq->ID = 0;
+
         if (eq->proc != NULL) {         // Execute proc if non-NULL
             eq->proc(eq->arg1, eq->arg2);
         }
 
         event_t* next = eq->next;
 
-        eq->next = event.free;          // Return to free queue
-        event.free = eq;
-        eq->ID = 0;
-        event.count--;
+        // free event if not reused
+        if (eq->reuse == 0) {
+            eq->next = event.free;      // Return to free queue
+            event.free = eq;
+            event.count--;
+        }
 
         eq = next;
     }

--- a/sark/sark_timer.c
+++ b/sark/sark_timer.c
@@ -37,7 +37,8 @@ void event_register_timer(vic_slot slot)
 //------------------------------------------------------------------------------
 
 // Schedule an event to occur at some time in the future (measured in
-// microseconds).
+// microseconds).  Requires that (hardware) TIMER2 has been set up by
+// a call to timer_register.
 // NOTE: this procedure assumes the following event conditions on entry:
 // e->next == NULL
 // e->time == 0

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1651,6 +1651,7 @@ void c_main(void)
 
         timer1_init(sark.cpu_clk * 1000);       // Initialise 1ms timer
 
+        desc_init();                    // Initialise TX and RX descriptors
         queue_init();                   // Initialise various queues
         nn_init();                      // Initialise NN package
         netinit_start();                // Initialise late-stage boot process datastructures
@@ -1673,9 +1674,10 @@ void c_main(void)
 
         timer1_init(sark.cpu_clk * 1000);  // Initialise 1ms timer
 
+        desc_init();                    // Initialise TX and RX descriptors
         queue_init();                   // Initialise various queues
         nn_init();                      // Initialise NN package
-        
+
         // recover the link enable map
         link_en = sv->link_en;
 

--- a/scamp/scamp-3.sct
+++ b/scamp/scamp-3.sct
@@ -4,20 +4,20 @@
 
 IMAGE 0
 {
-      	ITCM 0 0x7f00
-  	{   
-    	    	* (_alib_reset, +FIRST)
-    		* (+RO)
-		* (_alib_align, +LAST)
-  	}
+        ITCM 0 0x7f00
+        {
+                * (_alib_reset, +FIRST)
+                * (+RO)
+                * (_alib_align, +LAST)
+        }
 
-  	DTCM 0x00400000 0x00003800 
-  	{
-    		* (+RW)
-		* (+ZI)
-  	}
+        DTCM 0x00400000
+        {
+                * (+RW)
+                * (+ZI)
+        }
 
-	STACK 0x00404000 EMPTY -0x800
-	{
-	}
+        STACK 0x00408000 EMPTY -0x800
+        {
+        }
 }

--- a/scamp/scamp-p2p.c
+++ b/scamp/scamp-p2p.c
@@ -146,7 +146,7 @@ void desc_init(void)
 
     rx_desc_t *rdesc = rx_desc_table;
 
-    // initialise RX descriptors reusable events
+    // initialise RX descriptor reusable events
     for (uint i = 0; i < P2P_NUM_STR; i++) {
         e = event_new((event_proc) NULL, 0, 0);
         rdesc->event = e;

--- a/scamp/scamp-p2p.c
+++ b/scamp/scamp-p2p.c
@@ -327,6 +327,7 @@ uint p2p_send_msg(uint addr, sdp_msg_t *msg)
 	    timer_schedule(e, open_ack_time);
 	} else {
 	    sw_error(SW_OPT);
+	    return RC_BUF;
 	}
 
 	p2p_send_ctl(P2P_OPEN_REQ, addr, (len << 8) + ctrl);
@@ -379,6 +380,7 @@ uint p2p_send_msg(uint addr, sdp_msg_t *msg)
 			timer_schedule(e, data_ack_time);
 		    } else {
 			sw_error(SW_OPT);
+			return RC_BUF;
 		    }
 		}
 

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -333,6 +333,7 @@ extern void reset_ap(uint virt_mask);
 // scamp-p2p.c
 
 extern uint p2p_send_msg(uint addr, sdp_msg_t *msg);
+extern void desc_init(void);
 
 // scamp-nn.c
 extern void p2pc_addr_nn_send(uint arg1, uint arg2);


### PR DESCRIPTION
A monitor core can fail to allocate an 'event', needed to schedule the timeout used whenever a message is sent to another monitor core (to react in case P2P packets are dropped). Currently, the monitor will still send the message but then it may busy wait forever if there is no message acknowledge.

Currently, events are held in a pool of free events and are allocated dynamically. When a process needs an event it requests it, configures the event and schedules it. Scheduling the event transfers ownership of the event to the scheduler/dispatcher, who free the event once they are done with it.

This pull request tries to solve this problem by modifying how events are managed. The event data structure has an added field that indicates that the event is reusable, _i.e._, a process does ***not*** transfer ownership to the scheduler/dispatcher. Once the scheduler/dispatcher are done with an event, they mark the event as 'inactive' but do ***not*** free it. This allows the process to reuse the event and guarantees that it will not fail to allocate an event.

Reusable events are allocated during start up to the P2P transmitter and to each of the P2P receiver streams, making sure that they can always schedule timeouts.
