### PR TITLE
Update to release notes

### DIFF
--- a/release.txt
+++ b/release.txt
@@ -4,7 +4,18 @@
 #
 #-------------------------------------------------------------------------------
 
-Version 3.4.2 - TBD.
+Version 3.4.2 - Changes to support larger groups of boards
+
+* ALL: License changed to Apache2 [#169]
+
+* SCAMP: Improvements to inter-board synch [#164]
+* SCAMP: Better link testing [#164]
+
+* SCAMP: More reliable application copy-and-boot [#162]
+
+* SARK+SCAMP: Better SDRAM allocation API [#159]
+
+* Spin1_API: Better support for TIMER2 to support split neuron models [#155]
 
 #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Omitted is mention of the changes to support CI testing, remove unused and unusable code, etc.

----

Here are the markdown-ified changes for the release proposed, suitable for copying to the final release notes on Github:

> Version 3.4.2 - Changes to support larger groups of boards
> ---
> 
> * **ALL:** License changed to Apache2 [#169]
> 
> * **SCAMP:** Improvements to inter-board synch [#164]
> * **SCAMP:** Better link testing [#164]
> 
> * **SCAMP:** More reliable application copy-and-boot [#162]
> 
> * **SARK**+**SCAMP:** Better SDRAM allocation API [#159]
> 
> * **Spin1_API:** Better support for TIMER2 to support split neuron models [#155]
