### PR TITLE
added a gcc linker script to place scamp stacks in the correct location.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
                 }
             }
         }
-        
+
         stage('Setup') {
             steps {
                 sh 'pip install spalloc'
@@ -47,48 +47,50 @@ pipeline {
                 sh 'echo "owner = Jenkins" >> ~/.config/spalloc'
             }
         }
-        
+
         stage('ARMCC Build and Test') {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
+                SPINN_PATH = "${workspace}/hwtests/board_tests"
                 WORKSPACE = "${workspace}"
                 PERL5LIB = "${workspace}/spinnaker_tools/tools:$PERL5LIB"
             }
             steps {
-                
+
                 // Build base and SCAMP with armcc
                 catchError {
                     sh 'make GNU=0 -C $SPINN_DIRS'
                     sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make GNU=0 -C $SPINN_DIRS/scamp'
                     sh 'make GNU=0 -C $SPINN_DIRS/scamp install'
-                    
-                    // Boot a 3-board machine
-                    sh 'spalloc 3 -c hwtests/board_tests/boot-bt {}'
+
+                    // Boot a SpiNN-5 board
+                    sh 'spalloc -c hwtests/board_tests/boot-bt {}'
                 }
-                
+
                 // Build BMP with armcc
                 catchError {
                     sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make -C $SPINN_DIRS/bmp'
                 }
             }
         }
-        
+
         stage('GCC Build and Test') {
             environment {
                 SPINN_DIRS = "${workspace}/spinnaker_tools"
+                SPINN_PATH = "${workspace}/hwtests/board_tests"
                 WORKSPACE = "${workspace}"
                 PERL5LIB = "${workspace}/spinnaker_tools/tools:$PERL5LIB"
             }
             steps {
-                
+
                 // Build base and SCAMP with gcc
                 sh 'make GNU=1 -C $SPINN_DIRS'
                 sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make GNU=1 -C $SPINN_DIRS/scamp'
                 sh 'make GNU=1 -C $SPINN_DIRS/scamp install'
-                
-                // Boot a 3-board machine
-                sh 'spalloc 3 -c hwtests/board_tests/boot-bt {}'
-                
+
+                // Boot a SpiNN-5 board
+                sh 'spalloc -c hwtests/board_tests/boot-bt {}'
+
                 // Cannot build BMP with gcc so far
             }
         }

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -15,6 +15,7 @@
 
 APP := scamp-3
 override THUMB := 1
+override SCAMP := 1
 include ../make/spinnaker_tools.mk
 
 SCAMP_OBJS = spinn_phy.o spinn_srom.o spinn_net.o scamp-app.o \
@@ -118,9 +119,9 @@ tar:
 	scamp/spinn_srom.c scamp/spinn_net.c scamp/scamp-app.c \
 	scamp/scamp-p2p.c scamp/scamp-nn.c scamp/scamp-cmd.c \
 	scamp/scamp-boot.c scamp/scamp-isr.c scamp/scamp-del.c scamp/spinn_phy.h \
-	scamp/scamp.h scamp/spinn_net.h scamp/spinn_srom.h scamp/spinn_regs.h \
+	scamp/scamp.h scamp/spinn_net.h scamp/spinn_regs.h \
 	scamp/boot_aplx.s scamp/$(APP).c scamp/$(APP).sct scamp/sark.c \
-	scamp/Makefile scamp/mkpad scamp/mksv
+	scamp/Makefile scamp/mkpad scamp/mksv scamp/$(APP).lnk scamp/boot.lnk
 
 clean:
 	$(RM) -r $(BUILD_DIR)* $(APP).boot

--- a/scamp/boot.lnk
+++ b/scamp/boot.lnk
@@ -1,6 +1,6 @@
 
 /*
-// sark.lnk	    GNU linker script for SARK/SpiNNaker applications
+// boot.lnk	    GNU linker script for scamp/boot_aplx.s build
 //
 // Copyright (C)    The University of Manchester - 2011-2013
 //

--- a/scamp/scamp-3.lnk
+++ b/scamp/scamp-3.lnk
@@ -1,0 +1,107 @@
+
+/*
+// scamp-3.lnk	    GNU linker script for SCAMP build
+//
+// Copyright (C)    The University of Manchester - 2011-2020
+//
+// Author           Steve Temple, APT Group, School of Computer Science
+//
+// Email            temples@cs.man.ac.uk
+//
+
+// Copyright (c) 2011-2020 The University of Manchester
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+
+MEMORY
+{
+    ITCM : ORIGIN = 0, LENGTH = 0x7f00
+    DTCM : ORIGIN = 0x400000, LENGTH = 0xf800
+}
+
+
+SECTIONS
+{
+    ITCM_BASE = 0x00000000;
+    DTCM_BASE = 0x00400000;
+
+    STACK_TOP = 0x00408000;
+    STACK_SIZE = 0x800;
+
+    APLX_SIZE = 64;
+    APLX_ENTRY = 16;
+
+    . = ITCM_BASE;
+
+    RO_DATA :
+    {
+          * (_alib_reset);
+          * (alib_*);
+          * (.text*);
+          __init_array_start = .;
+          KEEP (*(.init_array*))
+          __init_array_end = .;
+          * (.rodata*);
+          * (.fini*);
+          * (.init*);
+    } > ITCM
+
+    . = ALIGN (4);
+
+    /*
+      Attempt to deal with .ARM.exdix* sections. Ideally we probably
+      want to throw these away but for now they go into the RO binary
+      See also "objcopy" lines in make file...
+    */
+
+    EX_DATA :
+    {
+        * (.ARM.exidx*);
+    } > ITCM
+
+    RO_LENGTH = . - ITCM_BASE;
+
+    . = DTCM_BASE;
+
+    RW_DATA  :
+    {
+        * (.data*);
+    } > DTCM
+
+    . = ALIGN (4);
+
+    RW_LENGTH = . - DTCM_BASE;
+
+    ZI_DATA  :
+    {
+	* (.bss*);
+	* (COMMON);
+    } > DTCM
+
+    . = ALIGN (4);
+
+    HEAP_BASE = .;
+
+    RO_BASE = ITCM_BASE;
+    RO_FROM = APLX_SIZE;
+
+    RW_BASE = DTCM_BASE;
+    RW_FROM = APLX_SIZE + RO_LENGTH - APLX_ENTRY;
+
+    ZI_BASE = RW_BASE + RW_LENGTH;
+    ZI_LENGTH = HEAP_BASE - ZI_BASE;
+}


### PR DESCRIPTION
With the current STACK_TOP setting, scamp can corrupt a downloaded boot image (> 30Kb) when initialising its stacks.

This PR moves the scamp stacks from DTCM_TOP to the TOP of the bottom half of DTCM. This had already been done for armcc compilation but needed updating for gcc compilation.