### PR TITLE
Split synapse neuron models

### DIFF
--- a/include/spin1_api.h
+++ b/include/spin1_api.h
@@ -158,6 +158,11 @@ static inline void spin1_delay_us(uint n) {
     sark_delay_us(n);
 }
 
+/*!
+* \brief This function enables the use of timer_schedule_proc
+*/
+void spin1_enable_timer_schedule_proc(void);
+
 // ------------------------------------------------------------------------
 
 

--- a/include/spin1_api.h
+++ b/include/spin1_api.h
@@ -72,6 +72,18 @@ enum {
     FRPL_PACKET_RECEIVED = 7  //!< Fixed route packet with payload received
 };
 
+//! Match events above to their VIC interrupts.  Indices must match!
+static const uint VIC_EVENTS[] = {
+    (1 << CC_MC_INT),         //!< 0. Multicast packet received
+    (1 << DMA_DONE_INT),      //!< 1. DMA transfer complete
+    (1 << TIMER1_INT),        //!< 2. Regular timer tick
+    0,                        //!< 3. SDP message received; handled elsewhere
+    (1 << SOFTWARE_INT),      //!< 4. User-triggered interrupt
+    (1 << CC_MC_INT),         //!< 5. Mulitcast packet with payload received
+    (1 << CC_FR_INT),         //!< 6. Fixed route packet received
+    (1 << CC_FR_INT)          //!< 7. Fixed route packet with payload received
+};
+
 // ------------------------------------------------------------------------
 // DMA transfer parameters
 // ------------------------------------------------------------------------

