### PR TITLE
Fixes for SCAMP

### DIFF
--- a/sark/sark_event.c
+++ b/sark/sark_event.c
@@ -411,9 +411,9 @@ static inline event_t *take_one_event_from_queue(proc_queue_t *queue) {
     event_t* e = queue->proc_head;  // Get head of queue
     if (e != NULL) {
 	queue->proc_head = e->next; // Remove from queue
+	e->next = NULL;             // Value here is irrelevant to caller
     }
     cpu_int_restore(cpsr);
-    e->next = NULL;                 // Value here is irrelevant to caller
     return e;
 }
 

--- a/sark/sark_event.c
+++ b/sark/sark_event.c
@@ -299,14 +299,11 @@ void event_stop(uint rc)
 
 // Adds an event to a list of events which can (all) be executed
 // at some later time. Later events are queued at the tail of the queue.
+// This is the core of the implementation of event_queue and event_queue_proc
 
-uint event_queue(event_t *e, event_priority priority)
+static void enqueue_event(event_t *e, event_priority priority)
 {
-    if (priority > PRIO_MAX) {
-        return 0;
-    }
-
-    proc_queue_t *queue = event.proc_queue + priority;
+    proc_queue_t *queue = &event.proc_queue[priority];
 
     uint cpsr = cpu_int_disable();
 
@@ -318,7 +315,18 @@ uint event_queue(event_t *e, event_priority priority)
     }
 
     cpu_int_restore(cpsr);
+}
 
+// Adds an event to a list of events which can (all) be executed
+// at some later time. Later events are queued at the tail of the queue.
+
+uint event_queue(event_t *e, event_priority priority)
+{
+    if (priority > PRIO_MAX) {
+        return 0;
+    }
+
+    enqueue_event(e, priority);
     return 1;
 }
 
@@ -330,12 +338,16 @@ uint event_queue(event_t *e, event_priority priority)
 uint event_queue_proc(event_proc proc, uint arg1, uint arg2,
                       event_priority priority)
 {
+    if (priority > PRIO_MAX) {
+        return 0;
+    }
     event_t *e = event_new(proc, arg1, arg2);
     if (e == NULL) {
         return 0;
     }
 
-    return event_queue(e, priority);
+    enqueue_event(e, priority);
+    return 1;
 }
 
 
