### PR TITLE
Disable part of build that needs missing dependency

### DIFF
--- a/.github/workflows/c_actions.yml
+++ b/.github/workflows/c_actions.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Install system dependencies
-      run: sudo apt-get -q install gcc-arm-none-eabi freeglut3-dev --fix-missing
+      run: sudo apt-get -q install gcc-arm-none-eabi --fix-missing
     - name: Set C environment variables
       run: |
         echo "SPINN_DIRS=$PWD" >> $GITHUB_ENV
@@ -40,7 +40,6 @@ jobs:
         make -C apps/hello
         make -C apps/hello_cpp
         make -C apps/life
-        make -C apps/pt_demo
       env:
         GCC_COLORS: error=01;31:warning=01;35:note=01;36:range1=32:range2=34:locus=01:quote=01:fixit-insert=32:fixit-delete=31:diff-filename=01:diff-hunk=32:diff-delete=31:diff-insert=32
         CFLAGS: -fdiagnostics-color

--- a/make/spinnaker_tools.mk
+++ b/make/spinnaker_tools.mk
@@ -90,7 +90,7 @@ ifeq ($(GNU),1)
         CFLAGS += -fdata-sections -ffunction-sections
         LD := $(GP)-ld -i
     else
-        LD := $(GP)-gcc -T$(LD_LNK) -Wl,-e,cpu_reset -Wl,-static -ffreestanding -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,--use-blx -nostartfiles -static
+        LD := $(GP)-gcc -T$(LD_LNK) -Wl,-e,cpu_reset -Wl,-static -ffreestanding -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,--use-blx --nostartfiles -static
         LFLAGS += -L $(SPINN_LIB_DIR)
     endif
 

--- a/make/spinnaker_tools.mk
+++ b/make/spinnaker_tools.mk
@@ -90,7 +90,7 @@ ifeq ($(GNU),1)
         CFLAGS += -fdata-sections -ffunction-sections
         LD := $(GP)-ld -i
     else
-        LD := $(GP)-gcc -T$(LD_LNK) -Wl,-e,cpu_reset -Wl,-static -ffreestanding -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,--use-blx --nostartfiles -static
+        LD := $(GP)-gcc -T$(LD_LNK) -Wl,-e,cpu_reset -Wl,-static -ffreestanding -fdata-sections -ffunction-sections -Wl,--gc-sections -Wl,--use-blx -nostartfiles -static
         LFLAGS += -L $(SPINN_LIB_DIR)
     endif
 

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -91,7 +91,7 @@ $(BUILD_DIR)%.gas: %.s
 $(BUILD_DIR)boot_aplx.elf: $(BUILD_DIR)boot_aplx.gas $(BUILD_DIR)spinnaker.gas $(BUILD_DIR)sark.gas
 	$(MKDIR) $(BUILD_DIR)
 	$(AS) -I $(BUILD_DIR) -o $(BUILD_DIR)boot_aplx.o $<
-	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx -nostartfiles $(BUILD_DIR)boot_aplx.o -o $@
+	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx --nostartfiles $(BUILD_DIR)boot_aplx.o -o $@
 
 else
 $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.s

--- a/scamp/Makefile
+++ b/scamp/Makefile
@@ -91,7 +91,7 @@ $(BUILD_DIR)%.gas: %.s
 $(BUILD_DIR)boot_aplx.elf: $(BUILD_DIR)boot_aplx.gas $(BUILD_DIR)spinnaker.gas $(BUILD_DIR)sark.gas
 	$(MKDIR) $(BUILD_DIR)
 	$(AS) -I $(BUILD_DIR) -o $(BUILD_DIR)boot_aplx.o $<
-	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx --nostartfiles $(BUILD_DIR)boot_aplx.o -o $@
+	$(GP)-ld -Tboot.lnk -static --no-gc-sections --use-blx $(BUILD_DIR)boot_aplx.o -o $@
 
 else
 $(BUILD_DIR)boot_aplx.elf: boot_aplx.s $(BUILD_DIR)spinnaker.s $(BUILD_DIR)sark.s


### PR DESCRIPTION
`pt_demo` really isn't high priority for us to keep working, and I believe that is the only part of this repo that actually needs to build against GLUT...