### PR TITLE
adds a cast to avoid mixed enumerated types warning.

### DIFF
--- a/spin1_api/spin1_api.c
+++ b/spin1_api/spin1_api.c
@@ -1452,7 +1452,8 @@ uint spin1_schedule_callback(callback_t cback, uint arg0, uint arg1,
 *******/
 
 void spin1_enable_timer_schedule_proc(void) {
-    event_register_timer(TIMER2_PRIORITY);
+  //NOTE: mixes enumerated types - cast avoids compiler warning
+  event_register_timer((vic_slot) TIMER2_PRIORITY);
 }
 
 


### PR DESCRIPTION
Function 'spin1_enable_timer_schedule_proc' [spin1_api.c, line 1454] generates a warning because it mixes two different enumerated types:
- vic_slot
- spin1_api_vic_priorties

This pull request adds a cast to avoid the warning.
