### PR TITLE
Generate a .tag file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 **/build
 html
 /doxybuild
+/sllt.tag

--- a/.ratexcludes
+++ b/.ratexcludes
@@ -4,6 +4,7 @@
 **/*.conf
 **/*.fig
 **/*.eps
+**/*.tag
 
 **/build/**
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1641,7 +1641,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = doxybuild/tools/html/sllt.tag
 
 # If the ALLEXTERNALS tag is set to YES, all external class will be listed in
 # the class index. If set to NO, only the inherited external classes will be


### PR DESCRIPTION
This should allow downstream doxygen builds to link to the docs, as tag files are a machine-readable (XML) description of the structure of the generated documentation. Benefits will be mainly observable elsewhere. For (sparse) details on how this works, see https://www.doxygen.nl/manual/external.html

Note that the BMP doesn't get a tag file. Don't expect to ever need that!