### PR TITLE
Add queue for user events

### DIFF
--- a/docs/spin1_api/spin1_api.tex
+++ b/docs/spin1_api/spin1_api.tex
@@ -688,7 +688,7 @@ The dispatcher provides a number of services to the application programmer:
 \rowcolors {1}{ blue!25 }{ blue!25 }
 \begin{tabularx}{\textwidth}{| l X |}
 \hline
-\textbf{notes:} & $\bullet$ FAILURE indicates a trigger attempt before a previous one has been serviced. \\%
+\textbf{notes:} & $\bullet$ FAILURE indicates that the trigger event queue is full. \\%
  & $\bullet$ arg0 and arg1 will be passed as arguments to the registered callback. \\%
  & $\bullet$ function arguments are not validated. \\%
 \hline

--- a/include/spin1_api.h
+++ b/include/spin1_api.h
@@ -515,6 +515,7 @@ typedef struct {
     uint dma_queue_full;                // dma queue full count
     uint task_queue_full;               // task queue full count
     uint tx_packet_queue_full;          // transmitter packet queue full count
+    uint user_event_queue_full;         // user event queue full count
     uint writeBack_errors;              // write-back buffer error count
     uint total_fr_packets;              // total routed FR packets during simulation
     uint dumped_fr_packets;             // total dumped FR packets by the router

--- a/include/spin1_api_params.h
+++ b/include/spin1_api_params.h
@@ -120,6 +120,12 @@
 #define RX_RECEIVED_MASK      0x80000000
 // -----------------
 
+// --------------
+/* user events */
+// --------------
+// internal user event queue size
+#define USER_EVENT_QUEUE_SIZE 4
+
 // --------------------
 /* memory allocation */
 // --------------------
@@ -205,6 +211,20 @@ typedef struct {
     packet_t queue[TX_PACKET_QUEUE_SIZE];
 } tx_packet_queue_t;
 // -----------------
+
+// --------------
+/* user events */
+// --------------
+typedef struct {
+    uint arg0;
+    uint arg1;
+} user_event_t;
+
+typedef struct {
+    uint start;
+    uint end;
+    user_event_t queue[USER_EVENT_QUEUE_SIZE];
+} user_event_queue_t;
 
 // -----------------------
 /* scheduler/dispatcher */

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1570,11 +1570,8 @@ uint spin1_trigger_user_event(uint arg0, uint arg1)
     user_event_queue.queue[user_event_queue.end].arg0 = arg0;
     user_event_queue.queue[user_event_queue.end].arg1 = arg1;
 
-    /* if no other user event, trigger on now */
-    if (user_event_queue.start == user_event_queue.end) {
-        /* trigger software interrupt in the VIC */
-        vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
-    }
+    // Trigger a user event (doesn't matter if already set)
+    vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
 
     user_event_queue.end = new_end;
     spin1_mode_restore(cpsr);

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1535,9 +1535,16 @@ uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
 /****f* spin1_api.c/spin1_trigger_user_event
 *
 * SUMMARY
-*  This function triggers a USER EVENT, i.e., a software interrupt.
-*  The function returns FAILURE if a previous trigger attempt
-*  is still pending.
+*  This function triggers a USER EVENT i.e. a software interrupt.
+*  If a previous trigger event is still pending or executing, the event will
+*  be queued until that callback completes.
+*  The function returns FAILURE if the queue of user events to be called is
+*  already full.
+*
+*  NOTE: The callback handler should be able to cope with the fact that a
+*  second call to the function may result in no work to do should a callback
+*  be queued whilst the first is still running and the first deals with
+*  "pending tasks".
 *
 * SYNOPSIS
 *  __irq void spin1_trigger_user_event(uint arg0, uint arg1)

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -554,17 +554,15 @@ INT_HANDLER timer1_fiqsr()
 */
 INT_HANDLER soft_int_isr()
 {
-    // Clear software interrupt in the VIC
-    vic[VIC_SOFT_CLR] = (1 << SOFTWARE_INT);
-
     uint arg0  = user_event_queue.queue[user_event_queue.start].arg0;
     uint arg1  = user_event_queue.queue[user_event_queue.start].arg1;
 
-    // Update queue pointer and trigger new event if queue not empty
+    // Update queue pointer
     user_event_queue.start = (user_event_queue.start + 1) % USER_EVENT_QUEUE_SIZE;
 
-    if (user_event_queue.start != user_event_queue.end) {
-        vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
+    // If the queue is now empty, clear the interrupt
+    if (user_event_queue.start == user_event_queue.end) {
+        vic[VIC_SOFT_CLR] = (1 << SOFTWARE_INT);
     }
 
     // If application callback registered schedule it
@@ -592,17 +590,15 @@ INT_HANDLER soft_int_isr()
 */
 INT_HANDLER soft_int_fiqsr()
 {
-    // Clear software interrupt in the VIC
-    vic[VIC_SOFT_CLR] = (1 << SOFTWARE_INT);
-
     uint arg0  = user_event_queue.queue[user_event_queue.start].arg0;
     uint arg1  = user_event_queue.queue[user_event_queue.start].arg1;
 
     // Update queue pointer and trigger new event if queue not empty
     user_event_queue.start = (user_event_queue.start + 1) % USER_EVENT_QUEUE_SIZE;
 
-    if (user_event_queue.start != user_event_queue.end) {
-        vic[VIC_SOFT_SET] = (1 << SOFTWARE_INT);
+    // If the queue is now empty, clear the interrupt
+    if (user_event_queue.start == user_event_queue.end) {
+        vic[VIC_SOFT_CLR] = (1 << SOFTWARE_INT);
     }
 
     // Execute preeminent callback


### PR DESCRIPTION
This adds a queue for the user event, so that if it is ever used with priority 0 (which it is in the neuron code), it will allow the calling of a second trigger of the user event whilst the first is running, and put it in a queue.  In this version the queue is just 4 elements long, but that is enough for the use case being considered (the neuron code).

This was made mostly by copying the DMA queue code and modifying it for relevance.  Currently it clears the software interrupt and then re-enables it if there is another item in the queue.  I don't know if this is necessary. 