@@ -344,20 +356,36 @@ uint event_queue_proc(event_proc proc, uint arg1, uint arg2,
 // Execute a list of events (in the order in which they were added
 // to the list). Events are returned to the free queue after execution.
 
+static void event_free(event_t *e)
+{
+    // free event if not reused
+    if (e->reuse == 0) {
+        uint cpsr = cpu_int_disable();
+
+        e->next = event.free;   // Return to free queue
+        event.free = e;
+        event.count--;
+
+        cpu_int_restore(cpsr);
+    }
+}
+
+static inline event_t *get_queue_contents(proc_queue_t *queue)
+{
+    uint cpsr = cpu_int_disable();
+    event_t* e = queue->proc_head;  // Get list of events and
+    queue->proc_head = NULL;        // update list head
+    cpu_int_restore(cpsr);
+    return e;
+}
+
 void event_run(uint restart)
 {
     uint priority = PRIO_0;
 
     while (priority <= PRIO_MAX && event.state == EVENT_RUN) {
-        proc_queue_t *queue = event.proc_queue + priority;
-
-        uint cpsr = cpu_int_disable();
-
-        event_t* e = queue->proc_head;  // Get list of events and
-        queue->proc_head = NULL;        // update list head
-
-        cpu_int_restore(cpsr);
-
+        proc_queue_t *queue = &event.proc_queue[priority];
+        event_t* e = get_queue_contents(queue);  // Get list of events
         event_t *x = e;                 // Non-NULL if any events run
 
         while (e != NULL) {
@@ -365,20 +393,8 @@ void event_run(uint restart)
 
             // mark event as inactive - do it here in case 'proc' reuses it
             e->ID = 0;
-
             e->proc(e->arg1, e->arg2);  // No need to check for NULL here
-
-            // free event if not reused
-            if (e->reuse == 0) {
-                uint cpsr = cpu_int_disable();
-
-                e->next = event.free;   // Return to free queue
-                event.free = e;
-                event.count--;
-
-                cpu_int_restore(cpsr);
-            }
-
+            event_free(e);
             e = next;
         }
 
@@ -390,43 +406,35 @@ void event_run(uint restart)
     }
 }
 
+static inline event_t *take_one_event_from_queue(proc_queue_t *queue) {
+    uint cpsr = cpu_int_disable();  // Interrupts off to manipulate queue
+    event_t* e = queue->proc_head;  // Get head of queue
+    if (e != NULL) {
+	queue->proc_head = e->next; // Remove from queue
+    }
+    cpu_int_restore(cpsr);
+    e->next = NULL;                 // Value here is irrelevant to caller
+    return e;
+}
 
 void event_run2(uint restart)
 {
     event_priority priority = PRIO_0;
 
     while (priority <= PRIO_MAX && event.state == EVENT_RUN) {
-        proc_queue_t *queue = event.proc_queue + priority;
+        proc_queue_t *queue = &event.proc_queue[priority];
 
-        uint cpsr = cpu_int_disable();  // Interrupts off to manipulate queue
-
-        event_t* e = queue->proc_head;  // Get head of queue
+        event_t* e = take_one_event_from_queue(queue);  // Get head of queue
 
         if (e == NULL) {                // If no item on queue...
-            cpu_int_restore(cpsr);
             priority++;
             continue;
         }
 
-        queue->proc_head = e->next;     // Remove from queue
-
-        cpu_int_restore(cpsr);          // Interrupts on again
-
         // mark event as inactive - do it here in case 'proc' reuses it
         e->ID = 0;
-
         e->proc(e->arg1, e->arg2);      // Execute the "proc"
-
-        // free event if not reused
-        if (e->reuse == 0) {
-            cpsr = cpu_int_disable();   // Return to free queue
-
-            e->next = event.free;
-            event.free = e;
-            event.count--;
-
-            cpu_int_restore(cpsr);
-        }
+        event_free(e);
 
         if (restart) {                  // Back to priority 0 if anything
             priority = PRIO_0;          // executed

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -342,13 +342,13 @@ void udp_pkt(uchar *rx_pkt, uint rx_len)
             tag = msg->tag = transient_tag(ip_hdr->srce, rx_pkt+6, udp_srce, tag_tto);
         }
 
-        eth_discard();
-
         if ((flags & SDPF_REPLY) == 0 ||
                 (tag < TAG_TABLE_SIZE && tag_table[tag].flags != 0)) {
             arp_add(rx_pkt+6, ip_hdr->srce);
+            eth_discard();
             msg_queue_insert(msg, srce_ip);
         } else {
+            eth_discard();
             sark_msg_free(msg);
         }
     } else {                            // Reverse IPTag...


### PR DESCRIPTION
In the process of doing the Data In work, I've noticed that sometimes (very occasionally, but much more likely when SpiNNaker's ethernet interface is being pushed hard) the SpiNNaker system would end up in a state where no messages would get through from a board to host. This has made debugging (let alone stabilising) the Data In protocol really difficult.

A critical part of this has been working out why messages were getting lost. This PR _appears_ to fix this in testing.

**The critical bit is the moving of the calls to `eth_discard()` to slightly later in `udp_pkt()`** (in `scamp-3.c`) so that we don't look inside the released packet buffer at all. We suspect that the issue is that other packets coming in could _occasionally_ smash the ARP cache update, and once that was poisoned the outbound messages (which are asynchronous to the inbound messages) would black-hole for long enough to trigger some other kind of failure mode (of unknown nature) in the Data In code (which we couldn't debug because SCAMP had become extremely unhappy by this point due to the deluge of packets from Data In). We also suspect that the source of the smashing packets was other unbooted SpiNNaker boards on the same subnet; we have quite a few of those after all…

The changes to `sark_event.c` are about stopping a _theoretical_ failure mode (a way of losing an allocated event) but I really don't think those are the problem. But I've changed the code to be clearer and more limited in how it handles saved CPSRs; I want the bits where we turn interrupts off to be very obviously correct. (I've added more functions; they're `static inline` so they should produce effectively the same code. It's a technique used heavily in the neuron code.)

I still have to fix bits of Data In, but this seems to help a lot.