### PR TITLE
fix_commsctrl_hazard

### DIFF
--- a/include/version.h
+++ b/include/version.h
@@ -29,7 +29,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define SLLT_VER_STR    "3.2.6"
-#define SLLT_VER_NUM    0x030206
+#define SLLT_VER_STR    "3.3.0"
+#define SLLT_VER_NUM    0x030300
 
 #endif

--- a/include/version.h
+++ b/include/version.h
@@ -29,7 +29,7 @@
 #ifndef __VERSION_H__
 #define __VERSION_H__
 
-#define SLLT_VER_STR    "3.2.5"
-#define SLLT_VER_NUM    0x030205
+#define SLLT_VER_STR    "3.2.6"
+#define SLLT_VER_NUM    0x030206
 
 #endif

--- a/release.txt
+++ b/release.txt
@@ -4,7 +4,13 @@
 #
 #-------------------------------------------------------------------------------
 
-Version 3.2.6 - Bug fixing
+Version 3.3.0 - Bug fixing and new feature
+
+New Feature:
+
+* Spin1 API: new function spin1_dma_flush clears hardware and software
+  DMA queues and aborts any ongoing DMA transfers.
+
 
 Bug fixes:
 

--- a/release.txt
+++ b/release.txt
@@ -4,6 +4,21 @@
 #
 #-------------------------------------------------------------------------------
 
+Version 3.2.6 - Bug fixing
+
+Bug fixes:
+
+* SCAMP/SARK: removes a potential SDP loophole in which both sender
+  and receiver could free a shared-buffer SDP message at the same time.
+
+* SCAMP/SARK: fixes a hazard by allocating events before accessing
+  shared resources.
+
+* Spin1 API: removes a read-after-write hazard in the comms controller.
+
+#-------------------------------------------------------------------------------
+
+
 Version 3.2.5 - Bug fixing
 
 Bug fixes:
@@ -18,6 +33,7 @@ Bug fixes:
   runs out of events and fails to timeout communications.
 
 * Adds citation and manifest files.
+
 #-------------------------------------------------------------------------------
 
 

--- a/scamp/scamp-p2p.c
+++ b/scamp/scamp-p2p.c
@@ -155,7 +155,8 @@ void desc_init(void)
     tx_desc_t *tdesc = &tx_desc;
 
     // initialise TX descriptor reusable event
-    event_t* e = event_new((event_proc) NULL, 0, 0);
+    // proc_byte_set used as default (to avoid compiler warning)
+    event_t* e = event_new(proc_byte_set, 0, 0);
     tdesc->event = e;
     tdesc->event_id = e->ID;
     e->ID = 0;                          // mark event as inactive
@@ -164,8 +165,9 @@ void desc_init(void)
     rx_desc_t *rdesc = rx_desc_table;
 
     // initialise RX descriptor reusable events
+    // proc_byte_set used as default (to avoid compiler warning)
     for (uint i = 0; i < P2P_NUM_STR; i++) {
-        e = event_new((event_proc) NULL, 0, 0);
+        e = event_new(proc_byte_set, 0, 0);
         rdesc->event = e;
         rdesc->event_id = e->ID;
         e->ID = 0;                      // mark event as inactive

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1102,6 +1102,7 @@ uint spin1_send_packet(uint key, uint data, uint TCR)
 
     /* clear sticky TX full bit and check TX state */
     cc[CC_TCR] = TX_TCR_MCDEFAULT;
+    (void) cc[CC_TCR];  // needed to avoid a RAW hazard accessing CC_TCR
 
     if (cc[CC_TCR] & TX_FULL_MASK) {
         if ((tx_packet_queue.end + 1) % TX_PACKET_QUEUE_SIZE

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -294,7 +294,7 @@ INT_HANDLER cc_tx_empty_isr()
         }
 
         cc[CC_TXKEY]  = key;
-	(void) cc[CC_TCR];  // needed to avoid a RAW hazard accessing CC_TCR
+        (void) cc[CC_TCR];  // needed to avoid a RAW hazard accessing CC_TCR
     }
 
     // If queue empty turn off tx_empty interrupt

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -271,6 +271,7 @@ INT_HANDLER cc_tx_empty_isr()
 
     // Clear the sticky TX full bit
     cc[CC_TCR] = TX_TCR_MCDEFAULT;
+    (void) cc[CC_TCR];  // needed to avoid a RAW hazard accessing CC_TCR
 
     // Drain queue: send packets while queue not empty and CC not full
 
@@ -293,6 +294,7 @@ INT_HANDLER cc_tx_empty_isr()
         }
 
         cc[CC_TXKEY]  = key;
+	(void) cc[CC_TCR];  // needed to avoid a RAW hazard accessing CC_TCR
     }
 
     // If queue empty turn off tx_empty interrupt


### PR DESCRIPTION
This pull request solves a read-after-write hazard in the comms controller.

The hazard is caused by a comms controller one-clock-cycle delay in updating register CC_TCR (documented in the SpiNNaker datasheet). If a core reads this register in the clock cycle immediately after that register was modified, the core reads the old value.

This pull request introduces a 'redundant' read to cc[CC_TCR] to avoid a read-after-write hazard. The added reads are introduced only where needed, i.e., where the register is read after it was potentially modified. The redundant reads provide the required one-clock-cycle delay and also act as sequence points to prevent the compiler from re-ordering instructions across them.

Note that sending any packet. i.e., writing to register CC_TXKEY, can modify CC_TCR indirectly.