### PR TITLE
Add link to info

### DIFF
--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1740,7 +1740,7 @@ void chk_bl_del(void)
             // start boot image DMA to SDRAM for delegate,
             dma[DMA_ADRS] = (uint) SDRAM_BASE;
             dma[DMA_ADRT] = (uint) DTCM_BASE + 0x00008000;
-            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x7100;
+            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x8000;
 
             // take blacklisted cores out of the application pool
             sc[SC_CLR_OK] = bl_cores;

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -1740,7 +1740,7 @@ void chk_bl_del(void)
             // start boot image DMA to SDRAM for delegate,
             dma[DMA_ADRS] = (uint) SDRAM_BASE;
             dma[DMA_ADRT] = (uint) DTCM_BASE + 0x00008000;
-            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x8000;
+            dma[DMA_DESC] = 1 << 24 | 4 << 21 | 1 << 19 | 0x7100;
 
             // take blacklisted cores out of the application pool
             sc[SC_CLR_OK] = bl_cores;

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -474,12 +474,12 @@ uint cmd_info(sdp_msg_t *msg)
     // Add the link followed to get to root as this is used in signalling
     uint word = p2p_root >> P2P_LOG_EPW;
     uint offset = P2P_BPE * (p2p_root & P2P_EMASK);
-    uint p2p_root = (uint)(rtr_p2p + word);
-    uint link_root = (p2p_root >> offset) & 0x7;
+    uint p2p_root_data = rtr_p2p[word];
+    uint link_root = (p2p_root_data >> offset) & 0x7;
     *(buf++) = link_root;
 
     // Returned packet size
-    return 12 + 18 + 2 + 4 + 1;
+    return 12 + 18 + 2 + 4 + 4;
 }
 
 //------------------------------------------------------------------------------

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -477,6 +477,7 @@ uint cmd_info(sdp_msg_t *msg)
     uint p2p_root_data = rtr_p2p[word];
     ushort link_root = (p2p_root_data >> offset) & 0x7;
     // We only need the first byte of the data as the second will always be 0
+    // (We use a short here because the packet length has to be even)
     *(buf++) = link_root;
     *(buf++) = 0;
 

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -475,11 +475,13 @@ uint cmd_info(sdp_msg_t *msg)
     uint word = p2p_root >> P2P_LOG_EPW;
     uint offset = P2P_BPE * (p2p_root & P2P_EMASK);
     uint p2p_root_data = rtr_p2p[word];
-    uint link_root = (p2p_root_data >> offset) & 0x7;
+    ushort link_root = (p2p_root_data >> offset) & 0x7;
+    // We only need the first byte of the data as the second will always be 0
     *(buf++) = link_root;
+    *(buf++) = 0;
 
     // Returned packet size
-    return 12 + 18 + 2 + 4 + 4;
+    return 12 + 18 + 2 + 4 + 2;
 }
 
 //------------------------------------------------------------------------------

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -471,8 +471,15 @@ uint cmd_info(sdp_msg_t *msg)
     *(buf++) = sv->ip_addr[2];
     *(buf++) = sv->ip_addr[3];
 
+    // Add the link followed to get to root as this is used in signalling
+    uint word = p2p_root >> P2P_LOG_EPW;
+    uint offset = P2P_BPE * (p2p_root & P2P_EMASK);
+    uint p2p_root = (uint)(rtr_p2p + word);
+    uint link_root = (p2p_root >> offset) & 0x7;
+    *(buf++) = link_root;
+
     // Returned packet size
-    return 12 + 18 + 2 + 4;
+    return 12 + 18 + 2 + 4 + 1;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This simply adds the "link to root" to the chip info command, where this link is the link identified in the P2P table that packets should be sent to to get to the root chip.  This allows others to quickly identify the tree of chips for sending signals, and so allows us to remove chips when a chip in the path is down.