### PR TITLE
Allocate events before touching shared resources

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -2287,6 +2287,15 @@ existing free queue. Returns 1 on success, 0 on failure.
 uint event_alloc (uint events);
 
 /*!
+Free a previously allocated event. The event MUST NOT have been scheduled.
+
+\param e the event to free
+*/
+
+__attribute__((nonnull))
+void event_free(event_t *e);
+
+/*!
 Allocate a new event from the free queue and intialise "proc", "arg1"
 and "arg2" fields. The "ID", "next" and "time" fields are also set.
 

--- a/sark/sark_event.c
+++ b/sark/sark_event.c
@@ -370,8 +370,8 @@ uint event_queue_proc(event_proc proc, uint arg1, uint arg2,
 
 //------------------------------------------------------------------------------
 
-// Execute a list of events (in the order in which they were added
-// to the list). Events are returned to the free queue after execution.
+// free an event that is no longer in use.
+// The freed event MUST NOT have been scheduled.
 
 void event_free(event_t *e)
 {
@@ -395,6 +395,12 @@ static inline event_t *get_queue_contents(proc_queue_t *queue)
     cpu_int_restore(cpsr);
     return e;
 }
+
+
+//------------------------------------------------------------------------------
+
+// Execute a list of events (in the order in which they were added
+// to the list). Events are returned to the free queue after execution.
 
 void event_run(uint restart)
 {

--- a/sark/sark_event.c
+++ b/sark/sark_event.c
@@ -373,7 +373,7 @@ uint event_queue_proc(event_proc proc, uint arg1, uint arg2,
 // Execute a list of events (in the order in which they were added
 // to the list). Events are returned to the free queue after execution.
 
-static void event_free(event_t *e)
+void event_free(event_t *e)
 {
     // free event if not reused
     if (e->reuse == 0) {

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -563,11 +563,10 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
         sw_error(SW_OPT);
         return RC_BUF;          // !! not the right RC
     }
-    uint id = e->ID;
 
     sdp_msg_t *shm_msg = sark_shmsg_get();
     if (shm_msg == NULL) {
-	timer_cancel(e, id);
+	event_free(e);
         return RC_BUF;
     }
 
@@ -578,6 +577,7 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
 
     sc[SC_SET_IRQ] = SC_CODE + (1 << v2p_map[dest]);
 
+    uint id = e->ID;
     timer_schedule(e, 1000);    // !! const??
 
     while (vcpu->mbox_ap_cmd != SHM_IDLE && flag == 0) {

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -566,7 +566,7 @@ uint shm_send_msg(uint dest, sdp_msg_t *msg) // Send msg AP
 
     sdp_msg_t *shm_msg = sark_shmsg_get();
     if (shm_msg == NULL) {
-	event_free(e);
+        event_free(e);
         return RC_BUF;
     }
 


### PR DESCRIPTION
Because shared resources are seen by other cores, it's best to acquire events (which are local) before doing anything shared (like allocating a message from the shared queue or touching a mailbox). Also, doing this means that the failure mode where a shared message is allocated but an
event is not (in `shm_send_msg`) can't result in a message getting used twice at once and can't corrupt the stack of shared messages.

Fixes #108

(This will need heavy testing, given that the problem was only occurring under very heavy load. Which is why nobody noticed it before. And our Python code just can't fire packets at SCAMP fast enough to trigger the problem in the first place.)