### PR TITLE
Sdram retry fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 html
 /doxybuild
 /sllt.tag
+/Debug/

--- a/include/sark.h
+++ b/include/sark.h
@@ -167,7 +167,15 @@ enum sark_aplx_command {
 
 #define ALLOC_LOCK      1       //!< Lock this operation
 #define ALLOC_ID        2       //!< Use supplied AppID
-#define ALLOC_TAG_RETRY 4       //!< If tag in use, just return address
+
+//! This allows for a "retry" of the allocation request when an SDRAM tag is
+//! specified.  If this flag is specified, and the tag in use, and the size of
+//! the allocation requested is the same as the size currently allocated, just
+//! return the address of the tag from the previous allocation.  Without this
+//! flag, the previous behavior is maintained, meaning that each tag can only
+//! be allocated once, and a re-allocation request will result in a NULL being
+//! returned.
+#define ALLOC_TAG_RETRY 4
 
 //------------------------------------------------------------------------------
 

--- a/include/sark.h
+++ b/include/sark.h
@@ -167,6 +167,7 @@ enum sark_aplx_command {
 
 #define ALLOC_LOCK      1       //!< Lock this operation
 #define ALLOC_ID        2       //!< Use supplied AppID
+#define ALLOC_TAG_RETRY 4       //!< If tag in use, just return address
 
 //------------------------------------------------------------------------------
 

--- a/sark/sark_alloc.c
+++ b/sark/sark_alloc.c
@@ -56,6 +56,13 @@ void *sark_xalloc(heap_t *heap, uint size, uint tag, uint flag)
     uint entry = (app_id << 8) + tag;
 
     if (tag != 0 && sv->alloc_tag[entry] != NULL) {
+        if (flag & ALLOC_TAG_RETRY) {
+            block_t* block = sv->alloc_tag[entry] - 1;
+            uint alloc_size = (uchar *) block->next - (uchar *) block;
+            if (size == alloc_size) {
+                return sv->alloc_tag[entry];
+            }
+        }
         return NULL;
     }
 

--- a/sark/sark_alloc.c
+++ b/sark/sark_alloc.c
@@ -58,7 +58,8 @@ void *sark_xalloc(heap_t *heap, uint size, uint tag, uint flag)
     if (tag != 0 && sv->alloc_tag[entry] != NULL) {
         if (flag & ALLOC_TAG_RETRY) {
             block_t* block = sv->alloc_tag[entry] - 1;
-            uint alloc_size = (uchar *) block->next - (uchar *) block;
+            uint alloc_size =
+                    ((uchar *) block->next - (uchar *) block) - sizeof(block_t);
             if (size == alloc_size) {
                 return sv->alloc_tag[entry];
             }

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -775,6 +775,7 @@ uint cmd_alloc(sdp_msg_t *msg)
 {
     uint op = msg->arg1 & 255;
     uint app_id = (msg->arg1 >> 8) & 255;
+    uint extra_flag = (msg->arg1 >> 16) & 255;
     if (op > ALLOC_MAX) {
         msg->cmd_rc = RC_ARG;
         return 0;
@@ -782,7 +783,6 @@ uint cmd_alloc(sdp_msg_t *msg)
 
     switch (op) {
     case ALLOC_SDRAM:
-        uint extra_flag = (msg->arg1 >> 16) & 255;
         msg->arg1 = (uint) sark_xalloc(sv->sdram_heap,
                 msg->arg2,
                 msg->arg3,

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -782,10 +782,11 @@ uint cmd_alloc(sdp_msg_t *msg)
 
     switch (op) {
     case ALLOC_SDRAM:
+        uint extra_flag = (msg->arg1 >> 16) & 255;
         msg->arg1 = (uint) sark_xalloc(sv->sdram_heap,
                 msg->arg2,
                 msg->arg3,
-                ALLOC_LOCK + ALLOC_ID + (app_id << 8));
+                ALLOC_LOCK + ALLOC_ID + (app_id << 8) + extra_flag);
         sv->app_data[app_id].clean = 0;
         break;
 


### PR DESCRIPTION
Adds the ability for an SDRAM tag allocation to be "retried".  This means that if the response to the allocation is not received back to the host, the host can retry without creating a second allocation, provided a tag is used and the flag is set appropriately in the request (i.e. it is optional, but at least possible).

This has been tested by SpiNNakerManchester/IntegrationTests#100