### PR TITLE
Convert some_fun() to some_fun(void)

### DIFF
--- a/apps/pt_demo/tracer.c
+++ b/apps/pt_demo/tracer.c
@@ -1372,7 +1372,7 @@ void sdp_packet_callback(uint msg, uint port)
 }
 
 
-void load_mc_routing_tables()
+void load_mc_routing_tables(void)
 {
     if (sark_core_id() != sark_app_lead()) {
         return;
@@ -1410,7 +1410,7 @@ void timer_callback(uint time, uint none)
 }
 
 
-void c_main()
+void c_main(void)
 {
     io_printf(IO_BUF, "Started tracer\n");
 

--- a/apps/sdping/sdping.c
+++ b/apps/sdping/sdping.c
@@ -103,7 +103,7 @@ void flip_led(uint ticks, uint null)
 
 // Main program just sets up callbacks and then starts the API
 
-void c_main()
+void c_main(void)
 {
     io_printf(IO_STD, ">> sdping\n");
 

--- a/apps/simple/simple.c
+++ b/apps/simple/simple.c
@@ -89,7 +89,7 @@ uint *sdram_buffer;
 *
 * SOURCE
 */
-void app_init()
+void app_init(void)
 {
     /* ------------------------------------------------------------------- */
     /* initialise routing entries                                          */
@@ -156,7 +156,7 @@ void app_init()
 *
 * SOURCE
 */
-void app_done()
+void app_done(void)
 {
     // report simulation time
     io_printf(IO_BUF, "[core %d] simulation lasted %d ticks\n", coreID,
@@ -377,7 +377,7 @@ void check_memcopy(uint tid, uint ttag)
 *
 * SOURCE
 */
-void c_main()
+void c_main(void)
 {
     // Get core and chip IDs
 

--- a/bmp/bmp_crc.c
+++ b/bmp/bmp_crc.c
@@ -138,7 +138,7 @@ void crc32_buf(void *buf, uint32_t len)
 
 uint8_t buf[4096];
 
-int main()
+int main(void)
 {
     uint32_t crc = 0xffffffff;
     uint32_t count = 0;

--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -352,7 +352,7 @@ void sark_block_free(mem_block_t *root, void *blk)
 // Get a free SDP message from the shared SysRAM pool. Returns pointer
 // to message on success, NULL on failure.
 
-sdp_msg_t* sark_shmsg_get()
+sdp_msg_t* sark_shmsg_get(void)
 {
     uint cpsr = sark_lock_get(LOCK_MSG);
 

--- a/sark/sark_hw.c
+++ b/sark/sark_hw.c
@@ -405,7 +405,7 @@ uint rtr_fr_get(void)
 
 // Initialise router point-to-point tables (every entry set to 6)
 
-void rtr_p2p_init()
+void rtr_p2p_init(void)
 {
     for (uint i = 0; i < P2P_TABLE_SIZE; i++) {
         rtr_p2p[i] = P2P_INIT;

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -100,7 +100,8 @@ user_event_queue_t user_event_queue;
 // -----------------------
 //! The queue of scheduled tasks.
 static task_queue_t task_queue[NUM_PRIORITIES-1];  // priority <= 0 is non-queueable
-//! The registered callbacks for each event type.
+//! \brief The registered callbacks for each event type.
+//! \warning SARK knows about this variable!
 cback_t callback[NUM_EVENTS];
 
 
@@ -884,7 +885,7 @@ uint spin1_start(sync_bool sync)
     return start(sync, 0);
 }
 
-uint spin1_start_paused()
+uint spin1_start_paused(void)
 {
     return start(SYNC_NOWAIT, 1);
 }

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -257,10 +257,11 @@ INT_HANDLER cc_tx_empty_isr(void)
     while (tx_packet_queue.start != tx_packet_queue.end
             && ~cc[CC_TCR] & 0x40000000) {
         // Dequeue packet
+        packet_t *packet = &tx_packet_queue.queue[tx_packet_queue.start];
 
-        uint key = tx_packet_queue.queue[tx_packet_queue.start].key;
-        uint data = tx_packet_queue.queue[tx_packet_queue.start].data;
-        uint TCR = tx_packet_queue.queue[tx_packet_queue.start].TCR;
+        uint key = packet->key;
+        uint data = packet->data;
+        uint TCR = packet->TCR;
 
         tx_packet_queue.start = (tx_packet_queue.start + 1) % TX_PACKET_QUEUE_SIZE;
 
@@ -306,8 +307,9 @@ INT_HANDLER dma_done_isr(void)
 
     // Prepare data for callback before triggering a new DMA transfer
 
-    uint completed_id  = dma_queue.queue[dma_queue.start].id;
-    uint completed_tag = dma_queue.queue[dma_queue.start].tag;
+    copy_t *entry = &dma_queue.queue[dma_queue.start];
+    uint completed_id  = entry->id;
+    uint completed_tag = entry->tag;
 
     //TODO: can schedule up to 2 transfers if DMA free
     // Update queue pointer and trigger new transfer if queue not empty
@@ -315,9 +317,10 @@ INT_HANDLER dma_done_isr(void)
     dma_queue.start = (dma_queue.start + 1) % DMA_QUEUE_SIZE;
 
     if (dma_queue.start != dma_queue.end) {
-        uint *system_address = dma_queue.queue[dma_queue.start].system_address;
-        uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
-        uint  description = dma_queue.queue[dma_queue.start].description;
+        entry = &dma_queue.queue[dma_queue.start];
+        uint *system_address = entry->system_address;
+        uint *tcm_address = entry->tcm_address;
+        uint description = entry->description;
 
         dma[DMA_ADRS] = (uint) system_address;
         dma[DMA_ADRT] = (uint) tcm_address;
@@ -355,8 +358,9 @@ INT_HANDLER dma_done_fiqsr(void)
 
     // Prepare data for callback before triggering a new DMA transfer
 
-    uint completed_id  = dma_queue.queue[dma_queue.start].id;
-    uint completed_tag = dma_queue.queue[dma_queue.start].tag;
+    copy_t *entry = &dma_queue.queue[dma_queue.start];
+    uint completed_id  = entry->id;
+    uint completed_tag = entry->tag;
 
     //TODO: can schedule up to 2 transfers if DMA free
 
@@ -365,9 +369,10 @@ INT_HANDLER dma_done_fiqsr(void)
     dma_queue.start = (dma_queue.start + 1) % DMA_QUEUE_SIZE;
 
     if (dma_queue.start != dma_queue.end) {
-        uint *system_address = dma_queue.queue[dma_queue.start].system_address;
-        uint *tcm_address = dma_queue.queue[dma_queue.start].tcm_address;
-        uint  description = dma_queue.queue[dma_queue.start].description;
+        entry = &dma_queue.queue[dma_queue.start];
+        uint *system_address = entry->system_address;
+        uint *tcm_address = entry->tcm_address;
+        uint description = entry->description;
 
         dma[DMA_ADRS] = (uint) system_address;
         dma[DMA_ADRT] = (uint) tcm_address;


### PR DESCRIPTION
**Minor changes only.**

A general C rule is to only declare a function as taking any arbitrary arguments (with no access) in _very_ rare cases.

Also rewrote a few ISRs to definitely resolve an index into a queue to a specific entry. I'd hope that this wouldn't matter, but I prefer to resolve rather than assume that the index won't change, and it does encourage the compiler to generate good code.