### PR TITLE
Fix release sh

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ fi
 cd "$SPINN_DIRS"
 
 # Version low-level tools version number
-VER=`grep SLLT_VER_STR include/version.h | cut -f3 | sed s/\"//g`
+VER=`grep SLLT_VER_STR include/version.h | tr -s ' ' | cut -d' ' -f3 | sed s/\"//g`
 
 # Release name
 NAME=spinnaker_tools_$VER
@@ -41,7 +41,7 @@ if [ -n "$(git status --porcelain | grep -vx " M setup")" ]; then
   echo "WARNING: There are some uncommitted changes."
   git status --short
   echo "Press <return> to build anyway or Ctrl+C to stop."
-  read
+  read REPLY
 fi
 
 # Warn if we're not in the master branch
@@ -49,7 +49,7 @@ if [ -z "$(git branch | grep -x "* master")" ]; then
   echo "WARNING: Not in master branch."
   git branch
   echo "Press <return> to build anyway or Ctrl+C to stop."
-  read
+  read REPLY
 fi
 
 # Use a temporary working directory to produce the build

--- a/release.sh
+++ b/release.sh
@@ -26,7 +26,7 @@ fi
 cd "$SPINN_DIRS"
 
 # Version low-level tools version number
-VER=`grep SLLT_VER_STR include/version.h | tr -s ' ' | cut -d' ' -f3 | sed s/\"//g`
+VER=`grep SLLT_VER_STR include/version.h | awk '{ print $3 }' | sed s/\"//g`
 
 # Release name
 NAME=spinnaker_tools_$VER


### PR DESCRIPTION
This pull request updates release.sh.

The current 'master' version relies on the use of tabs to separate fields in 'version.h'. This version works correctly with any "white space" combination. This stopped working when we translated all tabs to spaces.

The current 'master' version assumes that 'bash' is used to run 'release.sh'. Other shells produce an error with the 'read' command without arguments. This version adds an argument to the 'read' command, which works correctly in bash but also in other shells.
