### PR TITLE
suppress last scamp build warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,9 @@ pipeline {
 
                 // Build base and SCAMP with armcc
                 catchError {
+                    // show compiler version
+                    sh 'armcc --vsn'
+
                     sh 'make GNU=0 -C $SPINN_DIRS'
                     sh 'PATH="$WORKSPACE/spinnaker_tools/tools:$PATH" make GNU=0 -C $SPINN_DIRS/scamp'
                     sh 'make GNU=0 -C $SPINN_DIRS/scamp install'
@@ -82,6 +85,9 @@ pipeline {
                 PERL5LIB = "${workspace}/spinnaker_tools/tools:$PERL5LIB"
             }
             steps {
+
+                // show compiler version
+                sh 'arm-none-eabi-gcc --version'
 
                 // Build base and SCAMP with gcc
                 sh 'make GNU=1 -C $SPINN_DIRS'

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Installation and Setup
 
     The version of the GNU tools that was used to test this release is
 
-        gcc version 4.9.3 20150529 (release) [ARM/embedded-4_9-branch revision 227977]
+        gcc 9.2.1 20191025 (release) [ARM/arm-9-branch revision 277599]
 
     This (and more recent versions) can be downloaded from
     [this web site](https://launchpad.net/gcc-arm-embedded).
 
     The version of the ARM tools that was used to test this release is
 
-        ARM C/C++ Compiler, RVCT4.0 [Build 400]
+        ARM C/C++ Compiler, 4.1 [Build 894]
 
  2. Source the setup file in the directory in which it lives
 
@@ -31,13 +31,6 @@ Installation and Setup
 
         make GNU=0	        # If you are using ARM tools
         make        		# If you are using GNU tools
-
-    Note that you may see some compiler warnings during these builds.
-
-        ARM: Warning: A1581W: Added 2 bytes of padding at address ...
-        ARM: Warning: C3017W: cpsr may be used before being set
-
-    These are harmless and can be ignored.
 
 Use of the Tools
 ----------------

--- a/make/spinnaker_tools.mk
+++ b/make/spinnaker_tools.mk
@@ -112,11 +112,16 @@ else
     OTIME := -Otime
     ALL_WARNINGS :=
 
+    # suppress linker warning about empty RW sections when building scamp
+    ifeq ($(SCAMP), 1)
+        LD_FLAG := --diag_suppress L6329W
+    endif
+
     ifeq ($(LIB), 1)
         CFLAGS += --split_sections
         LD := armlink --partial
     else
-        LD = armlink --scatter=$(SPINN_TOOLS_DIR)/sark.sct --remove --entry cpu_reset
+        LD = armlink --scatter=$(SPINN_TOOLS_DIR)/sark.sct $(LD_FLAG) --remove --entry cpu_reset
     endif
 
     AR := armar -rsc


### PR DESCRIPTION
suppressed warning about empty RW section during scamp build.

It is safe to suppress it, and the result is a clean scamp build.
