### PR TITLE
Avoid anyone using stdlib and stdio

### DIFF
--- a/include/stdio.h
+++ b/include/stdio.h
@@ -1,0 +1,1 @@
+#error NO NOT USE stdio.h in spinnaker

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -1,0 +1,1 @@
+#error NO NOT USE stdlib.h in spinnaker

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -9,8 +9,6 @@
 //
 //------------------------------------------------------------------------------
 
-#include <stdlib.h>
-
 #include "spinnaker.h"
 #include "sark.h"
 #include "scamp.h"
@@ -519,6 +517,13 @@ void p2pb_nn_send(uint arg1, uint arg2)
         }
     }
 }
+
+#ifndef abs
+static inline int abs(int i)
+{      /* compute absolute value of int argument */
+    return (i < 0 ? -i : i);
+}
+#endif
 
 // Update our current best guess of our coordinates based on a packet from a
 // neighbour


### PR DESCRIPTION
including stdlib or stdio can cause clashes with assert.h and spin-print.h

As these tool are too big for spinnaker anyway make sure none still tries to use them.