### PR TITLE
Add a badge to track the build status, in common with other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg)](https://github.com/SpiNNakerManchester/spinnaker_tools/actions?query=workflow%3A%22C+Actions%22)
+[![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg?branch=master)](https://github.com/SpiNNakerManchester/spinnaker_tools/actions?query=workflow%3A%22C+Actions%22+branch%3Amaster)
 
 SpiNNaker Low-Level Software Tools
 ==================================

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg)
+[![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg)](https://github.com/SpiNNakerManchester/spinnaker_tools/actions?query=workflow%3A%22C+Actions%22)
 
 SpiNNaker Low-Level Software Tools
 ==================================

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg)
+
 SpiNNaker Low-Level Software Tools
 ==================================
 [<small>Automated Documentation Build</small>](http://spinnakermanchester.github.io/spinnaker_tools/)


### PR DESCRIPTION
Badge says ![C Actions](https://github.com/SpiNNakerManchester/spinnaker_tools/workflows/C%20Actions/badge.svg) right now; do we want to change the label? If so, we have to change the name in the action as well as in the badge markdown burst.