--- a/include/spin1_api_params.h
+++ b/include/spin1_api_params.h
@@ -174,14 +174,15 @@ enum spin1_api_multicast_entries {
 // -----------------------
 enum spin1_api_vic_priorties {
     SARK_PRIORITY =        0,   //!< Communication with SARK/SCAMP
-    TIMER1_PRIORITY =      1,   //!< Timer interrupt
-    DMA_DONE_PRIORITY =    2,   //!< DMA complete
-    RX_READY_PRIORITY =    3,   //!< Multicast message ready to receive
-    FR_READY_PRIORITY =    4,   //!< Fixed route message ready to receive
-    CC_TMT_PRIORITY =      5,   //!< Comms controller timeout
-    SOFT_INT_PRIORITY =    6,   //!< Software-driven interrupt
+    TIMER2_PRIORITY =      1,   //!< Timer 2 interrupt (events)
+    TIMER1_PRIORITY =      2,   //!< Timer interrupt
+    DMA_DONE_PRIORITY =    3,   //!< DMA complete
+    RX_READY_PRIORITY =    4,   //!< Multicast message ready to receive
+    FR_READY_PRIORITY =    5,   //!< Fixed route message ready to receive
+    CC_TMT_PRIORITY =      6,   //!< Comms controller timeout
+    SOFT_INT_PRIORITY =    7,   //!< Software-driven interrupt
 #if USE_WRITE_BUFFER == TRUE
-    DMA_ERR_PRIORITY =     7    //!< DMA error
+    DMA_ERR_PRIORITY =     8    //!< DMA error
 #endif
 };
 

--- a/include/spin1_api_params.h
+++ b/include/spin1_api_params.h
@@ -155,6 +155,8 @@ enum spin1_api_error_codes {
 // -----------------------
 //! callback queue parameters
 enum spin1_api_callback_queue_params {
+    N_TASK_QUEUES = 4,    //!< Number of priorities - 1 because priority 0 is
+                          //!< not queued
     NUM_PRIORITIES =  5,  //!< Number of priorities
     TASK_QUEUE_SIZE = 16  //!< Size of task queue
 };

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -57,7 +57,7 @@ static const uint ALL_HANDLED_INTERRUPTS =
         ((1 << TIMER1_INT) | (1 << SOFTWARE_INT) | (1 << CC_MC_INT) |
          (1 << CC_FR_INT) | (1 << DMA_ERR_INT)  | (1 << DMA_DONE_INT));
 //! The highest priority selected
-static int highest_priority = -1;
+static uint highest_priority = 0;
 
 //! \brief Which event is to be handled by the FIQ.
 //! \details Used to enforce that only one type of basic interrupt handler
@@ -108,7 +108,7 @@ user_event_queue_t user_event_queue;
 /* scheduler/dispatcher */
 // -----------------------
 //! The queue of scheduled tasks.
-static task_queue_t task_queue[NUM_PRIORITIES-1];  // priority <= 0 is non-queueable
+static task_queue_t task_queue[N_TASK_QUEUES];
 //! \brief The registered callbacks for each event type.
 //! \warning SARK knows about this variable!
 cback_t callback[NUM_EVENTS];
@@ -478,7 +478,7 @@ static void dispatch(void)
         // scheduler/dispatcher accesses to queues
         cpsr = spin1_int_disable();
 
-        while (run && i <= highest_priority) {
+        while (run && i < highest_priority) {
             tq = &task_queue[i];
 
             i++;  // prepare for next priority queue
@@ -584,8 +584,11 @@ void spin1_callback_on(uint event_id, callback_t cback, int priority)
     if (run) {
         vic[VIC_ENABLE] = VIC_EVENTS[event_id];
     }
-    if (priority > highest_priority) {
-        highest_priority = priority;
+    if (priority > 0) {
+        uint p = (uint) priority;
+        if (p > highest_priority) {
+            highest_priority = priority;
+        }
     }
 }
 

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1016,7 +1016,6 @@ void spin1_dma_flush(void)
     // abort any ongoing transfer in the DMA controller,
     // and clear any pending DMA_COMPLETE interrupts in the DMA controller
     dma[DMA_CTRL] = 0x1f;
-    dma[DMA_CTRL] = 0x0d;
 
     // purge any queued DMA_COMPLETE callbacks in the callback queues
     if (callback[DMA_TRANSFER_DONE].priority > 0) {
@@ -1060,6 +1059,12 @@ void spin1_dma_flush(void)
     dma_queue.start = 0;
     dma_queue.end   = 0;
     spin1_mode_restore(cpsr);
+
+    // and finally make sure the DMA unit is reset fully
+    while (dma[DMA_STAT] & 0x1) {
+        continue;
+    }
+    dma[DMA_CTRL] = 0x0d;
 }
 /*
 *******/

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -298,8 +298,6 @@ static void configure_vic(uint enable_timer)
     old_select = vic[VIC_SELECT];
     old_enable = vic[VIC_ENABLE];
 
-    // configure irq based on user request
-
     // configure fiq -- if requested by user
     switch (fiq_event) {
     case MC_PACKET_RECEIVED:

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1406,6 +1406,10 @@ uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
 /*
 *******/
 
+void spin1_enable_timer_schedule_proc(void) {
+    event_register_timer(TIMER2_PRIORITY);
+}
+
 
 /****f* spin1_api.c/spin1_trigger_user_event
 *

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -155,6 +155,7 @@ extern INT_HANDLER timer1_fiqsr(void);
 extern INT_HANDLER soft_int_fiqsr(void);
 //! \brief Interrupt handler for messages from SCAMP.
 extern INT_HANDLER sark_int_han(void);
+extern INT_HANDLER sark_fiqsr(void);
 
 // ----------------------------
 /* intercore synchronisation */
@@ -322,6 +323,10 @@ static void configure_vic(uint enable_timer)
     case USER_EVENT:
         sark_vec->fiq_vec = soft_int_fiqsr;
         fiq_select = (1 << SOFTWARE_INT);
+        break;
+    case SDP_PACKET_RX:
+        sark_vec->fiq_vec = sark_fiqsr;
+        fiq_select = (1 << CPU_INT);
         break;
     }
 

--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -289,8 +289,7 @@ static void configure_vic(uint enable_timer)
     uint fiq_select = 0;
 
     // disable the relevant interrupts while configuring the VIC
-
-    vic[VIC_DISABLE] = ALL_HANDLED_INTERRUPTS;
+    vic[VIC_DISABLE] = user_int_select;
 
     // remember default fiq handler
 

--- a/spin1_api/spin1_isr.c
+++ b/spin1_api/spin1_isr.c
@@ -542,3 +542,9 @@ INT_HANDLER soft_int_fiqsr(void)
 }
 /*
 *******/
+
+extern void sark_int(void *pc);
+INT_HANDLER sark_fiqsr(void)
+{
+    sark_int(NULL);
+}


### PR DESCRIPTION
These changes were made to help the split synapse-neuron model run faster (though some ended up not being used, they don't do any harm I don't think).  Here is a summary of the changes:
 - Only enable interrupts based on which callbacks are registered.  This avoids ISRs being called when they are not used e.g. if the user handles the interrupt elsewhere, or doesn't want to make use of the interrupt at all.
 - Allow SDP FIQ (not used other than to test it out in one case, but shouldn't do any harm.
 - Add TIMER2 Priority (from work done with Luca originally I believe).
 - Minor fix to DMA queue clearing; it seemed that the DMA doesn't always reset properly, so this waits for it to finish any transfers.
 - Dispatch queue processing only looks at highest set priority level.