### PR TITLE
Different app loading

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -444,7 +444,7 @@ enum sark_scp_command_codes {
     CMD_AR = 19,                //!< Application core reset
 
     CMD_NNP = 20,               //!< Send broadcast NN packet
-
+    CMD_APP_COPY_RUN = 21,      //!< Copy app from adjacent chip and reset
     CMD_SIG = 22,               //!< Send signal to apps
     CMD_FFD = 23,               //!< Send flood-fill data
 


### PR DESCRIPTION
Add a app copy command which can be sent to a chip to ask it to copy a binary from an adjacent chip and then start it.  This is part of what needs to be done, but this is needed along with existing functionality to make binary loading reasonably fast but also reliable (much more important than fast).

Testing in progress (see other PRs).