### PR TITLE
Timer sync

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -1018,7 +1018,7 @@ typedef struct sv {
     uchar boot_delay;           //!< 42 Delay between boot NN pkts (us)
     uchar soft_wdog;            //!< 43 Soft watchdog control
 
-    uint __PAD3;                //!< 44
+    uint sync_alignment;        //!< 44 delay for sync0/1 alignment (us)
 
     heap_t *sysram_heap;        //!< 48 Heap in SysRAM
     heap_t *sdram_heap;         //!< 4c Heap in SDRAM

--- a/include/sark.h
+++ b/include/sark.h
@@ -48,7 +48,7 @@
 
 //! Clock drift fixed-point number definition in terms of the number of
 //! fractional bits and the mask to get the fractional bits
-#define DRIFT_FP_BITS 20
+#define DRIFT_FP_BITS 17
 #define DRIFT_INT_MASK (((1 << (32 - DRIFT_FP_BITS)) - 1) << DRIFT_FP_BITS)
 #define DRIFT_FRAC_MASK ((1 << DRIFT_FP_BITS) - 1)
 #define DRIFT_ONE (1 << DRIFT_FP_BITS)

--- a/include/sark.h
+++ b/include/sark.h
@@ -46,6 +46,14 @@
 
 #define DEAD_WORD       0xdeaddead  //!< Stack fill value
 
+//! Clock drift fixed-point number definition in terms of the number of
+//! fractional bits and the mask to get the fractional bits
+#define DRIFT_FP_BITS 20
+#define DRIFT_INT_MASK (((1 << (32 - DRIFT_FP_BITS)) - 1) << DRIFT_FP_BITS)
+#define DRIFT_FRAC_MASK ((1 << DRIFT_FP_BITS) - 1)
+#define DRIFT_ONE (1 << DRIFT_FP_BITS)
+#define TIME_BETWEEN_SYNC_US 2000000 // !< The time between sync signals in us
+
 //------------------------------------------------------------------------------
 
 /*!
@@ -1001,7 +1009,8 @@ typedef struct sv {
 
     uint led0;                  //!< 30 LED definition words (for up
     uint led1;                  //!< 34 to 15 LEDs)
-    int clock_drift;            //!< 38 drift of clock from boot chip clock
+    int clock_drift;            //!< 38 drift of clock from boot chip clock in ticks / us
+                                //      NOTE: This is a fixed point number!!!
     uint random;                //!< 3c Random number seed
 
     uchar root_chip;            //!< 40 Set if we are the root chip

--- a/include/sark.h
+++ b/include/sark.h
@@ -1001,7 +1001,7 @@ typedef struct sv {
 
     uint led0;                  //!< 30 LED definition words (for up
     uint led1;                  //!< 34 to 15 LEDs)
-    uint __PAD2;                //!< 38
+    int clock_drift;            //!< 38 drift of clock from boot chip clock
     uint random;                //!< 3c Random number seed
 
     uchar root_chip;            //!< 40 Set if we are the root chip

--- a/include/spin1_api_params.h
+++ b/include/spin1_api_params.h
@@ -131,14 +131,15 @@
 // VIC priorities
 // -----------------------
 #define SARK_PRIORITY          0
-#define TIMER1_PRIORITY        1
-#define DMA_DONE_PRIORITY      2
-#define RX_READY_PRIORITY      3
-#define FR_READY_PRIORITY      4
-#define CC_TMT_PRIORITY        5
-#define SOFT_INT_PRIORITY      6
+#define TIMER1_PRIORITY        2
+//#define DMA_DONE_PRIORITY      2
+#define DMA_DONE_PRIORITY      3
+#define RX_READY_PRIORITY      4
+#define FR_READY_PRIORITY      5
+#define CC_TMT_PRIORITY        6
+#define SOFT_INT_PRIORITY      7
 #if USE_WRITE_BUFFER == TRUE
-  #define DMA_ERR_PRIORITY     7
+  #define DMA_ERR_PRIORITY     8
 #endif
 
 // ------------------------------------------------------------------------

--- a/include/spin1_api_params.h
+++ b/include/spin1_api_params.h
@@ -131,15 +131,14 @@
 // VIC priorities
 // -----------------------
 #define SARK_PRIORITY          0
-#define TIMER1_PRIORITY        2
-//#define DMA_DONE_PRIORITY      2
-#define DMA_DONE_PRIORITY      3
-#define RX_READY_PRIORITY      4
-#define FR_READY_PRIORITY      5
-#define CC_TMT_PRIORITY        6
-#define SOFT_INT_PRIORITY      7
+#define TIMER1_PRIORITY        1
+#define DMA_DONE_PRIORITY      2
+#define RX_READY_PRIORITY      3
+#define FR_READY_PRIORITY      4
+#define CC_TMT_PRIORITY        5
+#define SOFT_INT_PRIORITY      6
 #if USE_WRITE_BUFFER == TRUE
-  #define DMA_ERR_PRIORITY     8
+  #define DMA_ERR_PRIORITY     7
 #endif
 
 // ------------------------------------------------------------------------

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1193,7 +1193,7 @@ void compute_st(void)
         }
     }
 
-    rtr_mc_set(0, 0xffff5554, 0xfffffffe, route);
+    rtr_mc_set(0, SCAMP_MC_ROUTING_KEY, SCAMP_MC_ROUTING_MASK, route);
 }
 
 

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1272,6 +1272,14 @@ void proc_100hz(uint a1, uint a2)
                 compute_st();
                 sv->p2p_up = p2p_up = 1;
 
+                // estimate sync0/1 delay (us) from (0, 0)
+                uint nodes = (hop_table[0] & 0x00ffffff) + 1;
+                uint ttr   = ((NODE_DLY_NS * nodes) +
+                              (BRD_DLY_NS * (nodes >> 3))) >> 10;
+
+                // estimate delay to farthest possible chip
+                sv->sync_alignment = TOP_DLY_US - ttr;
+
                 if (srom.flags & SRF_ETH) {
                     uint s = phy_read(PHY_STATUS);
                     sv->eth_up = (s & 4) >> 2;

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1136,7 +1136,7 @@ void compute_st(void)
         }
     }
 
-    rtr_mc_set(0, 0xffff5555, 0xffffffff, route);
+    rtr_mc_set(0, 0xffff5554, 0xfffffffe, route);
 }
 
 

--- a/scamp/scamp-app.c
+++ b/scamp/scamp-app.c
@@ -218,6 +218,8 @@ void proc_power_down(uint virt_mask, uint phys_mask)
 
 void signal_app(uint data)
 {
+    uint cpsr;
+
     uint sig = (data >> 16) & 15;
     uint app_mask = (data >> 8) & 255;
     uint app_id = data & 255;
@@ -246,13 +248,23 @@ void signal_app(uint data)
         break;
 
     case SIG_SYNC0:
+        // wait to align signal arrival with farthest chip
+        // do not allow interrupts to extend the delay!
+        cpsr = cpu_int_disable();
+        sark_delay_us(sv->sync_alignment);
         sc[SC_CLRFLAG] = virt_mask;
         sc[SC_SET_IRQ] = SC_CODE + phys_mask;
+        cpu_int_restore(cpsr);
         break;
 
     case SIG_SYNC1:
+        // wait to align signal arrival with farthest chip
+        // do not allow interrupts to extend the delay!
+        cpsr = cpu_int_disable();
+        sark_delay_us(sv->sync_alignment);
         sc[SC_SETFLAG] = virt_mask;
         sc[SC_SET_IRQ] = SC_CODE + phys_mask;
+        cpu_int_restore(cpsr);
         break;
 
     case SIG_TIMER:

--- a/scamp/scamp-boot.c
+++ b/scamp/scamp-boot.c
@@ -22,7 +22,7 @@
 #define BOOT_BUF (DTCM_BASE + 0x8000)
 
 // BLOCK_COUNT * BYTE_COUNT must be < 32kB
-#define BLOCK_COUNT     28      // From 1-256
+#define BLOCK_COUNT     31      // From 1-256
 #define WORD_COUNT      256     // From 1-256
 #define BYTE_COUNT      (WORD_COUNT * sizeof(uint))
 

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -645,7 +645,7 @@ uint cmd_sig(sdp_msg_t *msg)
             msg->cmd_rc = RC_ARG;
             return 0;
         }
-        pkt_tx(PKT_MC_PL, data, 0xffff5555);
+        pkt_tx(PKT_MC_PL, data, SCAMP_MC_SIGNAL_KEY);
     } else if (type == 1) {
         uint mask = msg->arg3;
 

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -139,7 +139,6 @@ static int samples[N_ITEMS];
 static int sum = 0;
 static uint n_samples = 0;
 static uint sample_pos;
-static int last_average;
 
 INT_HANDLER pkt_mc_int()
 {
@@ -168,8 +167,7 @@ INT_HANDLER pkt_mc_int()
                     sum = (sum - samples[sample_pos]) + drift;
                     samples[sample_pos] = drift;
                     sample_pos = (sample_pos + 1) % N_ITEMS;
-                    uint average_drift = sum / N_ITEMS;
-                    sv->clock_drift = average_drift;
+                    sv->clock_drift = sum / N_ITEMS;
                 }
             }
         }

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -134,8 +134,9 @@ __asm void eth_rx_int(void)
 // Maximum difference between timers over 2 seconds in clock ticks; experiments
 // have shown maximum difference is about 1ms over 160 seconds which is
 // 6.25us over 1 second, which is 2500 clock ticks at 200Mhz.  This is
-// multiplied by 2 as drift could be in either direction.
-#define MAX_DIFF 5000
+// multiplied by 2 as drift could be in either direction.  Further experiments
+// show that slightly higher values are encountered, so 10000 is used.
+#define MAX_DIFF 10000
 
 // Number of samples to keep to get an average
 #define N_ITEMS 16

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -176,9 +176,9 @@ INT_HANDLER pkt_mc_int()
 
     // Checksum ??
 
-    if (key == 0xffff5555) {
+    if (key == SCAMP_MC_SIGNAL_KEY) {
         signal_app(data);
-    } else if (key == 0xffff5554 && netinit_phase == NETINIT_PHASE_DONE) {
+    } else if (key == SCAMP_MC_TIME_SYNC_KEY && netinit_phase == NETINIT_PHASE_DONE) {
         // Timer synchronisation - only do once netinit phase is complete to
         // avoid clashing with other network traffic.
         int ticks = tc[T1_COUNT];
@@ -283,7 +283,7 @@ INT_HANDLER ms_timer_int()
     if ((sv->p2p_root == sv->p2p_addr)
             && (netinit_phase == NETINIT_PHASE_DONE)) {
         if (time_to_next_sync == 0) {
-            pkt_tx(PKT_MC_PL, n_beacons_sent, 0xffff5554);
+            pkt_tx(PKT_MC_PL, n_beacons_sent, SCAMP_MC_TIME_SYNC_KEY);
             n_beacons_sent += 1;
             time_to_next_sync = TIME_BETWEEN_SYNC_US;
         }

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -184,7 +184,15 @@
 
 // Number of microseconds to wait between sending P2PB packets on neighbouring
 // chips
-#define P2PB_OFFSET_USEC 100
+#define P2PB_OFFSET_USEC        100
+
+//------------------------------------------------------------------------------
+
+// sync0/sync1 arrival alignment
+
+#define NODE_DLY_NS             500     // per-node delay (ns)
+#define BRD_DLY_NS              900     // board-to-board delay (ns)
+#define TOP_DLY_US              155     // largest delay in 256x256 nodes (us)
 
 //------------------------------------------------------------------------------
 

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -39,6 +39,25 @@
 
 //------------------------------------------------------------------------------
 
+// SCAMP Multicast constants
+
+// Key used in the routing table
+#define SCAMP_MC_ROUTING_KEY    0xffff5554
+
+// Mask used in the routing table
+#define SCAMP_MC_ROUTING_MASK   0xfffffffe
+
+// The meaning of the individual keys - an enum might be better but doesn't
+// work because the 'enumeration value is out of "int" range'
+
+// The key used for time synchronisation packets
+#define SCAMP_MC_TIME_SYNC_KEY 0xffff5554
+
+// The key used for signal packets
+#define SCAMP_MC_SIGNAL_KEY 0xffff5555
+
+//------------------------------------------------------------------------------
+
 // IPTag table sizes
 
 #define TAG_FIXED_SIZE          8       // At bottom of table

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -14,7 +14,7 @@ static volatile uint run;               // controls simulation start/exit
 static volatile uint paused;            // indicates when paused
 static volatile uint resume_sync;       // controls re-synchronisation
 uint ticks;                             // number of elapsed timer periods
-static uint timer_tick;                 // timer tick period
+uint timer_tick;                        // timer tick period
 static uint timer_phase;                // additional phase on starting the timer
 
 // default fiq handler -- restored after simulation
@@ -258,8 +258,8 @@ void configure_timer1(uint time, uint phase)
     // do not enable yet!
     tc[T1_CONTROL] = 0;
     tc[T1_INT_CLR] = 1;
-    tc[T1_LOAD] = sv->cpu_clk * (time + phase);
-    tc[T1_BG_LOAD] = sv->cpu_clk * time;
+    tc[T1_LOAD] = (sv->cpu_clk * (time + phase)) + sv->clock_drift;
+    tc[T1_BG_LOAD] = (sv->cpu_clk * time) + sv->clock_drift;
 }
 /*
 *******/

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -460,7 +460,6 @@ INT_HANDLER timer1_isr()
             drift_sign = -1;
         }
         time_to_next_drift_update += TIME_BETWEEN_SYNC_US;
