### PR TITLE
Improve flood fill

### DIFF
--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -1410,7 +1410,6 @@ void nn_do_fcpy(uint start_addr, uint chksum_link_length_id) {
 
     for (uint i = 0; i < length; i++) {
         if (link_read_word(addr, link, (uint *) addr, 100) != RC_OK) {
-            io_printf(IO_BUF, "Failed to read!\n");
             sw_error(SW_OPT);
             return;
         }

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -222,7 +222,7 @@ enum scamp_nn_opcodes {
     NN_CMD_SIG0 =  0,  //!< Misc (GTPC, Set FwdRty, LED, etc)
     NN_CMD_RTRC =  1,  //!< Router Control Reg
     NN_CMD_LTPC =  2,  //!< Local Time Phase Control (ID=0, Fwd=0)
-    NN_CMD_SP_3 =  3,  //!< Spare
+    NN_CMD_FCPY =  3,  //!< Copy data flood-fill
 
     NN_CMD_SIG1 =  4,  //!< Misc (MEM, etc)
     NN_CMD_P2PC =  5,  //!< P2P Address setup (Handled specially)


### PR DESCRIPTION
This adds a flood copy, which makes a chip copy data from a neighbour chip.  This should work as an improved flood fill in combination with an initial copy to the first chip.