### PR TITLE
Fix for armcc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,9 @@ pipeline {
         stage('Setup') {
             steps {
                 sh 'pip install spalloc'
-                gitAskPass('98413a50-3a5d-4ca9-b672-5bfc168f01a5', 'git clone https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests hwtests')
+                dir 'hwtests' {
+                    git branch:'master', credentialsId: '98413a50-3a5d-4ca9-b672-5bfc168f01a5', url:'https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests'
+                }
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,9 +52,9 @@ pipeline {
                     sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
                 }
                 
-                // Build BMPC with armcc
+                // Build BMP with armcc
                 catchError {
-                    sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
+                    sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmp'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,7 @@ pipeline {
     stages {
         stage('Clean and Checkout') {
             steps {
+                echo "PATH is: $PATH"
                 sh 'rm -rf ${WORKSPACE}/*'
                 sh 'rm -rf ${WORKSPACE}/.[a-zA-Z0-9]*'
                 dir('spinnaker_tools') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,13 +43,19 @@ pipeline {
             steps {
                 
                 // Build with armcc
-                sh 'make -C $SPINN_DIRS GNU=0'
+                catchError {
+                    sh 'make -C $SPINN_DIRS GNU=0'
+                }
                 
                 // Build SCAMP with armcc
-                sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
+                catchError {
+                    sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
+                }
                 
                 // Build BMPC with armcc
-                sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
+                catchError {
+                    sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
+                }
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         }
     }
     environment {
-        PATH = "${workspace}/spinnaker_tools/tools:$PATH"
+        
     }
     options {
         skipDefaultCheckout true
@@ -44,16 +44,15 @@ pipeline {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
             }
             steps {
-                echo "PATH is: $PATH"
                 
                 // Build with armcc
                 sh 'make -C $SPINN_DIRS GNU=0'
                 
                 // Build SCAMP with armcc
-                sh 'make -C $SPINN_DIRS/scamp GNU=0'
+                sh 'PATH="${workspace}/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
                 
                 // Build BMPC with armcc
-                sh 'make -C $SPINN_DIRS/bmpc GNU=0'
+                sh 'PATH="${workspace}/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
                 WORKSPACE = "${workspace}"
-                PERL5LIB = "${workspace}/spinnaker_tools:$PERL5LIB"
+                PERL5LIB = "${workspace}/spinnaker_tools/tools:$PERL5LIB"
             }
             steps {
                 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,9 @@ pipeline {
             args '--privileged'
         }
     }
+    environment {
+        PATH = "${workspace}/spinnaker_tools/tools:$PATH"
+    }
     options {
         skipDefaultCheckout true
     }
@@ -38,11 +41,11 @@ pipeline {
         stage('Build') {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
-                PATH = "${workspace}/spinnaker_tools/tools:$PATH"
             }
             steps {
-                sh 'echo $PATH'
             
+                sh 'echo $PATH'
+                
                 // Build with armcc
                 sh 'make -C $SPINN_DIRS GNU=0'
                 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,10 +21,6 @@ pipeline {
             args '--privileged'
         }
     }
-    environment {
-        // This is where 'pip install --user' puts things
-        PATH = "$HOME/.local/bin:$PATH"
-    }
     options {
         skipDefaultCheckout true
     }
@@ -42,6 +38,7 @@ pipeline {
         stage('Build') {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
+                PATH = "${workspace}/spinnaker_tools/tools:$PATH"
             }
             steps {
                 // Build with armcc

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
         stage('Build') {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
+                WORKSPACE = "${workspace}"
             }
             steps {
                 
@@ -45,10 +46,10 @@ pipeline {
                 sh 'make -C $SPINN_DIRS GNU=0'
                 
                 // Build SCAMP with armcc
-                sh 'PATH="${workspace}/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
+                sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/scamp GNU=0'
                 
                 // Build BMPC with armcc
-                sh 'PATH="${workspace}/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
+                sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmpc GNU=0'
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         stage('Setup') {
             steps {
                 sh 'pip install spalloc'
-                sh 'git clone https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests hwtests'
+                gitAskPass('98413a50-3a5d-4ca9-b672-5bfc168f01a5', 'git clone https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests hwtests')
             }
         }
         

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
                 WORKSPACE = "${workspace}"
+                PERL5LIB = "${workspace}/spinnaker_tools:$PERL5LIB"
             }
             steps {
                 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
             }
             steps {
                 // Boot a 3-board machine
-                sh 'spalloc 3 -c hwtests/board_tests/boot-bt {}'
+                sh 'spalloc 3 --owner Jenkins -c "hwtests/board_tests/boot-bt {}"'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,7 @@ pipeline {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
             }
             steps {
-            
-                sh 'echo $PATH'
+                echo "PATH is: $PATH"
                 
                 // Build with armcc
                 sh 'make -C $SPINN_DIRS GNU=0'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
             }
             steps {
                 // Boot a 3-board machine
-                sh 'spalloc 3 -c "hwtests/board_tests/boot-bt {}"'
+                sh 'spalloc 3 -c hwtests/board_tests/boot-bt {}'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,73 @@
+/*
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+pipeline {
+    agent {
+        docker { 
+            image 'python3.6'
+            args '--privileged'
+        }
+    }
+    environment {
+        // This is where 'pip install --user' puts things
+        PATH = "$HOME/.local/bin:$PATH"
+    }
+    options {
+        skipDefaultCheckout true
+    }
+    stages {
+        stage('Clean and Checkout') {
+            steps {
+                sh 'rm -rf ${WORKSPACE}/*'
+                sh 'rm -rf ${WORKSPACE}/.[a-zA-Z0-9]*'
+                dir('spinnaker_tools') {
+                    checkout scm
+                }
+            }
+        }
+        
+        stage('Build') {
+            environment {
+                SPINN_DIRS = "${workspace}/spinnaker_tools"
+            }
+            steps {
+                // Build with armcc
+                sh 'make -C $SPINN_DIRS GNU=0'
+                
+                // Build SCAMP with armcc
+                sh 'make -C $SPINN_DIRS/scamp GNU=0'
+                
+                // Build BMPC with armcc
+                sh 'make -C $SPINN_DIRS/bmpc GNU=0'
+            }
+        }
+        
+    }
+    post {
+        always {
+            script {
+                emailext subject: '$DEFAULT_SUBJECT',
+                    body: '$DEFAULT_CONTENT',
+                    recipientProviders: [
+                        [$class: 'CulpritsRecipientProvider'],
+                        [$class: 'DevelopersRecipientProvider'],
+                        [$class: 'RequesterRecipientProvider']
+                    ],
+                    replyTo: '$DEFAULT_REPLYTO'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,16 +21,12 @@ pipeline {
             args '--privileged'
         }
     }
-    environment {
-        
-    }
     options {
         skipDefaultCheckout true
     }
     stages {
         stage('Clean and Checkout') {
             steps {
-                echo "PATH is: $PATH"
                 sh 'rm -rf ${WORKSPACE}/*'
                 sh 'rm -rf ${WORKSPACE}/.[a-zA-Z0-9]*'
                 dir('spinnaker_tools') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
         stage('Setup') {
             steps {
                 sh 'pip install spalloc'
-                dir 'hwtests' {
+                dir('hwtests') {
                     git branch:'master', credentialsId: '98413a50-3a5d-4ca9-b672-5bfc168f01a5', url:'https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests'
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,8 @@ pipeline {
                 PATH = "${workspace}/spinnaker_tools/tools:$PATH"
             }
             steps {
+                sh 'echo $PATH'
+            
                 // Build with armcc
                 sh 'make -C $SPINN_DIRS GNU=0'
                 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,10 @@ pipeline {
                 dir('hwtests') {
                     git branch:'master', credentialsId: '98413a50-3a5d-4ca9-b672-5bfc168f01a5', url:'https://github.com/SpiNNakerManchester/SpiNNaker_hardware_tests'
                 }
+                sh 'mkdir ~/.config'
+                sh 'echo "[spalloc]" > ~/.config/spalloc'
+                sh 'echo "hostname = spinnaker.cs.man.ac.uk" >> ~/.config/spalloc'
+                sh 'echo "owner = Jenkins" >> ~/.config/spalloc'
             }
         }
         
@@ -76,7 +80,7 @@ pipeline {
             }
             steps {
                 // Boot a 3-board machine
-                sh 'spalloc 3 --owner Jenkins -c "hwtests/board_tests/boot-bt {}"'
+                sh 'spalloc 3 -c "hwtests/board_tests/boot-bt {}"'
             }
         }
     }

--- a/include/.gitignore
+++ b/include/.gitignore
@@ -7,3 +7,4 @@
 !spin1_api.h
 !spinnaker.h
 !version.h
+!scamp_spin1_sync.h

--- a/include/sark.h
+++ b/include/sark.h
@@ -63,14 +63,6 @@
 
 #define DEAD_WORD       0xdeaddead  //!< Stack fill value
 
-//! Clock drift fixed-point number definition in terms of the number of
-//! fractional bits and the mask to get the fractional bits
-#define DRIFT_FP_BITS 17
-#define DRIFT_INT_MASK (((1 << (32 - DRIFT_FP_BITS)) - 1) << DRIFT_FP_BITS)
-#define DRIFT_FRAC_MASK ((1 << DRIFT_FP_BITS) - 1)
-#define DRIFT_ONE (1 << DRIFT_FP_BITS)
-#define TIME_BETWEEN_SYNC_US 2000000 // !< The time between sync signals in us
-
 //------------------------------------------------------------------------------
 
 /*!

--- a/include/scamp_spin1_sync.h
+++ b/include/scamp_spin1_sync.h
@@ -1,0 +1,7 @@
+//! Clock drift fixed-point number definition in terms of the number of
+//! fractional bits and the mask to get the fractional bits
+#define DRIFT_FP_BITS 17U
+#define DRIFT_INT_MASK (((1U << (32 - DRIFT_FP_BITS)) - 1) << DRIFT_FP_BITS)
+#define DRIFT_FRAC_MASK ((1U << DRIFT_FP_BITS) - 1)
+#define DRIFT_ONE (1U << DRIFT_FP_BITS)
+#define TIME_BETWEEN_SYNC_US 2000000U // !< The time between sync signals in us

--- a/include/scamp_spin1_sync.h
+++ b/include/scamp_spin1_sync.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2019-2020 The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 //! Clock drift fixed-point number definition in terms of the number of
 //! fractional bits and the mask to get the fractional bits
 #define DRIFT_FP_BITS 17U

--- a/include/spinnaker.h
+++ b/include/spinnaker.h
@@ -1133,24 +1133,19 @@ enum {
 //! \brief Bits in the ARM Current Program Status Register
 //! \details
 //! 	https://www.keil.com/pack/doc/CMSIS/Core_A/html/group__CMSIS__CPSR.html
-enum {
-    // Mode bits: [4:0]
-    MODE_USER =     0x10, //!< User mode
-    MODE_FIQ =      0x11, //!< Fast interrupt mode
-    MODE_IRQ =      0x12, //!< Interrupt mode
-    MODE_SVC =      0x13, //!< Supervisor mode
-    MODE_ABT =      0x17, //!< Abort mode
-    MODE_UND =      0x1b, //!< Undefined mode
-    MODE_SYS =      0x1f, //!< System mode
+#define MODE_USER       0x10  //!< User mode
+#define MODE_FIQ        0x11  //!< Fast interrupt mode
+#define MODE_IRQ        0x12  //!< Interrupt mode
+#define MODE_SVC        0x13  //!< Supervisor mode
+#define MODE_ABT        0x17  //!< Abort mode
+#define MODE_UND        0x1b  //!< Undefined mode
+#define MODE_SYS        0x1f  //!< System mode
 
-    // Thumb bit: [5]
-    THUMB_BIT =     0x20, //!< Thumb instruction mode
+#define THUMB_BIT       0x20  //!< Thumb instruction mode flag
 
-    // Interrupt control: [7:6]
-    IMASK_IRQ =     0x80, //!< Mask: IRQ enabled
-    IMASK_FIQ =     0x40, //!< Mask: FIQ enabled
-    IMASK_ALL =     0xc0  //!< Mask: All interrupts enabled
-};
+#define IMASK_IRQ       0x80  //!< Mask: IRQ enabled
+#define IMASK_FIQ       0x40  //!< Mask: FIQ enabled
+#define IMASK_ALL       0xc0  //!< Mask: All interrupts enabled
 //! \}
 
 //------------------------------------------------------------------------------

--- a/include/spinnaker.h
+++ b/include/spinnaker.h
@@ -1100,9 +1100,17 @@ enum {
 
 // On-chip SDRAM
 //! Bits in #GPIO_PORT, also on-chip SDRAM
+#define TOP_BIT 0x80000000
+#ifndef __GNUC__
+// Don't warn out-of-int-range on armcc; uint is used anyway according to:
+// https://developer.arm.com/documentation/dui0491/c/
+// c-and-c---implementation-details/
+// structures--unions--enumerations--and-bitfields?lang=en
+#pragma push
+#pragma diag_suppress 66
+#endif
 enum {
-    // Out of range, so shouldn't be used
-    // SDRAM_TQ =      (1 << 31),
+    SDRAM_TQ =      TOP_BIT,
     SDRAM_DPD =     (1 << 30),
     SDRAM_HERE =    (1 << 29),
 
@@ -1111,6 +1119,10 @@ enum {
     JTAG_TDI =      (1 << 25),
     JTAG_TCK =      (1 << 24)
 };
+#ifndef __GNUC__
+// Undo suppression of warning
+#pragma pop
+#endif
 
 //! Bits in #SC_MISC_CTRL
 enum {

--- a/include/spinnaker.h
+++ b/include/spinnaker.h
@@ -1098,8 +1098,7 @@ enum {
     SERIAL_OE =     (SERIAL_NCS + SERIAL_CLK + SERIAL_SI)
 };
 
-// On-chip SDRAM
-//! Bits in #GPIO_PORT, also on-chip SDRAM
+//! The top bit of an unsigned integer
 #define TOP_BIT 0x80000000
 #ifndef __GNUC__
 // Don't warn out-of-int-range on armcc; uint is used anyway according to:
@@ -1109,6 +1108,8 @@ enum {
 #pragma push
 #pragma diag_suppress 66
 #endif
+// On-chip SDRAM
+//! Bits in #GPIO_PORT, also on-chip SDRAM
 enum {
     SDRAM_TQ =      TOP_BIT,
     SDRAM_DPD =     (1 << 30),

--- a/include/spinnaker.h
+++ b/include/spinnaker.h
@@ -1101,7 +1101,8 @@ enum {
 // On-chip SDRAM
 //! Bits in #GPIO_PORT, also on-chip SDRAM
 enum {
-    SDRAM_TQ =      (1 << 31),
+    // Out of range, so shouldn't be used
+    // SDRAM_TQ =      (1 << 31),
     SDRAM_DPD =     (1 << 30),
     SDRAM_HERE =    (1 << 29),
 

--- a/include/version.h
+++ b/include/version.h
@@ -30,8 +30,8 @@
 #define __VERSION_H__
 
 //! SpiNNaker Low Level Tools Version: string
-#define SLLT_VER_STR    "3.4.0"
+#define SLLT_VER_STR    "3.4.1"
 //! SpiNNaker Low Level Tools Version: BCD
-#define SLLT_VER_NUM    0x030400
+#define SLLT_VER_NUM    0x030401
 
 #endif

--- a/release.txt
+++ b/release.txt
@@ -4,6 +4,18 @@
 #
 #-------------------------------------------------------------------------------
 
+Version 3.4.1 - Bug fixing
+
+Bug fixes:
+
+* ALL: Documentation fixes
+
+* ALL: Reduce warnings when compiling with armcc
+
+* SCAMP: Allow building and booting with gcc compiler
+
+#-------------------------------------------------------------------------------
+
 Version 3.4.0 - New features
 
 New Features:

--- a/sark/sark_alloc.c
+++ b/sark/sark_alloc.c
@@ -63,7 +63,7 @@ void *sark_xalloc(heap_t *heap, uint size, uint tag, uint flag)
 
     size = ((size + 3) & ~3) + sizeof(block_t);
 
-    uint cpsr;
+    uint cpsr = 0;
 
     if (flag & ALLOC_LOCK) {
         cpsr = sark_lock_get(LOCK_HEAP);
@@ -145,7 +145,7 @@ void sark_xfree(heap_t *heap, void *ptr, uint flag)
         rt_error(RTE_NULL);
     }
 
-    uint cpsr;
+    uint cpsr = 0;
 
     if (flag & ALLOC_LOCK) {
         cpsr = sark_lock_get(LOCK_HEAP);
@@ -247,7 +247,7 @@ uint sark_heap_max(heap_t *heap, uint flag)
 {
     block_t *p = heap->free;
     uint max = 0;
-    uint cpsr;
+    uint cpsr = 0;
 
     if (flag & ALLOC_LOCK) {
         cpsr = sark_lock_get(LOCK_HEAP);

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1740,7 +1740,7 @@ void chk_bl_del(void)
             // start boot image DMA to SDRAM for delegate,
             dma[DMA_ADRS] = (uint) SDRAM_BASE;
             dma[DMA_ADRT] = (uint) DTCM_BASE + 0x00008000;
-            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x7100;
+            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | BOOT_IMAGE_SIZE;
 
             // take blacklisted cores out of the application pool
             sc[SC_CLR_OK] = bl_cores;

--- a/scamp/scamp-app.c
+++ b/scamp/scamp-app.c
@@ -131,7 +131,17 @@ void set_cpu_info(uint virt_mask, uint state, uint app_id)
 //! \return The bit index of the least significant set bit
 static inline uint find_lead(uint mask)
 {
+#ifdef __GNUC__
     return __builtin_ffs(mask);
+#else
+    uint count = 0;
+
+    while ((mask != 0) && ((mask & (1 << count)) == 0)) {
+        count++;
+    }
+
+    return count;
+#endif
 }
 
 //! \brief Start an application on a set of cores

--- a/scamp/scamp-app.c
+++ b/scamp/scamp-app.c
@@ -131,9 +131,6 @@ void set_cpu_info(uint virt_mask, uint state, uint app_id)
 //! \return The bit index of the least significant set bit
 static inline uint find_lead(uint mask)
 {
-#ifdef __GNUC__
-    return __builtin_ffs(mask);
-#else
     uint count = 0;
 
     while ((mask != 0) && ((mask & (1 << count)) == 0)) {
@@ -141,7 +138,6 @@ static inline uint find_lead(uint mask)
     }
 
     return count;
-#endif
 }
 
 //! \brief Start an application on a set of cores

--- a/scamp/scamp-boot.c
+++ b/scamp/scamp-boot.c
@@ -30,19 +30,8 @@
 
 //------------------------------------------------------------------------------
 
-// These settings handle a boot image of size BLOCK_COUNT * BYTE_COUNT bytes
-// Image sizes < 32kB are possible.
-
 //! The address of the buffer used for booting cores
 #define BOOT_BUF (DTCM_BASE + 0x8000)
-
-// BLOCK_COUNT * BYTE_COUNT must be < 32kB
-//! The number of blocks in the image to boot
-#define BLOCK_COUNT     31      // From 1-256
-//! The number of words in a block (1kB)
-#define WORD_COUNT      256     // From 1-256
-//! The number of bytes in a block
-#define BYTE_COUNT      (WORD_COUNT * sizeof(uint))
 
 //! \brief Flood fill phases, used in nearest neighbour packets.
 //! \details

--- a/scamp/scamp-del.c
+++ b/scamp/scamp-del.c
@@ -41,11 +41,11 @@ void img_cp_exe (void) {
     // start boot image DMA to top-half of DTCM,
     dma[DMA_ADRS] = (uint) SDRAM_BASE;
     dma[DMA_ADRT] = (uint) DTCM_BASE + 0x00008000;
-    dma[DMA_DESC] = 1 << 24 | 4 << 21 | 0 << 19 | 0x7100;
+    dma[DMA_DESC] = 1 << 24 | 4 << 21 | 0 << 19 | BOOT_IMAGE_SIZE;
 
     // start boot image DMA to ITCM,
     dma[DMA_ADRT] = (uint) ITCM_BASE;
-    dma[DMA_DESC] = 1 << 24 | 4 << 21 | 0 << 19 | 0x7100;
+    dma[DMA_DESC] = 1 << 24 | 4 << 21 | 0 << 19 | BOOT_IMAGE_SIZE;
 
     // wait for DTCM DMA to complete,
     while (!(dma[DMA_STAT] & (1 << 10))) {

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -28,6 +28,7 @@
 #include "spinnaker.h"
 #include "sark.h"
 #include "scamp.h"
+#include <scamp_spin1_sync.h>
 
 //! Multicast packet handler uses the FIQ VIC slot
 #define MC_SLOT SLOT_FIQ
@@ -125,7 +126,7 @@ __asm void eth_rx_int(void)
         mrs     lr, spsr                ;; Get SPSR_irq to LR
         stmfd   sp!, {r12, lr}          ;; Save SPSR & r12
 
-        msr     cpsr_c, #MODE_SYS       ;; Go to SYS mode, interrupts enabled
+        msr     cpsr_c, #0x1f           ;; Go to SYS mode, interrupts enabled
 
         stmfd   sp!, {r1-r3, lr}        ;; Save working regs and LR_sys
 
@@ -133,7 +134,7 @@ __asm void eth_rx_int(void)
 
         ldmfd   sp!, {r1-r3, lr}        ;; Restore working regs & LR_sys
 
-        msr     cpsr_c, #MODE_IRQ+IMASK_IRQ ; Back to IRQ mode, IRQ disabled
+        msr     cpsr_c, #0x12+0x80      ;; Back to IRQ mode, IRQ disabled
 
         mov     r12, #VIC_BASE          ;; Tell VIC we are done
         str     r12, [r12, #VIC_VADDR * 4]

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -126,7 +126,7 @@ __asm void eth_rx_int(void)
         mrs     lr, spsr                ;; Get SPSR_irq to LR
         stmfd   sp!, {r12, lr}          ;; Save SPSR & r12
 
-        msr     cpsr_c, #0x1f           ;; Go to SYS mode, interrupts enabled
+        msr     cpsr_c, #MODE_SYS       ;; Go to SYS mode, interrupts enabled
 
         stmfd   sp!, {r1-r3, lr}        ;; Save working regs and LR_sys
 
@@ -134,7 +134,7 @@ __asm void eth_rx_int(void)
 
         ldmfd   sp!, {r1-r3, lr}        ;; Restore working regs & LR_sys
 
-        msr     cpsr_c, #0x12+0x80      ;; Back to IRQ mode, IRQ disabled
+        msr     cpsr_c, #MODE_IRQ+IMASK_IRQ ;; Back to IRQ mode, IRQ disabled
 
         mov     r12, #VIC_BASE          ;; Tell VIC we are done
         str     r12, [r12, #VIC_VADDR * 4]

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -87,27 +87,24 @@ INT_HANDLER pkt_tx_int(void) // SPIN2 - optimise for register order??
 
 //! Ethernet packet received handler. Delegates to eth_receive()
 #ifdef __GNUC__
+#define STR(x) #x
+#define XSTR(s) STR(s)
 void eth_rx_int(void)
 {
     asm volatile (
     "   .arm \n\
         .global eth_receive \n\
-        .equ    MODE_SYS, 0x1f \n\
-        .equ    MODE_IRQ, 0x12 \n\
-        .equ    IMASK_IRQ, 0x80 \n\
-        .equ    VIC_BASE, 0x1f000000 \n\
-        .equ    VIC_VADDR, 0x30 \n\
         sub     lr, lr, #4 \n\
         stmfd   sp!, {r0, lr} \n\
         mrs     lr, spsr \n\
         stmfd   sp!, {r12, lr} \n\
-        msr     cpsr_c, #MODE_SYS \n\
+        msr     cpsr_c, #" XSTR(MODE_SYS) " \n\
         stmfd   sp!, {r1-r3, lr} \n\
         bl      eth_receive \n\
         ldmfd   sp!, {r1-r3, lr} \n\
-        msr     cpsr_c, #MODE_IRQ+IMASK_IRQ \n\
-        mov     r12, #VIC_BASE \n\
-        str     r12, [r12, #VIC_VADDR] \n\
+        msr     cpsr_c, #" XSTR(MODE_IRQ+IMASK_IRQ) " \n\
+        mov     r12, #" XSTR(VIC_BASE) " \n\
+        str     r12, [r12, #" XSTR(VIC_VADDR) "] \n\
         ldmfd   sp!, {r12, lr} \n\
         msr     spsr_cxsf, lr \n\
         ldmfd   sp!, {r0, pc}^ \n\

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -1300,7 +1300,7 @@ void nn_cmd_biff(uint x, uint y, uint data)
             // start boot image DMA to SDRAM for delegate,
             dma[DMA_ADRS] = (uint) SDRAM_BASE;
             dma[DMA_ADRT] = (uint) boot_img;
-            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x7100;
+            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | BOOT_IMAGE_SIZE;
 
             // don't kill a blacklisted monitor just yet,
             dead_cores &= ~(1 << sark.phys_cpu);

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -58,6 +58,24 @@
 //! \}
 //------------------------------------------------------------------------------
 
+//! \name SCAMP boot image constants
+//! \{
+
+// These settings handle a boot image of size BLOCK_COUNT * BYTE_COUNT bytes
+// Image sizes < 32kB are possible.
+// BLOCK_COUNT * BYTE_COUNT must be < 32kB
+
+//! The number of blocks in the image to boot
+#define BLOCK_COUNT     31      // From 1-256
+//! The number of words in a block (1kB)
+#define WORD_COUNT      256     // From 1-256
+//! The number of bytes in a block
+#define BYTE_COUNT      (WORD_COUNT * sizeof(uint))
+//! The maximum boot image size
+#define BOOT_IMAGE_SIZE (BLOCK_COUNT * BYTE_COUNT)
+//! \}
+//------------------------------------------------------------------------------
+
 //! \name IPTags
 //! \{
 // IPTag table sizes

--- a/scamp/spinn_srom.c
+++ b/scamp/spinn_srom.c
@@ -38,10 +38,11 @@ enum spinn_srom_commands {
     SROM_RDSR =     (0x05U << 24),
     SROM_WRSR =     (0x01U << 24),
     SROM_PE =       (0x42U << 24),
-    SROM_SE =       (0xd8U << 24),
-    SROM_CE =       (0xc7U << 24),
-    SROM_RDID =     (0xabU << 24),
-    SROM_DPD =      (0xb9U << 24)
+    // Out of range so shouldn't be used
+    // SROM_SE =       (0xd8U << 24),
+    // SROM_CE =       (0xc7U << 24),
+    // SROM_RDID =     (0xabU << 24),
+    // SROM_DPD =      (0xb9U << 24)
 };
 
 //! Flag bits within the SCP message

--- a/scamp/spinn_srom.c
+++ b/scamp/spinn_srom.c
@@ -38,11 +38,10 @@ enum spinn_srom_commands {
     SROM_RDSR =     (0x05U << 24),
     SROM_WRSR =     (0x01U << 24),
     SROM_PE =       (0x42U << 24),
-    // Out of range so shouldn't be used
-    // SROM_SE =       (0xd8U << 24),
-    // SROM_CE =       (0xc7U << 24),
-    // SROM_RDID =     (0xabU << 24),
-    // SROM_DPD =      (0xb9U << 24)
+    SROM_SE =       (0xd8U << 24),
+    SROM_CE =       (0xc7U << 24),
+    SROM_RDID =     (0xabU << 24),
+    SROM_DPD =      (0xb9U << 24)
 };
 
 //! Flag bits within the SCP message

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -23,6 +23,7 @@
 
 #include <spin1_api.h>
 #include <spin1_api_params.h>
+#include <scamp_spin1_sync.h>
 
 
 // ---------------------
@@ -773,18 +774,19 @@ static void report_warns(void)
 }
 
 
+#ifdef __GNUC__
+    register uint _lr asm("lr");
+#else
+    register uint _lr __asm("lr");
+#endif // __GNUC__
+
 void spin1_rte(rte_code code)
 {
     // Don't actually shutdown, just set the CPU into an RTE code and
     // stop the timer
     clean_up();
     sark_cpu_state(CPU_STATE_RTE);
-#ifdef __GNUC__
-    register uint lr asm("lr");
-#else
-    register uint lr __asm("lr");
-#endif // __GNUC__
-    sv_vcpu->lr = lr;        // Report the link register (calling address)
+    sv_vcpu->lr = _lr;        // Report the link register (calling address)
     sv_vcpu->rt_code = code;
     sv->led_period = 8;
 }

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -21,6 +21,7 @@
 
 #include <spin1_api.h>
 #include <spin1_api_params.h>
+#include <scamp_spin1_sync.h>
 
 //! \brief Wrapper for schedule_sysmode() that handles interrupts
 //! \param[in] event_id: ID of the event triggering a callback


### PR DESCRIPTION
Fixes that allow the code to compile using armcc again.  Also includes changes that remove warnings when compiling with armcc, as well as a change that means that the values of constants aren't copied when using gcc.