-        drift_accum = 0;
     }
 
     // Each timer tick we add on the integer number of clock cycles accumulated

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -452,7 +452,6 @@ INT_HANDLER timer1_isr()
     // Update drift if needed
     time_to_next_drift_update -= timer_tick;
     if (time_to_next_drift_update <= 0) {
-        vcpu_t *vcpu = (vcpu_t*) SV_VCPU;
         drift = timer_tick * sv->clock_drift;
         drift_sign = 1;
         if (drift < 0) {

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -11,6 +11,7 @@ extern uint user_arg0;
 extern uint user_arg1;
 
 extern uint ticks;
+extern uint timer_tick;
 
 extern dma_queue_t dma_queue;
 extern tx_packet_queue_t tx_packet_queue;
@@ -442,6 +443,11 @@ INT_HANDLER timer1_isr()
 
     // Increment simulation "time"
     ticks++;
+
+    // Every now and again, update the rate to adjust for drift changes
+    if ((ticks % 2048) == 0) {
+        tc[T1_BG_LOAD] = (sv->cpu_clk * timer_tick) + sv->clock_drift;
+    }
 
     // If application callback registered schedule it
     if (callback[TIMER_TICK].cback != NULL) {

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -12,6 +12,12 @@ extern uint user_arg1;
 
 extern uint ticks;
 extern uint timer_tick;
+extern uint timer_tick_clocks;
+extern int drift;
+extern int drift_accum;
+extern int drift_sign;
+extern int time_to_next_drift_update;
+extern int total_drift_added;
 
 extern dma_queue_t dma_queue;
 extern tx_packet_queue_t tx_packet_queue;
@@ -444,10 +450,34 @@ INT_HANDLER timer1_isr()
     // Increment simulation "time"
     ticks++;
 
-    // Every now and again, update the rate to adjust for drift changes
-    if ((ticks % 2048) == 0) {
-        tc[T1_BG_LOAD] = (sv->cpu_clk * timer_tick) + sv->clock_drift;
+    // Update drift if needed
+    time_to_next_drift_update -= timer_tick;
+    if (time_to_next_drift_update <= 0) {
+        vcpu_t *vcpu = (vcpu_t*) SV_VCPU;
+        char drift_char = ' ';
+        if (drift_sign < 0) {
+            drift_char = '-';
+        }
+        io_printf(IO_BUF, "%d, %c%d.%d, %d\n", ticks, drift_char, drift >> DRIFT_FP_BITS, drift * 10000 >> DRIFT_FP_BITS, total_drift_added);
+        drift = timer_tick * sv->clock_drift;
+        drift_sign = 1;
+        if (drift < 0) {
+            drift = -drift;
+            drift_sign = -1;
+        }
+        time_to_next_drift_update += TIME_BETWEEN_SYNC_US;
+        drift_accum = 0;
+        total_drift_added = 0;
     }
+    // Do drift adjustment
+    drift_accum += drift;
+    // Each timer tick we add on the integer number of clock cycles accumulated
+    // and subtract this from the accumulator.
+    int drift_int = drift_accum & DRIFT_INT_MASK;
+    drift_accum -= drift_int;
+    drift_int = (drift_int >> DRIFT_FP_BITS) * drift_sign;
+    total_drift_added += drift_int;
+    tc[T1_BG_LOAD] = timer_tick_clocks + drift_int;
 
     // If application callback registered schedule it
     if (callback[TIMER_TICK].cback != NULL) {


### PR DESCRIPTION
This is an attempt to synchronise the timers over multiple boards, implemented at the chip level.  This appears to work but testing to see if it really helps is in progress.

Two different synchronisation adjustments are included in the pull request:
- periodic clock drift correction across boards
- on-the-spot phase correction for sync0 and sync1 signals

- [x] Wait until testing is complete