### PR TITLE
Emergency fix

### DIFF
--- a/sark/sark_base.c
+++ b/sark/sark_base.c
@@ -39,8 +39,10 @@
 #include "spin1_api.h"
 #include "spin1_api_params.h"
 
+// OVERRIDDEN BY SPIN1_API
 cback_t WEAK callback[NUM_EVENTS];
 
+// OVERRIDDEN BY SPIN1_API
 void WEAK schedule_sysmode(uchar event_id, uint arg0, uint arg1) {}
 
 #endif

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1357,11 +1357,13 @@ uint spin1_set_mc_table_entry(uint entry, uint key, uint mask, uint route)
 *  that the function is only called by interrupt service routines responding
 *  to events, and these ISRs execute with interrupts disabled.
 *
+* \note Also called from sark_base.c and sark_alib.s via weak linking.
+*
 * \param[in] event_id: ID of the event triggering a callback
 * \param[in] arg0: argument to be passed to the callback
 * \param[in] arg1: argument to be passed to the callback
 */
-static void schedule_sysmode(uchar event_id, uint arg0, uint arg1)
+void schedule_sysmode(uchar event_id, uint arg0, uint arg1)
 {
     if (callback[event_id].priority <= 0) {
         callback[event_id].cback(arg0, arg1);


### PR DESCRIPTION
`schedule_sysmode()` in Spin1_API is called by SARK (two places, including assembly code) via weak linking (so things still built “correctly”). This means that it must not be `static`!