### PR TITLE
Reduce overhead

### DIFF
--- a/include/sark.h
+++ b/include/sark.h
@@ -454,8 +454,9 @@ enum sark_scp_command_codes {
 
     CMD_ALLOC = 28,             //!< Memory allocation
     CMD_RTR = 29,               //!< Router control
-    CMD_SYNC = 30,              //!< Control sending of synchronization msgs
+    CMD_RSVD = 30,              //!< Reserved (used elsewhere in software)
     CMD_INFO = 31,              //!< Get chip/core info
+    CMD_SYNC = 32,              //!< Control sending of synchronization msgs
 
     // 48-63 reserved for BMP
 

--- a/include/sark.h
+++ b/include/sark.h
@@ -437,7 +437,6 @@ enum sark_scp_command_codes {
     CMD_FILL = 5,               //!< Fill memory
 
     // Following for monitors only
-
     CMD_REMAP = 16,             //!< Remap application core
     CMD_LINK_READ = 17,         //!< Read neighbour memory
     CMD_LINK_WRITE = 18,        //!< Write neighbour memory
@@ -445,6 +444,7 @@ enum sark_scp_command_codes {
 
     CMD_NNP = 20,               //!< Send broadcast NN packet
 
+    CMD_SYNC = 21,              //!< Control sending of synchronization msgs
     CMD_SIG = 22,               //!< Send signal to apps
     CMD_FFD = 23,               //!< Send flood-fill data
 

--- a/scamp/scamp-3.c
+++ b/scamp/scamp-3.c
@@ -207,6 +207,9 @@ volatile uchar load = 0;
 //!     towards it over time.
 volatile uint disp_load = 0 << LOAD_FRAC_BITS;
 
+//! \brief Whether to perform clock synchronization (on by default at start)
+volatile uint do_sync = 1;
+
 //------------------------------------------------------------------------------
 
 //! Update timeouts in IPTags.

--- a/scamp/scamp-cmd.c
+++ b/scamp/scamp-cmd.c
@@ -859,6 +859,21 @@ uint cmd_remap(sdp_msg_t *msg)
     return 0;
 }
 
+//------------------------------------------------------------------------------
+
+extern volatile uint do_sync;
+extern uint n_beacons_sent;
+
+//! \brief Synchronization of cores handler
+//! \param[in,out] msg: SCP message, will be updated with result
+//! \return Always zero; result never has a payload
+uint cmd_sync(sdp_msg_t *msg) {
+    do_sync = msg->arg1;
+    // Increment the number of beacons sent, to ensure the next is ignored
+    n_beacons_sent++;
+    return 0;
+}
+
 
 //------------------------------------------------------------------------------
 
@@ -937,6 +952,8 @@ uint scamp_debug(sdp_msg_t *msg, uint srce_ip)
         return cmd_rtr(msg);
     case CMD_INFO:
         return cmd_info(msg);
+    case CMD_SYNC:
+        return cmd_sync(msg);
     default:
         msg->cmd_rc = RC_CMD;
         return 0;

--- a/scamp/scamp-isr.c
+++ b/scamp/scamp-isr.c
@@ -55,6 +55,7 @@ extern void msg_queue_insert(sdp_msg_t *msg, uint srce_ip);
 
 extern uchar v2p_map[MAX_CPUS];
 extern uint num_cpus;
+extern volatile uint do_sync;
 
 static uint centi_ms;   //!< Counts 0 to 9 in ms
 
@@ -293,7 +294,7 @@ INT_HANDLER pkt_p2p_int(void)
 //------------------------------------------------------------------------------
 
 //! Time beacon counter
-static uint n_beacons_sent = 0;
+uint n_beacons_sent = 0;
 //! Inter-synchronisation time, in microseconds
 static uint time_to_next_sync = TIME_BETWEEN_SYNC_US;
 
@@ -309,7 +310,7 @@ INT_HANDLER ms_timer_int(void)
 
     // Send the sync signal if appropriate
     if ((sv->p2p_root == sv->p2p_addr)
-            && (netinit_phase == NETINIT_PHASE_DONE)) {
+            && (netinit_phase == NETINIT_PHASE_DONE) && do_sync) {
         if (time_to_next_sync == 0) {
             uint data = (n_beacons_sent & N_BEACONS_MASK) << N_BEACONS_SHIFT;
             data |= tc[T1_COUNT] & SOURCE_T1_COUNT_MASK;

--- a/scamp/scamp-nn.c
+++ b/scamp/scamp-nn.c
@@ -307,7 +307,8 @@ void level_config(void)
 //! \param[in] key: The key of the packet
 void peek_ack_pkt(uint link, uint data, uint key)
 {
-    if (peek_pkt.flags != 1) {
+    if (peek_pkt.flags != 1 && peek_pkt.pkt.data == key
+            && peek_pkt.pkt.ctrl == link) {
         pkt_t t = {link, data, key};
         peek_pkt.pkt = t;
         peek_pkt.flags = 1;
@@ -340,7 +341,12 @@ void poke_ack_pkt(uint link, uint data, uint key)
 //! \return result code
 uint link_read_word(uint addr, uint link, uint *buf, uint timeout)
 {
+    // Clear any existing status and set the address to be checked against
+    cpu_int_disable();
+    peek_pkt.pkt.data = addr + 1;
+    peek_pkt.pkt.ctrl = link;
     peek_pkt.flags = 0;
+    cpu_int_enable();
 
     if (! pkt_tx(PKT_NND + (link << 18), 0, addr)) {
         return RC_PKT_TX;

--- a/scamp/scamp.h
+++ b/scamp/scamp.h
@@ -524,6 +524,9 @@ extern uint scamp_debug(sdp_msg_t *msg, uint srce_ip);
 //! \{
 
 extern void boot_nn(uint hw_ver);
+
+//! \name SCAMP disable links function.  See scamp-3.c
+extern void disable_unidirectional_links(void);
 //! \}
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains two changes related to the stability of SCAMP:

1) Add a command to disable and re-enable the synchronization between chips.  This means that the sync signal can be turned off during simulation, when the network is noisy and likely to lead to delays in signal propagation.  Note that so long as the drift has been reasonably calculated before this point, the boards should stay reasonably in sync (reasonably because it isn't absolute anyway).

2) Attempts to test links more thoroughly and so detect errors early on and take out the appropriate links.  This means that cross-board links, which can't be blacklisted anyway, are more likely to be removed.

3) Add checksum to app copy run.